### PR TITLE
Implementing KW, DW and MC routing - Take 1

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -202,29 +202,42 @@ end type subdomain
   LOGICAL(LGT)                               :: USRTAKE  ! .TRUE. if user takes from reach, .FALSE. otherwise
  end type RCHTOPO
 
- ! ---------- kinematic wave states (collection of particles) ---------------------------------
+ ! ---------- reach states --------------------------------------------------------------------
 
+ !---------- Lagrangian kinematic wave states (collection of particles) ---------------------------------
  ! Individual flow particles
  ! NOTE: type could possibly be private
- TYPE, public :: FPOINT
-  REAL(DP)                             :: QF       ! Flow
-  REAL(DP)                             :: QM       ! Modified flow
-  REAL(DP)                             :: TI       ! initial time of point in reach
-  REAL(DP)                             :: TR       ! time point expected to exit reach
-  LOGICAL(LGT)                         :: RF       ! routing flag (T if point has exited)
- END TYPE FPOINT
+ type, public :: FPOINT
+  real(dp)                             :: QF       ! Flow
+  real(dp)                             :: QM       ! Modified flow
+  real(dp)                             :: TI       ! initial time of point in reach
+  real(dp)                             :: TR       ! time point expected to exit reach
+  logical(lgt)                         :: RF       ! routing flag (T if point has exited)
+ end type FPOINT
 
  ! Collection of flow points within a given reach
- TYPE, public :: KREACH
-  TYPE(FPOINT),allocatable             :: KWAVE(:)
- END TYPE KREACH
+ type, public :: LKWRCH
+  type(FPOINT),allocatable             :: KWAVE(:)
+ end type LKWRCH
+
+ ! ---------- computational molecule ---------------------------------
+ type, public :: SUBRCH
+   real(dp), allocatable  :: Q(:)        ! Discharge at sub-reaches at current step (m3/s)
+   real(dp), allocatable  :: A(:)        ! Flow area at sub-reach at current step (m2)
+   real(dp), allocatable  :: H(:)        ! Flow height at sub-reach at current step (m)
+ end type SUBRCH
 
  ! ---------- irf states (future flow series ) ---------------------------------
-
  ! Future flow series
- TYPE, public :: IRFREACH
-  REAL(DP), allocatable                :: qfuture(:)    ! runoff volume in future time steps for IRF routing (m3/s)
- END TYPE IRFREACH
+ type, public :: IRFRCH
+  real(dp), allocatable   :: qfuture(:)    ! runoff volume in future time steps for IRF routing (m3/s)
+ end type IRFRCH
+
+ type, public :: STRSTA
+   type(IRFRCH)    :: IRF_ROUTE
+   type(LKWRCH)    :: LKW_ROUTE
+   type(SUBRCH)    :: molecule
+ end type STRSTA
 
  ! ---------- reach fluxes --------------------------------------------------------------------
 

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -1,58 +1,61 @@
-module globalData
+MODULE globalData
   ! This module includes global data structures
 
-  use public_var, only : integerMissing
+  USE public_var, ONLY : integerMissing
 
   ! data types
-  use nrtype
+  USE nrtype
 
   ! metadata types
-  use dataTypes,  only : struct_info   ! metadata type
-  use dataTypes,  only : dim_info      ! metadata type
-  use dataTypes,  only : var_info      ! metadata type
-  use objTypes,   only : meta_var      ! metadata type
+  USE dataTypes,  ONLY : struct_info   ! metadata type
+  USE dataTypes,  ONLY : dim_info      ! metadata type
+  USE dataTypes,  ONLY : var_info      ! metadata type
+  USE objTypes,   ONLY : meta_var      ! metadata type
 
   ! parameter structures
-  USE dataTypes,  only : RCHPRP        ! Reach parameters (properties)
-  USE dataTypes,  only : RCHTOPO       ! Network topology
+  USE dataTypes,  ONLY : RCHPRP        ! Reach parameters (properties)
+  USE dataTypes,  ONLY : RCHTOPO       ! Network topology
 
   ! routing structures
