### PR TITLE
minor changes in domain decomposition routine

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -61,7 +61,6 @@ implicit none
  ! segIndex points to the segment in the entire river network data
  ! segOrder is order within subset of mainstem segments or tributary segments
  type,public :: subbasin_mpi
-  character(32)              :: pfaf                  ! subbasin pfaf code - mainstem starting "-"
   integer(i4b)               :: basinType             ! basin type identifier: tributary->1, mainstem->2
   integer(i4b)               :: idNode                ! node ID
   integer(i4b)               :: outletIndex           ! reach index of a domain outlet

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -3,7 +3,6 @@ module globalData
   USE pio
 
   USE public_var, ONLY: integerMissing
-  USE public_var, ONLY: maxDomain
 
   ! data types
   USE nrtype
@@ -37,7 +36,7 @@ module globalData
 
   ! basin data structure
   USE dataTypes, ONLY: subbasin_omp  ! mainstem+tributary data structures
-  USE dataTypes, ONLY: subbasin_mpi  ! reach category (store mainstem code or pfaf code)
+  USE dataTypes, ONLY: subbasin_mpi  ! mpi domain data structure (list of segments and hru and type of basins)
 
   ! time data structure
   USE datetime_data, ONLY: datetime  ! datetime data class
@@ -199,8 +198,8 @@ module globalData
 
   ! domain data
   ! MPI
-  type(subbasin_mpi)             , public :: domains(maxDomain)   ! domain decomposition data structure (maximum domain is set to maxDomain)
-  integer(i4b)                   , public :: nDomain              ! domain counter
+  type(subbasin_mpi),allocatable , public :: domains_mpi(:)       ! mpi domain decomposition data structure
+  integer(i4b)                   , public :: nDomain_mpi          ! number of mpi domains
   ! OMP
   type(subbasin_omp), allocatable, public :: river_basin_main(:)   ! openMP domain decomposition for mainstem
   type(subbasin_omp), allocatable, public :: river_basin_trib(:)   ! openMP domain decomposition for tributary

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -108,11 +108,11 @@ CONTAINS
      seg:do iSeg=1,river_basin(ix)%branch(iTrib)%nRch
        jSeg = river_basin(ix)%branch(iTrib)%segIndex(iSeg)
        if (.not. doRoute(jSeg)) cycle
-         if ((NETOPO_in(jseg)%islake).and.(is_lake_sim))  then
-          call lake_route (iEns, jSeg, ixDesire, NETOPO_in, RPARAM_in, RCHFLX_out, ierr, message)
-         else
-          call segment_irf(iEns, jSeg, ixDesire, NETOPO_in,            RCHFLX_out, ierr, cmessage)
-         endif
+       if ((NETOPO_in(jseg)%islake).and.(is_lake_sim)) then
+        call lake_route (iEns, jSeg, ixDesire, NETOPO_in, RPARAM_in, RCHFLX_out, ierr, cmessage)
+       else
+        call segment_irf(iEns, jSeg, ixDesire, NETOPO_in,            RCHFLX_out, ierr, cmessage)
+       endif
        if(ierr/=0) call handle_err(ierr, trim(message)//trim(cmessage))
      end do seg
    end do trib

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -34,9 +34,6 @@ module public_var
   ! routing related constants
   integer(i4b),parameter,public   :: MAXQPAR=20             ! maximum number of particles
 
-  ! MPI domain decomposition parameters
-  integer(i4b),parameter,public   :: maxDomain=900000       ! maximum domains
-
   ! openMP domain decompostion parameters
   integer(i4b),parameter,public   :: maxSegs=100            ! maximum reach numbers within tributaries
   integer(i4b),parameter,public   :: maxLevel=20            ! maximum mainstem levels used for OMP domain decomposition


### PR DESCRIPTION
MPI decomposition data structure, domains_mpi is saved and the size was set to maxDomain (arbitrary size of 900,000 defined in public_var.f90). Now the size is set to actual number of MPI domain. Also, maxDomain is now removed

Some style fix.

Use errmsg optional argument in allocate statement. 


 