-  USE dataTypes,  only : KREACH        ! Collection of flow particles in each reach
-  USE dataTypes,  only : STRFLX        ! fluxes in each reach
+  USE dataTypes,  ONLY : STRSTA        ! restart state in each reach
+  USE dataTypes,  ONLY : STRFLX        ! fluxes in each reach
 
   ! lake structures
-  USE dataTypes,  only : LAKPRP        ! lake properties
-  USE dataTypes,  only : LAKTOPO       ! lake topology
-  USE dataTypes,  only : LKFLX         ! lake fluxes
+  USE dataTypes,  ONLY : LAKPRP        ! lake properties
+  USE dataTypes,  ONLY : LAKTOPO       ! lake topology
+  USE dataTypes,  ONLY : LKFLX         ! lake fluxes
 
   ! remapping structures
-  use dataTypes,  only : remap         ! remapping data type
-  use dataTypes,  only : runoff        ! runoff data type
+  USE dataTypes,  ONLY : remap         ! remapping data type
+  USE dataTypes,  ONLY : runoff        ! runoff data type
 
   ! basin data structure
-  use dataTypes,  only : subbasin_omp  ! mainstem+tributary data structures
+  USE dataTypes,  ONLY : subbasin_omp  ! mainstem+tributary data structures
 
   ! time data structure
-  use date_time,  only : datetime      ! time data
+  USE date_time,  ONLY : datetime      ! time data
 
   ! time data structure
-  use dataTypes,  only : nc           ! netCDF data
+  USE dataTypes,  ONLY : nc           ! netCDF data
 
   ! data size
-  USE var_lookup, only : nStructures   ! number of variables for data structure
-  USE var_lookup, only : nDimensions   ! number of variables for data structure
-  USE var_lookup, only : nStateDims    ! number of variables for data structure
-  USE var_lookup, only : nQdims        ! number of variables for data structure
-  USE var_lookup, only : nVarsHRU      ! number of variables for data structure
-  USE var_lookup, only : nVarsHRU2SEG  ! number of variables for data structure
-  USE var_lookup, only : nVarsSEG      ! number of variables for data structure
-  USE var_lookup, only : nVarsNTOPO    ! number of variables for data structure
-  USE var_lookup, only : nVarsPFAF     ! number of variables for data structure
-  USE var_lookup, only : nVarsRFLX     ! number of variables for data structure
-  USE var_lookup, only : nVarsIRFbas   ! number of variables for data structure
-  USE var_lookup, only : nVarsBasinQ   ! number of variables for data structure
-  USE var_lookup, only : nVarsIRF      ! number of variables for data structure
-  USE var_lookup, only : nVarsKWT      ! number of variables for data structure
+  USE var_lookup, ONLY : nStructures   ! number of variables for data structure
+  USE var_lookup, ONLY : nDimensions   ! number of variables for data structure
+  USE var_lookup, ONLY : nStateDims    ! number of variables for data structure
+  USE var_lookup, ONLY : nQdims        ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsHRU      ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsHRU2SEG  ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsSEG      ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsNTOPO    ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsPFAF     ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsRFLX     ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsIRFbas   ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsBasinQ   ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsIRF      ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsKWT      ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsKW       ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsDW       ! number of variables for data structure
+  USE var_lookup, ONLY : nVarsMC       ! number of variables for data structure
 
   implicit none
 
@@ -93,7 +96,10 @@ module globalData
   type(meta_var)                 , public :: meta_rflx   (nVarsRFLX   ) ! reach flux variables
   type(meta_var)                 , public :: meta_irf_bas(nVarsIRFbas ) ! basin IRF routing fluxes/states
   type(meta_var)                 , public :: meta_basinQ (nVarsBasinQ ) ! reach inflow from basin
-  type(meta_var)                 , public :: meta_kwt    (nVarsKWT    ) ! KWT routing fluxes/states
+  type(meta_var)                 , public :: meta_kwt    (nVarsKWT    ) ! KWT routing restart fluxes/states
+  type(meta_var)                 , public :: meta_kw     (nVarsKW     ) ! KW routing restart fluxes/states
+  type(meta_var)                 , public :: meta_dw     (nVarsDW     ) ! DW routing restart fluxes/states
+  type(meta_var)                 , public :: meta_mc     (nVarsMC     ) ! MC routing restart fluxes/states
   type(meta_var)                 , public :: meta_irf    (nVarsIRF    ) ! IRF routing fluxes/states
 
   ! ---------- data structures ----------------------------------------------------------------------
@@ -127,7 +133,7 @@ module globalData
   REAL(DP)        , ALLOCATABLE  , public :: FRAC_FUTURE(:)       ! fraction of runoff in future time steps
 
   ! routing data structures
-  TYPE(KREACH)    , allocatable  , public :: KROUTE(:,:)          ! Routing state variables (ensembles, space [reaches]) for the entire river network
+  TYPE(STRSTA)    , allocatable  , public :: RCHSTA(:,:)          ! Routing state variables (ensembles, space [reaches]) for the entire river network
   TYPE(STRFLX)    , allocatable  , public :: RCHFLX(:,:)          ! Reach fluxes (ensembles, space [reaches]) for entire river network
 
   ! lakes data structures

--- a/route/build/src/main_route.f90
+++ b/route/build/src/main_route.f90
@@ -28,7 +28,7 @@ contains
                        ierr, message)     ! output: error control
    ! Details:
    ! Given HRU (basin) runoff, perform hru routing (optional) to get reach runoff, and then channel routing ! Restriction:
-   ! 1. Reach order in NETOPO, RPARAM, RCHFLX, KROUTE must be in the same orders
+   ! 1. Reach order in NETOPO, RPARAM, RCHFLX, RCHSTA must be in the same orders
    ! 2. Process a list of reach indices (in terms of NETOPO etc.) given by ixRchProcessed
    ! 3. basinRunoff_in is given in the order of NETOPO(:)%HRUIX.
 
@@ -37,15 +37,18 @@ contains
    USE public_var, only : doesBasinRoute
    USE public_var, only : doesAccumRunoff
    USE public_var, only : allRoutingMethods
-   USE public_var, only : kinematicWave
+   USE public_var, only : kinematicWaveTracking
    USE public_var, only : impulseResponseFunc
+   USE public_var, only : kinematicWave
+   USE public_var, only : muskingumCunge
+   USE public_var, only : diffusiveWave
    USE globalData, only : TSEC                    ! beginning/ending of simulation time step [sec]
    USE globalData, only : ixPrint                 ! desired reach index to be on-screen print
 
    USE globalData, only : NETOPO           ! entire river reach netowrk topology structure
    USE globalData, only : RPARAM           ! entire river reach parameter structure
    USE globalData, only : RCHFLX           ! entire reach flux structure
-   USE globalData, only : KROUTE           ! entire river reach kwt sate structure
+   USE globalData, only : RCHSTA           ! entire river reach restart structure
    USE globalData, only : runoff_data      ! runoff data structure
    USE globalData, only : river_basin      ! OMP basin decomposition
    USE globalData, only : nRch             ! number of reaches in the whoel river network
@@ -127,7 +130,7 @@ contains
    endif
 
    ! perform KWT routing
-   if (routOpt==allRoutingMethods .or. routOpt==kinematicWave) then
+   if (routOpt==allRoutingMethods .or. routOpt==kinematicWaveTracking) then
     call system_clock(startTime)
     call kwt_route(iens,                 & ! input: ensemble index
                    river_basin,          & ! input: river basin data type
@@ -135,7 +138,7 @@ contains
                    ixPrint,              & ! input: index of the desired reach
                    NETOPO,               & ! input: reach topology data structure
                    RPARAM,               & ! input: reach parameter data structure
-                   KROUTE,               & ! inout: reach state data structure
+                   RCHSTA,               & ! inout: reach state data structure
                    RCHFLX,               & ! inout: reach flux data structure
                    ierr,cmessage)          ! output: error control
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -31,8 +31,11 @@ USE globalData, only : meta_PFAF      ! pfafstetter code
 USE globalData, only : meta_rflx      ! reach flux variables
 USE globalData, only : meta_irf_bas   ! within-basin irf routing future flow
 USE globalData, only : meta_basinQ    ! reach inflow from basin
-USE globalData, only : meta_irf       ! irf routing fluxes and states in a segment
-USE globalData, only : meta_kwt       ! kinematic wave routing fluxes and states in a segment
+USE globalData, only : meta_irf       ! irf routing restart states and fluxes in a segment
+USE globalData, only : meta_kwt       ! lagrangian kinematic wave routing restart states and fluxes in a segment
+USE globalData, only : meta_kw        ! kinematic wave routing restart fluxes and states in a segment
+USE globalData, only : meta_dw        ! diffusive wave routing restart fluxes and states in a segment
+USE globalData, only : meta_mc        ! muskingum-cunge routing restart fluxes and states in a segment
 
 ! indices of named variables
 USE var_lookup, only : ixStruct   , nStructures   ! index of variables for data structure
@@ -47,6 +50,9 @@ USE var_lookup, only : ixPFAF     , nVarsPFAF     ! index of variables for data 
 
 USE var_lookup, only : ixRFLX                     ! index of variables for data structure
 USE var_lookup, only : ixKWT                      ! index of variables for data structure
+USE var_lookup, only : ixKW                       ! index of variables for data structure
+USE var_lookup, only : ixDW                       ! index of variables for data structure
+USE var_lookup, only : ixMC                       ! index of variables for data structure
 USE var_lookup, only : ixIRF                      ! index of variables for data structure
 USE var_lookup, only : ixIRFbas                   ! index of variables for data structure
 USE var_lookup, only : ixBasinQ                   ! index of variables for data structure
@@ -147,31 +153,45 @@ contains
  ! PFAF CODE                                     varName        varDesc                                                varUnit, varType, varFile
  meta_PFAF  (ixPFAF%code             ) = var_info('code'           , 'pfafstetter code'                                   ,'-'    ,ixDims%seg   , .false.)
 
- ! ---------- populate segment fluxes/states metadata structures -----------------------------------------------------------------------------------------------------
-! Reach Flux                                   varName              varDesc                                 unit,   varType,    varDim,                     writeOut
- call meta_rflx(ixRFLX%basRunoff        )%init('basRunoff'        , 'basin runoff'                        , 'm/s' , nf90_float, [ixQdims%hru,ixQdims%time], .true.)
- call meta_rflx(ixRFLX%instRunoff       )%init('instRunoff'       , 'instantaneous runoff in each reach'  , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
- call meta_rflx(ixRFLX%dlayRunoff       )%init('dlayRunoff'       , 'delayed runoff in each reach'        , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
- call meta_rflx(ixRFLX%sumUpstreamRunoff)%init('sumUpstreamRunoff', 'sum of upstream runoff in each reach', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
- call meta_rflx(ixRFLX%KWTroutedRunoff  )%init('KWTroutedRunoff'  , 'KWT routed runoff in each reach'     , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
- call meta_rflx(ixRFLX%IRFroutedRunoff  )%init('IRFroutedRunoff'  , 'IRF routed runoff in each reach'     , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ ! ---------- populate segment fluxes/restart states metadata structures -----------------------------------------------------------------------------------------------------
+ ! meta variable = (variable name, description, unit, numeric type, dimemsion, flag to write)
+ ! Reach Flux
+ call meta_rflx(ixRFLX%basRunoff        )%init('basRunoff'        , 'basin runoff'                                      , 'm/s' , nf90_float, [ixQdims%hru,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%instRunoff       )%init('instRunoff'       , 'instantaneous runoff in each reach'                , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%dlayRunoff       )%init('dlayRunoff'       , 'delayed runoff in each reach'                      , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%sumUpstreamRunoff)%init('sumUpstreamRunoff', 'sum of upstream runoff in each reach'              , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%KWTroutedRunoff  )%init('KWTroutedRunoff'  , 'routed runoff in reach - lagrangian kinematic wave', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%MCroutedRunoff   )%init('MCroutedRunoff'   , 'routed runoff in reach - muskingum-cunge'          , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
+ call meta_rflx(ixRFLX%DWroutedRunoff   )%init('DWroutedRunoff'   , 'routed runoff in reach - diffusive wave'           , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
+ call meta_rflx(ixRFLX%KWroutedRunoff   )%init('KWroutedRunoff'   , 'routed runoff in reach - lagrangian kinematic wave', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
+ call meta_rflx(ixRFLX%IRFroutedRunoff  )%init('IRFroutedRunoff'  , 'routed runoff in reach - Impulse Response Function', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%volume           )%init('volume'           , 'lake and stream volume'                            , 'm3'  , nf90_float, [ixQdims%seg,ixQdims%time], .false.)
 
- ! Kinematic Wave                    varName      varDesc                                           unit,     varType,     varDim,                                             writeOut
+ ! Lagrangian kinematic Wave restart state
  call meta_kwt(ixKWT%tentry   )%init('tentry'   , 'time when a wave enters a segment'             , 'sec'   , nf90_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
  call meta_kwt(ixKWT%texit    )%init('texit'    , 'time when a wave is expected to exit a segment', 'sec'   , nf90_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
  call meta_kwt(ixKWT%qwave    )%init('qwave'    , 'flow of a wave'                                , 'm2/sec', nf90_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
  call meta_kwt(ixKWT%qwave_mod)%init('qwave_mod', 'modified flow of a wave'                       , 'm2/sec', nf90_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
  call meta_kwt(ixKWT%routed   )%init('routed'   , 'routing flag'                                  , '-'     , nf90_int,    [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
 
- ! Impulse Response Function       varName         varDesc              unit,     varType,     varDim,                                                 writeOut
- call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series', 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%tdh_irf,ixStateDims%ens] , .true.)
- call meta_irf(ixIRF%irfVol) %init('irf_volume' , 'IRF reach volume'  , 'm3'     ,nf90_double, [ixStateDims%seg,ixStateDims%ens]                     , .true.)
+ ! Kinematic Wave
+ call meta_kw(ixKW%qsub)%init('q_sub', 'flow at computational moelcule', 'm3/s', nf90_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens], .false.)
 
- ! Basin Impulse Response Function        varName    varDesc               unit,     varType,     varDim,                                            writeOut
+ ! Diffusive Wave
+ call meta_dw(ixDW%qsub)%init('q_sub', 'flow at computational moelcule', 'm3/s', nf90_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens], .false.)
+
+ ! Muskingum-cunge
+ call meta_mc(ixMC%qsub)%init('q_sub', 'flow at computational molecule', 'm3/s', nf90_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens], .false.)
+
+ ! Impulse Response Function
+ call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series', 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%tdh_irf,ixStateDims%ens] , .true.)
+ call meta_irf(ixIRF%irfVol )%init('irf_volume' , 'IRF reach volume'  , 'm3'     ,nf90_double, [ixStateDims%seg,ixStateDims%ens]                     , .true.)
+
+ ! Basin Impulse Response Function
  call meta_irf_bas(ixIRFbas%qfuture)%init('qfuture', 'future flow series', 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%tdh,ixStateDims%ens], .true.)
 
- ! reach inflow from basin                varName    varDesc                       unit,     varType,     varDim,                                    writeOut
- call meta_basinQ(ixBasinQ%q       )%init('basin_q', 'inflow into reach from hru' , 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%ens]       , .true.)
+ ! reach inflow from basin
+ call meta_basinQ(ixBasinQ%q)%init('basin_q', 'inflow into reach from hru', 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%ens], .true.)
 
  end subroutine popMetadat
 

--- a/route/build/src/process_ntopo.f90
+++ b/route/build/src/process_ntopo.f90
@@ -11,14 +11,17 @@ USE dataTypes, only : var_dlength,dlength ! double precision type: var(:)%dat, o
 USE public_var, only : idSegOut           ! ID for stream segment at the bottom of the subset
 
 ! options
-USE public_var, only : qtakeOption        ! option to compute network topology
-USE public_var, only : topoNetworkOption  ! option to compute network topology
-USE public_var, only : computeReachList   ! option to compute reach list
-USE public_var, only : hydGeometryOption  ! option to obtain routing parameters
-USE public_var, only : routOpt            ! option for desired routing method
-USE public_var, only : allRoutingMethods  ! option for routing methods - all the methods
-USE public_var, only : kinematicWave      ! option for routing methods - kinematic wave only
-USE public_var, only : impulseResponseFunc! option for routing methods - IRF only
+USE public_var, only : qtakeOption            ! option to compute network topology
+USE public_var, only : topoNetworkOption      ! option to compute network topology
+USE public_var, only : computeReachList       ! option to compute reach list
+USE public_var, only : hydGeometryOption      ! option to obtain routing parameters
+USE public_var, only : routOpt                ! option for desired routing method
+USE public_var, only : allRoutingMethods      ! option for routing methods - all the methods
+USE public_var, only : kinematicWaveTracking  ! option for routing methods - Lagrangian kinematic wave only
+USE public_var, only : impulseResponseFunc    ! option for routing methods - IRF only
+USE public_var, only : kinematicWave          ! option for routing methods - kinematic wave only
+USE public_var, only : diffusiveWave          ! option for routing methods - diffusive wave only
+USE public_var, only : muskingumCunge         ! option for routing methods - muskingum-cunge only
 
 ! named variables
 USE public_var, only : true,false         ! named integers for true/false
@@ -245,7 +248,7 @@ contains
  if(hydGeometryOption==compute)then
 
   ! (hydraulic geometry only needed for the kinematic wave method)
-  if (routOpt==allRoutingMethods .or. routOpt==kinematicWave) then
+  if (routOpt==allRoutingMethods .or. routOpt==kinematicWaveTracking .or. routOpt==kinematicWave .or. routOpt==diffusiveWave .or. routOpt==muskingumCunge) then
    do iSeg=1,nSeg
     structSEG(iSeg)%var(ixSEG%width)%dat(1) = wscale * sqrt(structSEG(iSeg)%var(ixSEG%totalArea)%dat(1))  ! channel width (m)
     structSEG(iSeg)%var(ixSEG%man_n)%dat(1) = mann_n                                                      ! Manning's "n" paramater (unitless)

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -61,9 +61,12 @@ module public_var
   integer(i4b), parameter,public  :: readFromFile=0         ! read given variable from a file
 
   ! routing methods
-  integer(i4b), parameter,public  :: allRoutingMethods=0    ! all routing methods
-  integer(i4b), parameter,public  :: impulseResponseFunc=1  ! impulse response function
-  integer(i4b), parameter,public  :: kinematicWave=2        ! kinematic wave
+  integer(i4b), parameter,public  :: allRoutingMethods=0     ! all routing methods
+  integer(i4b), parameter,public  :: impulseResponseFunc=1   ! impulse response function
+  integer(i4b), parameter,public  :: kinematicWaveTracking=2 ! Lagrangian kinematic wave
+  integer(i4b), parameter,public  :: kinematicWave=3         ! kinematic wave
+  integer(i4b), parameter,public  :: muskingumCunge=4        ! muskingum-cunge
+  integer(i4b), parameter,public  :: diffusiveWave=5         ! diffusiveWave
 
   ! ---------- variables in the control file --------------------------------------------------------
 

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -38,6 +38,7 @@ MODULE var_lookup
   integer(i4b)     :: tbound       = integerMissing   ! 2 elelment time bound vector
   integer(i4b)     :: ens          = integerMissing   ! runoff ensemble
   integer(i4b)     :: wave         = integerMissing   ! waves in a channel
+  integer(i4b)     :: fdmesh       = integerMissing   ! finite difference computational molecule
   integer(i4b)     :: tdh_irf      = integerMissing   ! irf routed future channel flow in a segment
   integer(i4b)     :: tdh          = integerMissing   ! uh routed future overland flow
  endtype iLook_stateDims
@@ -136,7 +137,11 @@ MODULE var_lookup
   integer(i4b)     :: dlayRunoff        = integerMissing  ! delayed runoff in each reac
   integer(i4b)     :: sumUpstreamRunoff = integerMissing  ! sum of upstream runoff in each reach
   integer(i4b)     :: KWTroutedRunoff   = integerMissing  ! Lagrangian KWT routed runoff in each reach
+  integer(i4b)     :: KWroutedRunoff    = integerMissing  ! KW routed runoff in each reach
+  integer(i4b)     :: MCroutedRunoff    = integerMissing  ! muskingum-cunge routed runoff in each reach
+  integer(i4b)     :: DWroutedRunoff    = integerMissing  ! diffusive wave routed runoff in each reach
   integer(i4b)     :: IRFroutedRunoff   = integerMissing  ! IRF routed runoff in each reach
+  integer(i4b)     :: volume            = integerMissing  ! water volume
  endtype iLook_RFLX
  ! Reach inflow from basin
  type, public  ::  iLook_basinQ
@@ -154,6 +159,18 @@ MODULE var_lookup
   integer(i4b)     :: qwave_mod      = integerMissing  ! wave flow after merged
   integer(i4b)     :: routed         = integerMissing  ! Routed out of a segment or not
  endtype iLook_KWT
+ ! KW state/fluxes
+ type, public  ::  iLook_KW
+  integer(i4b)     :: qsub           = integerMissing  ! discharge
+ endtype iLook_KW
+ ! DW state/fluxes
+ type, public  ::  iLook_DW
+  integer(i4b)     :: qsub           = integerMissing  ! discharge
+ endtype iLook_DW
+ ! MC state/fluxes
+ type, public  ::  iLook_MC
+  integer(i4b)     :: qsub           = integerMissing  ! discharge
+ endtype iLook_MC
  !IRF state/fluxes
  type, public  ::  iLook_IRF
   integer(i4b)     :: qfuture        = integerMissing  ! future routed flow
@@ -164,15 +181,18 @@ MODULE var_lookup
  ! ***********************************************************************************************************
  type(iLook_struct)   ,public,parameter :: ixStruct    = iLook_struct   (1,2,3,4,5)
  type(iLook_dims)     ,public,parameter :: ixDims      = iLook_dims     (1,2,3,4,5,6,7)
- type(iLook_stateDims),public,parameter :: ixStateDims = iLook_stateDims(1,2,3,4,5,6,7)
+ type(iLook_stateDims),public,parameter :: ixStateDims = iLook_stateDims(1,2,3,4,5,6,7,8)
  type(iLook_qDims)    ,public,parameter :: ixqDims     = iLook_qDims    (1,2,3,4)
  type(iLook_HRU)      ,public,parameter :: ixHRU       = iLook_HRU      (1)
  type(iLook_HRU2SEG)  ,public,parameter :: ixHRU2SEG   = iLook_HRU2SEG  (1,2,3,4)
  type(iLook_SEG)      ,public,parameter :: ixSEG       = iLook_SEG      (1,2,3,4,5,6,7,8,9,10,11,12,13,14)
  type(iLook_NTOPO)    ,public,parameter :: ixNTOPO     = iLook_NTOPO    (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17)
  type(iLook_PFAF)     ,public,parameter :: ixPFAF      = iLook_PFAF     (1)
- type(iLook_RFLX)     ,public,parameter :: ixRFLX      = iLook_RFLX     (1,2,3,4,5,6)
+ type(iLook_RFLX)     ,public,parameter :: ixRFLX      = iLook_RFLX     (1,2,3,4,5,6,7,8,9,10)
  type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      (1,2,3,4,5)
+ type(iLook_KW)       ,public,parameter :: ixKW        = iLook_KW       (1)
+ type(iLook_DW)       ,public,parameter :: ixDW        = iLook_DW       (1)
+ type(iLook_MC)       ,public,parameter :: ixMC        = iLook_MC       (1)
  type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      (1,2)
  type(iLook_IRFbas  ) ,public,parameter :: ixIRFbas    = iLook_IRFbas   (1)
  type(iLook_basinQ  ) ,public,parameter :: ixBasinQ    = iLook_basinQ   (1)
@@ -189,10 +209,13 @@ MODULE var_lookup
  integer(i4b),parameter,public    :: nVarsNTOPO   = storage_size(ixNTOPO    )/iLength
  integer(i4b),parameter,public    :: nVarsPFAF     = storage_size(ixPFAF    )/iLength
  integer(i4b),parameter,public    :: nVarsRFLX     = storage_size(ixRFLX    )/iLength
- integer(i4b),parameter,public    :: nVarsKWT      = storage_size(ixKWT      )/iLength
- integer(i4b),parameter,public    :: nVarsIRF      = storage_size(ixIRF      )/iLength
- integer(i4b),parameter,public    :: nVarsIRFbas   = storage_size(ixIRFbas   )/iLength
- integer(i4b),parameter,public    :: nVarsBasinQ   = storage_size(ixBasinQ   )/iLength
+ integer(i4b),parameter,public    :: nVarsKWT      = storage_size(ixKWT     )/iLength
+ integer(i4b),parameter,public    :: nVarsKW       = storage_size(ixKW      )/iLength
+ integer(i4b),parameter,public    :: nVarsDW       = storage_size(ixDW      )/iLength
+ integer(i4b),parameter,public    :: nVarsMC       = storage_size(ixMC      )/iLength
+ integer(i4b),parameter,public    :: nVarsIRF      = storage_size(ixIRF     )/iLength
+ integer(i4b),parameter,public    :: nVarsIRFbas   = storage_size(ixIRFbas  )/iLength
+ integer(i4b),parameter,public    :: nVarsBasinQ   = storage_size(ixBasinQ  )/iLength
  ! ***********************************************************************************************************
 
 END MODULE var_lookup

--- a/route/build/src/write_simoutput.f90
+++ b/route/build/src/write_simoutput.f90
@@ -8,7 +8,10 @@ USE public_var,only: integerMissing
 USE public_var,only: routOpt                ! routing scheme options  0-> both, 1->IRF, 2->KWT, otherwise error
 USE public_var,only: doesBasinRoute         ! basin routing options   0-> no, 1->IRF, otherwise error
 USE public_var,only: doesAccumRunoff        ! option to delayed runoff accumulation over all the upstream reaches. 0->no, 1->yes
+USE public_var,only: kinematicWaveTracking  ! Lagrangian kinematic wave
 USE public_var,only: kinematicWave          ! kinematic wave
+USE public_var,only: diffusiveWave          ! diffusive wave
+USE public_var,only: muskingumCunge         ! muskingum cunge
 USE public_var,only: impulseResponseFunc    ! impulse response function
 USE public_var,only: allRoutingMethods      ! all routing methods
 USE globalData,only: meta_rflx
@@ -240,7 +243,7 @@ CONTAINS
 
  ! Modify write option
  ! Routing option
- if (routOpt==kinematicWave) then
+ if (routOpt==kinematicWaveTracking) then
   meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
  elseif (routOpt==impulseResponseFunc) then
   meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.


### PR DESCRIPTION
This is the first step to implement kinematic wave, muskingum-cunge and diffusive wave routing methods

This commit includes the following changes.
1. Replace KROUTE data structure with RCHSTA, which includes restart variables for other routing method
2. Changes related to styles
3. Add meta and variable lookup for KW, MC, and DW routing method (actual routing routines are not added yet)

This update does not change control file setup and previous simulations (output files). 