### PR TITLE
musking-cunge routing implementation

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -158,6 +158,7 @@ CORE = \
     basinUH.f90 \
     irf_route.f90 \
     kwt_route.f90 \
+    mc_route.f90 \
     main_route.f90 \
     model_setup.f90
 

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -150,5 +150,6 @@ MODULE globalData
 
   ! miscellaneous
   integer(i4b)                   , public :: ixPrint=integerMissing   ! index of desired reach to be on-screen print
+  integer(i4b)                   , public :: nMolecule                ! number of computational molecule (used for KW, MC, DW)
 
 end module globalData

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -1,0 +1,390 @@
+MODULE mc_route_module
+
+! muskingum-cunge routing
+
+USE nrtype
+! data types
+USE dataTypes,   ONLY: STRFLX            ! fluxes in each reach
+USE dataTypes,   ONLY: STRSTA            ! state in each reach
+USE dataTypes,   ONLY: RCHTOPO           ! Network topology
+USE dataTypes,   ONLY: RCHPRP            ! Reach parameter
+USE dataTypes,   ONLY: subbasin_omp      ! mainstem+tributary data strucuture
+! global data
+USE public_var,  ONLY: iulog             ! i/o logical unit number
+USE public_var,  ONLY: realMissing       ! missing value for real number
+USE public_var,  ONLY: integerMissing    ! missing value for integer number
+! subroutines: general
+USE model_finalize, ONLY : handle_err
+
+! privary
+implicit none
+private
+
+public::mc_route
+
+contains
+
+ ! *********************************************************************
+ ! subroutine: perform muskingum-cunge routing through the river network
+ ! *********************************************************************
+ SUBROUTINE mc_route(iens,                 & ! input: ensemble index
+                     river_basin,          & ! input: river basin information (mainstem, tributary outlet etc.)
+                     T0,T1,                & ! input: start and end of the time step
+                     ixDesire,             & ! input: reachID to be checked by on-screen pringing
+                     NETOPO_in,            & ! input: reach topology data structure
+                     RPARAM_in,            & ! input: reach parameter data structure
+                     RCHSTA_out,           & ! inout: reach state data structure
+                     RCHFLX_out,           & ! inout: reach flux data structure
+                     ierr,message,         & ! output: error control
+                     ixSubRch)               ! optional input: subset of reach indices to be processed
+
+   implicit none
+
+   ! Input
+   integer(i4b),       intent(in)                 :: iEns                 ! ensemble member
+   type(subbasin_omp), intent(in),    allocatable :: river_basin(:)       ! river basin information (mainstem, tributary outlet etc.)
+   real(dp),           intent(in)                 :: T0,T1                ! start and end of the time step (seconds)
+   integer(i4b),       intent(in)                 :: ixDesire             ! index of the reach for verbose output
+   type(RCHTOPO),      intent(in),    allocatable :: NETOPO_in(:)         ! River Network topology
+   type(RCHPRP),       intent(in),    allocatable :: RPARAM_in(:)         ! River reach parameter
+   ! inout
+   type(STRSTA),       intent(inout), allocatable :: RCHSTA_out(:,:)      ! reach state data
+   type(STRFLX),       intent(inout), allocatable :: RCHFLX_out(:,:)      ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
+   ! output variables
+   integer(i4b),       intent(out)                :: ierr                 ! error code
+   character(*),       intent(out)                :: message              ! error message
+   ! input (optional)
+   integer(i4b),       intent(in), optional       :: ixSubRch(:)          ! subset of reach indices to be processed
+   ! local variables
+   character(len=strLen)                          :: cmessage             ! error message for downwind routine
+   logical(lgt),                      allocatable :: doRoute(:)           ! logical to indicate which reaches are processed
+   integer(i4b)                                   :: LAKEFLAG=0           ! >0 if processing lakes
+   integer(i4b)                                   :: nOrder               ! number of stream order
+   integer(i4b)                                   :: nTrib                ! number of tributary basins
+   integer(i4b)                                   :: nSeg                 ! number of reaches in the network
+   integer(i4b)                                   :: iSeg, jSeg           ! loop indices - reach
+   integer(i4b)                                   :: iTrib                ! loop indices - branch
+   integer(i4b)                                   :: ix                   ! loop indices stream order
+
+   ierr=0; message='mc_route/'
+
+   ! number of reach check
+   if (size(NETOPO_in)/=size(RCHFLX_out(iens,:))) then
+    ierr=20; message=trim(message)//'sizes of NETOPO and RCHFLX mismatch'; return
+   endif
+
+   nSeg = size(NETOPO_in)
+
+   allocate(doRoute(nSeg), stat=ierr)
+
+   if (present(ixSubRch))then
+    doRoute(:)=.false.
+    doRoute(ixSubRch) = .true. ! only subset of reaches are on
+   else
+    doRoute(:)=.true. ! every reach is on
+   endif
+
+   nOrder = size(river_basin)
+
+   do ix = 1, nOrder
+
+     nTrib=size(river_basin(ix)%branch)
+
+!$OMP PARALLEL DO schedule(dynamic,1)                   & ! chunk size of 1
+!$OMP          private(jSeg, iSeg)                      & ! private for a given thread
+!$OMP          private(ierr, cmessage)                  & ! private for a given thread
+!$OMP          shared(T0,T1)                            & ! private for a given thread
+!$OMP          shared(LAKEFLAG)                         & ! private for a given thread
+!$OMP          shared(river_basin)                      & ! data structure shared
+!$OMP          shared(doRoute)                          & ! data array shared
+!$OMP          shared(NETOPO_in)                        & ! data structure shared
+!$OMP          shared(RPARAM_in)                        & ! data structure shared
+!$OMP          shared(RCHSTA_out)                       & ! data structure shared
+!$OMP          shared(RCHFLX_out)                       & ! data structure shared
+!$OMP          shared(ix, iEns, ixDesire)               & ! indices shared
+!$OMP          firstprivate(nTrib)
+     trib:do iTrib = 1,nTrib
+       seg:do iSeg=1,river_basin(ix)%branch(iTrib)%nRch
+         jSeg  = river_basin(ix)%branch(iTrib)%segIndex(iSeg)
+         if (.not. doRoute(jSeg)) cycle
+         call mc_rch(iEns,jSeg,           & ! input: array indices
+                     ixDesire,            & ! input: index of the desired reach
+                     T0,T1,               & ! input: start and end of the time step
+                     LAKEFLAG,            & ! input: flag if lakes are to be processed
+                     NETOPO_in,           & ! input: reach topology data structure
+                     RPARAM_in,           & ! input: reach parameter data structure
+                     RCHSTA_out,          & ! inout: reach state data structure
+                     RCHFLX_out,          & ! inout: reach flux data structure
+                     ierr,cmessage)         ! output: error control
+         if(ierr/=0) call handle_err(ierr, trim(message)//trim(cmessage))
+       end do  seg
+     end do trib
+!$OMP END PARALLEL DO
+
+   end do
+
+ END SUBROUTINE mc_route
+
+ ! *********************************************************************
+ ! subroutine: perform muskingum-cunge routing for one segment
+ ! *********************************************************************
+ SUBROUTINE mc_rch(iEns, segIndex, & ! input: index of runoff ensemble to be processed
+                   ixDesire,       & ! input: reachID to be checked by on-screen pringing
+                   T0,T1,          & ! input: start and end of the time step
+                   LAKEFLAG,       & ! input: flag if lakes are to be processed
+                   NETOPO_in,      & ! input: reach topology data structure
+                   RPARAM_in,      & ! input: reach parameter data structure
+                   RCHSTA_out,     & ! inout: reach state data structure
+                   RCHFLX_out,     & ! inout: reach flux data structure
+                   ierr, message)    ! output: error control
+
+ implicit none
+
+ ! Input
+ integer(i4b),  intent(in)                 :: iEns              ! runoff ensemble to be routed
+ integer(i4b),  intent(in)                 :: segIndex          ! segment where routing is performed
+ integer(i4b),  intent(in)                 :: ixDesire          ! index of the reach for verbose output
+ real(dp),      intent(in)                 :: T0,T1             ! start and end of the time step (seconds)
+ integer(i4b),  intent(in)                 :: LAKEFLAG          ! >0 if processing lakes
+ type(RCHTOPO), intent(in),    allocatable :: NETOPO_in(:)      ! River Network topology
+ type(RCHPRP),  intent(in),    allocatable :: RPARAM_in(:)      ! River reach parameter
+ ! inout
+ type(STRSTA),  intent(inout), allocatable :: RCHSTA_out(:,:)   ! reach state data
+ type(STRFLX),  intent(inout), allocatable :: RCHFLX_out(:,:)   ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
+ ! Output
+ integer(i4b),  intent(out)                :: ierr              ! error code
+ character(*),  intent(out)                :: message           ! error message
+ ! Local variables to
+ logical(lgt)                              :: doCheck           ! check details of variables
+ logical(lgt)                              :: isHW              ! headwater basin?
+ integer(i4b)                              :: nUps              ! number of upstream segment
+ integer(i4b)                              :: iUps              ! upstream reach index
+ integer(i4b)                              :: iRch_ups          ! index of upstream reach in NETOPO
+ real(dp)                                  :: q_upstream        ! total discharge at top of the reach being processed
+ character(len=strLen)                     :: cmessage          ! error message from subroutine
+
+ ierr=0; message='mc_rch/'
+
+ doCheck = .false.
+ if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+   doCheck = .true.
+ end if
+
+ ! get discharge coming from upstream
+ nUps = size(NETOPO_in(segIndex)%UREACHI)
+ isHW = .true.
+ q_upstream = 0.0_dp
+ if (nUps>0) then
+   isHW = .false.
+   do iUps = 1,nUps
+     iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%REACH_Q
+   end do
+ endif
+
+ if(doCheck)then
+   write(iulog,'(A)') 'CHECK muskingum-cunge routing'
+   if (nUps>0) then
+     do iUps = 1,nUps
+       iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+       write(iulog,'(A,X,I6,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%REACH_Q
+     enddo
+   end if
+   write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iEns,segIndex)%BASIN_QR(1)=',RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
+ endif
+
+ ! solve muskingum-cunge alogorithm
+ call muskingum_cunge(RPARAM_in(segIndex),         &    ! input: parameter at segIndex reach
+                      T0,T1,                       &    ! input: start and end of the time step
+                      q_upstream,                  &    ! input: total discharge at top of the reach being processed
+                      isHW,                        &    ! input: is this headwater basin?
+                      RCHSTA_out(iens,segIndex),   &    ! inout:
+                      RCHFLX_out(iens,segIndex),   &    ! inout: updated fluxes at reach
+                      doCheck,                     &    ! input: reach index to be examined
+                      ierr, cmessage)                    ! output: error control
+ if(ierr/=0)then
+    write(message, '(A,X,I10,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage)
+    return
+ endif
+
+ if(doCheck)then
+  write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%REACH_Q
+ endif
+
+ END SUBROUTINE mc_rch
+
+
+ ! *********************************************************************
+ ! subroutine: solve muskingum equation
+ ! *********************************************************************
+ SUBROUTINE muskingum_cunge(rch_param,     & ! input: river parameter data structure
+                            T0,T1,         & ! input: start and end of the time step
+                            q_upstream,    & ! input: discharge from upstream
+                            isHW,          & ! input: is this headwater basin?
+                            rstate,        & ! inout: reach state at a reach
+                            rflux,         & ! inout: reach flux at a reach
+                            doCheck,       & ! input: reach index to be examined
+                            ierr,message)
+ ! ----------------------------------------------------------------------------------------
+ ! Perform muskingum-cunge routing
+ !
+ !
+ !
+ !
+ ! *
+ ! *
+ ! *
+ !
+ ! state array:
+ ! (time:0:1, loc:0:1) 0-previous time step/inlet, 1-current time step/outlet.
+ ! Q or A(1,2,3,4): 1: (t=0,x=0), 2: (t=0,x=1), 3: (t=1,x=0), 4: (t=1,x=1)
+
+ IMPLICIT NONE
+ ! Input
+ type(RCHPRP), intent(in)                 :: rch_param    ! River reach parameter
+ real(dp),     intent(in)                 :: T0,T1        ! start and end of the time step (seconds)
+ real(dp),     intent(in)                 :: q_upstream   ! total discharge at top of the reach being processed
+ logical(lgt), intent(in)                 :: isHW         ! is this headwater basin?
+ logical(lgt), intent(in)                 :: doCheck      ! reach index to be examined
+ ! Input/Output
+ type(STRSTA), intent(inout)              :: rstate       ! curent reach states
+ type(STRFLX), intent(inout)              :: rflux        ! current Reach fluxes
+ ! Output
+ integer(i4b), intent(out)                :: ierr         ! error code
+ character(*), intent(out)                :: message      ! error message
+ ! LOCAL VAIRABLES
+ real(dp)                                 :: alpha        ! sqrt(slope)(/mannings N* width)
+ real(dp)                                 :: beta         ! constant, 5/3
+ real(dp)                                 :: theta        ! dT/dX
+ real(dp)                                 :: X            ! X-factor in descreterized kinematic wave
+ real(dp)                                 :: dt           ! interval of time step [sec]
+ real(dp)                                 :: dx           ! length of segment [m]
+ real(dp)                                 :: Q(0:1,0:1)   ! discharge at computational molecule
+ real(dp)                                 :: Qbar         ! 3-point average discharge [m3/s]
+ real(dp)                                 :: Abar         ! 3-point average flow area [m2]
+ real(dp)                                 :: Vbar         ! 3-point average velocity [m/s]
+ real(dp)                                 :: Ybar         ! 3-point average flow depth [m]
+ real(dp)                                 :: B            ! flow top width [m]
+ real(dp)                                 :: ck           ! kinematic wave celerity [m/s]
+ real(dp)                                 :: Cn           ! Courant number [-]
+ real(dp)                                 :: dTsub        ! time inteval for sut time-step [sec]
+ real(dp)                                 :: C0,C1,C2     ! muskingum parameters
+ real(dp), allocatable                    :: QoutLocal(:) ! out discharge [m3/s] at sub time step
+ real(dp), allocatable                    :: QinLocal(:)  ! in discharge [m3/s] at sub time step
+ integer(i4b)                             :: ix           ! loop index
+ integer(i4b)                             :: ntSub        ! number of sub time-step
+ character(len=strLen)                    :: cmessage     ! error message from subroutine
+ real(dp), parameter                      :: Y = 0.5      ! muskingum parameter Y (this is fixed)
+
+ ierr=0; message='muskingum-cunge/'
+
+ Q(0,0) = rstate%molecule%Q(1) ! inflow at previous time step (t-1)
+ Q(0,1) = rstate%molecule%Q(2) ! outflow at previous time step (t-1)
+ Q(1,1) = realMissing
+
+ if (.not. isHW) then
+
+   ! Get the reach parameters
+   ! A = (Q/alpha)**(1/beta)
+   ! Q = alpha*A**beta
+   alpha = sqrt(rch_param%R_SLOPE)/(rch_param%R_MAN_N*rch_param%R_WIDTH**(2._dp/3._dp))
+   beta  = 5._dp/3._dp
+   dx = rch_param%RLENGTH
+   dt = T1-T0
+   theta = dt/dx     ! [s/m]
+
+   ! compute total flow rate and flow area at upstream end at current time step
+   Q(1,0) = q_upstream
+
+   if (doCheck) then
+     write(iulog,'(4(A,X,G12.5))') ' length [m] =',rch_param%RLENGTH,'slope [-] =',rch_param%R_SLOPE,'channel width [m] =',rch_param%R_WIDTH,'manning coef =',rch_param%R_MAN_N
+     write(iulog,'(3(A,X,G12.5))') ' Qin(t-1) Q(0,0)=',Q(0,0),' Qin(t) Q(0,1)=',Q(0,1),' Qout(t-1) Q(1,0)=',Q(1,0)
+   end if
+
+   ! first, using 3-point average in computational molecule, check Cournat number is less than 1, otherwise subcycle within one time step
+   Qbar = (Q(0,0)+Q(1,0)+Q(0,1))/3.0  ! average discharge [m3/s]
+   Abar = (Qbar/alpha)**(1/beta)      ! average flow area [m2] (from manning equation)
+   Vbar = Qbar/Abar                   ! average velocity [m/s]
+   ck   = beta*Vbar                   ! kinematic wave celerity [m/s]
+   Cn   = ck*theta                    ! Courant number [-]
+
+   ! time-step adjustment so Courant number is less than 1
+   ntSub = 1
+   dTsub = dt
+   if (Cn>1.0_dp) then
+     ntSub = ceiling(dt/dx*cK)
+     dTsub = dt/ntSub
+   end if
+   if (doCheck) then
+     write(iulog,'(A,X,I3,A,X,G12.5)') ' No. sub timestep=',nTsub,' sub time-step [sec]=',dTsub
+   end if
+
+   allocate(QoutLocal(0:ntSub), QinLocal(0:ntSub), stat=ierr, errmsg=cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   QoutLocal(:) = realMissing
+   QoutLocal(0) = Q(0,1)
+   QinLocal(:)  = realMissing
+   QinLocal(0)  = Q(0,0)
+
+   ! solve outflow at each sub time step
+   do ix = 1, nTsub
+     QinLocal(ix) = Q(0,0)+(Q(1,0)-Q(0,0))*(ix)/nTsub
+
+     Qbar = (QinLocal(ix)+QinLocal(ix-1)+QoutLocal(ix-1))/3.0 ! 3 point average discharge [m3/s]
+     Abar = (Qbar/alpha)**(1/beta)                            ! flow area [m2] (manning equation)
+     Ybar = Abar/rch_param%R_WIDTH                            ! flow depth [m] (rectangular channel)
+     B = rch_param%R_WIDTH                                    ! top width at water level [m] (rectangular channel)
+     ck = beta*(Qbar/Abar)                                    ! kinematic wave celerity [m/s]
+
+     X = 0.5*(1.0 - Qbar/(B*rch_param%R_SLOPE*ck*dX))         ! X factor for descreterized kinematic wave equation
+     Cn = ck*dTsub/dx                                         ! Courant number [-]
+
+     C0 = (-X+Cn*(1-Y))/(1-X+Cn*(1-Y))
+     C1 = (X+Cn*Y)/(1-X+Cn*(1-Y))
+     C2 = (1-X-Cn*Y)/(1-X+Cn*(1-Y))
+
+     QoutLocal(ix) = C0* QinLocal(ix)+ C1* QinLocal(ix-1)+ C2* QoutLocal(ix-1)
+     QoutLocal(ix) = max(0.0, QoutLocal(ix))
+
+     if (isnan(QoutLocal(ix))) then
+       ierr=10; message=trim(message)//'QoutLocal is Nan; activate vodose for this segment for diagnosis';return
+     end if
+
+     if (doCheck) then
+       write(iulog,'(A,I3,X,A,G12.5,X,A,G12.5)') '   sub time-step= ',ix,'Courant number= ',Cn, 'Q= ',QoutLocal(ix)
+     end if
+   end do
+
+   Q(1,1) = sum(QoutLocal(1:nTsub))/nTsub
+
+ else ! if head-water
+
+   Q(1,0) = 0._dp
+   Q(1,1) = 0._dp
+
+   if (doCheck) then
+     write(iulog,'(A)')            ' This is headwater '
+   endif
+
+ endif
+
+ ! compute volume
+ rflux%REACH_VOL(0) = rflux%REACH_VOL(1)
+ rflux%REACH_VOL(1) = rflux%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dT
+ rflux%REACH_VOL(1) = max(rflux%REACH_VOL(1), 0._dp)
+
+ ! add catchment flow
+ rflux%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)
+
+ if (doCheck) then
+   write(iulog,'(A,X,G12.5)') ' Qout(t)=',Q(1,1)
+ endif
+
+ ! save inflow (index 1) and outflow (index 2) at current time step
+ rstate%molecule%Q(1) = Q(1,0)
+ rstate%molecule%Q(2) = Q(1,1)
+
+ END SUBROUTINE muskingum_cunge
+
+
+END MODULE mc_route_module

--- a/route/build/src/model_setup.f90
+++ b/route/build/src/model_setup.f90
@@ -235,6 +235,7 @@ CONTAINS
   USE public_var,    ONLY : diffusiveWave
   USE public_var,    ONLY : fname_state_in    ! name of state input file
   USE public_var,    ONLY : restart_dir       ! directory containing output data
+  USE globalData,    ONLY : nMolecule         ! number of computational molecule for finite difference
   USE globalData,    ONLY : RCHFLX            ! reach flux structure
   USE globalData,    ONLY : RCHSTA            ! reach restart state structure
   USE globalData,    ONLY : TSEC              ! begining/ending of simulation time step [sec]
@@ -246,7 +247,6 @@ CONTAINS
   character(*),        intent(out) :: message          ! error message
   ! local variable
   real(dp)                         :: T0,T1            ! begining/ending of simulation time step [sec]
-  integer(i4b)                     :: nMolecule        ! number of computational molecule (used for KW, LKW, MC, DW)
   integer(i4b)                     :: iens             ! ensemble index (currently only 1)
   integer(i4b)                     :: ix               ! loop index
   character(len=strLen)            :: cmessage         ! error message of downwind routine

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -97,6 +97,7 @@ contains
  meta_stateDims(ixStateDims%tbound  ) = dim_info('tbound',  integerMissing, 2)               ! time bound (alway 2 - start and end)
  meta_stateDims(ixStateDims%ens     ) = dim_info('ens',     integerMissing, integerMissing)  ! runoff ensemble
  meta_stateDims(ixStateDims%wave    ) = dim_info('wave',    integerMissing, MAXQPAR)         ! reach waves vector (max. number is defined as MAXQPAR)
+ meta_stateDims(ixStateDims%fdmesh  ) = dim_info('fdmesh',  integerMissing, integerMissing)  ! finite difference mesh points
  meta_stateDims(ixStateDims%tdh_irf ) = dim_info('tdh_irf', integerMissing, integerMissing)  ! future time steps for irf routing
  meta_stateDims(ixStateDims%tdh     ) = dim_info('tdh',     integerMissing, integerMissing)  ! future time steps for bsasin irf routing
 
@@ -160,11 +161,11 @@ contains
  call meta_rflx(ixRFLX%instRunoff       )%init('instRunoff'       , 'instantaneous runoff in each reach'                , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%dlayRunoff       )%init('dlayRunoff'       , 'delayed runoff in each reach'                      , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%sumUpstreamRunoff)%init('sumUpstreamRunoff', 'sum of upstream runoff in each reach'              , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
- call meta_rflx(ixRFLX%KWTroutedRunoff  )%init('KWTroutedRunoff'  , 'routed runoff in reach - lagrangian kinematic wave', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%KWTroutedRunoff  )%init('KWTroutedRunoff'  , 'routed runoff in reach - lagrangian kinematic wave', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
  call meta_rflx(ixRFLX%MCroutedRunoff   )%init('MCroutedRunoff'   , 'routed runoff in reach - muskingum-cunge'          , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
  call meta_rflx(ixRFLX%DWroutedRunoff   )%init('DWroutedRunoff'   , 'routed runoff in reach - diffusive wave'           , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
  call meta_rflx(ixRFLX%KWroutedRunoff   )%init('KWroutedRunoff'   , 'routed runoff in reach - lagrangian kinematic wave', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
- call meta_rflx(ixRFLX%IRFroutedRunoff  )%init('IRFroutedRunoff'  , 'routed runoff in reach - Impulse Response Function', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%IRFroutedRunoff  )%init('IRFroutedRunoff'  , 'routed runoff in reach - Impulse Response Function', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
  call meta_rflx(ixRFLX%volume           )%init('volume'           , 'lake and stream volume'                            , 'm3'  , nf90_float, [ixQdims%seg,ixQdims%time], .false.)
 
  ! Lagrangian kinematic Wave restart state

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -158,7 +158,7 @@ contains
    ! MISCELLANEOUS
    case('<debug>');                read(cData,*,iostat=io_error) debug             ! print out detailed information throught the probram
    case('<seg_outlet>'   );        read(cData,*,iostat=io_error) idSegOut          ! desired outlet reach id (if -9999 --> route over the entire network)
-   case('<route_opt>');            read(cData,*,iostat=io_error) routOpt           ! routing scheme options  0-> both, 1->IRF, 2->KWT, otherwise error
+   case('<route_opt>');            read(cData,*,iostat=io_error) routOpt           ! routing scheme options  0-> IRF+KWT (to be removed), 1->IRF, 2->KWT, 3-> KW, 4->MC, 5->DW
    case('<desireId>'   );          read(cData,*,iostat=io_error) desireId          ! turn off checks or speficy reach ID if necessary to print on screen
    case('<doesBasinRoute>');       read(cData,*,iostat=io_error) doesBasinRoute    ! basin routing options   0-> no, 1->IRF, otherwise error
    case('<doesAccumRunoff>');      read(cData,*,iostat=io_error) doesAccumRunoff   ! option to delayed runoff accumulation over all the upstream reaches. 0->no, 1->yes
@@ -173,6 +173,7 @@ contains
    case('<sumUpstreamRunoff>');    read(cData,*,iostat=io_error) meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile
    case('<KWTroutedRunoff>');      read(cData,*,iostat=io_error) meta_rflx(ixRFLX%KWTroutedRunoff  )%varFile
    case('<IRFroutedRunoff>');      read(cData,*,iostat=io_error) meta_rflx(ixRFLX%IRFroutedRunoff  )%varFile
+   case('<MCroutedRunoff>');       read(cData,*,iostat=io_error) meta_rflx(ixRFLX%MCroutedRunoff   )%varFile
 
    ! VARIABLE NAMES for data (overwrite default name in popMeta.f90)
    ! HRU structure

--- a/route/build/src/read_restart.f90
+++ b/route/build/src/read_restart.f90
@@ -25,7 +25,6 @@ CONTAINS
                           T0, T1,          &   ! output: start and end time [sec]
                           ierr, message)       ! Output: error control
 
- ! State/flux data structures
  USE globalData, ONLY: RCHFLX                    ! To get q future for basin IRF and IRF (these should not be in this data strucuture)
  USE globalData, ONLY: RCHSTA                    ! restart state data structure
  USE dataTypes,  ONLY: states
@@ -96,259 +95,310 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
  end if
 
+ if (opt==muskingumCunge) then
+   call read_MC_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
+ end if
+
  call close_nc(ncidRestart, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  CONTAINS
 
   SUBROUTINE read_basinQ_state(ierr, message1)
-  ! meta data
-  USE globalData, ONLY: meta_basinQ               ! reach inflow from basin at previous time step
-  ! Named variables
-  USE var_lookup, ONLY: ixBasinQ, nVarsBasinQ
-  implicit none
-  ! output
-  integer(i4b), intent(out)     :: ierr           ! error code
-  character(*), intent(out)     :: message1       ! error message
-  ! local variables
-  character(len=strLen)         :: cmessage1      ! error message of downwind routine
-  type(states)                  :: state          ! temporal state data structures
-  integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
-  integer(i4b)                  :: ntdh           ! dimension size
+    USE globalData, ONLY: meta_basinQ               ! reach inflow from basin at previous time step
+    USE var_lookup, ONLY: ixBasinQ, nVarsBasinQ
+    implicit none
+    ! output
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b)                  :: ntdh           ! dimension size
 
-  ! initialize error control
-  ierr=0; message1='read_basinQ_state/'
+    ! initialize error control
+    ierr=0; message1='read_basinQ_state/'
 
-  allocate(state%var(nVarsBasinQ), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(state%var(nVarsBasinQ), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsBasinQ
-    select case(iVar)
-      case(ixBasinQ%q); allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
-      case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for reach inflow:'//trim(meta_basinQ(iVar)%varName); return; endif
-  end do
+    do iVar=1,nVarsBasinQ
+      select case(iVar)
+        case(ixBasinQ%q); allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for reach inflow:'//trim(meta_basinQ(iVar)%varName); return; endif
+    end do
 
-  do iVar=1,nVarsBasinQ
+    do iVar=1,nVarsBasinQ
 
-   select case(iVar)
-     case(ixBasinQ%q); call get_nc(ncidRestart, meta_basinQ(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
-     case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index for nc writing'; return
-   end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_basinQ(iVar)%varName); return; endif
+     select case(iVar)
+       case(ixBasinQ%q); call get_nc(ncidRestart, meta_basinQ(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
+       case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index for nc writing'; return
+     end select
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_basinQ(iVar)%varName); return; endif
 
-  enddo
+    enddo
 
-  do iens=1,nens
-    do iSeg=1,nSeg
-      do iVar=1,nVarsBasinQ
-        select case(iVar)
-          case(ixBasinQ%q); RCHFLX(iens,iSeg)%BASIN_QR(1) = state%var(iVar)%array_2d_dp(iSeg,iens)
-          case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index'; return
-        end select
+    do iens=1,nens
+      do iSeg=1,nSeg
+        do iVar=1,nVarsBasinQ
+          select case(iVar)
+            case(ixBasinQ%q); RCHFLX(iens,iSeg)%BASIN_QR(1) = state%var(iVar)%array_2d_dp(iSeg,iens)
+            case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index'; return
+          end select
+        enddo
       enddo
     enddo
-  enddo
 
   END SUBROUTINE read_basinQ_state
 
 
   SUBROUTINE read_IRFbas_state(ierr, message1)
-  ! meta data
-  USE globalData, ONLY: meta_irf_bas              ! basin IRF routing
-  ! Named variables
-  USE var_lookup, ONLY: ixIRFbas, nVarsIRFbas
-  implicit none
-  ! output
-  integer(i4b), intent(out)     :: ierr           ! error code
-  character(*), intent(out)     :: message1       ! error message
-  ! local variables
-  character(len=strLen)         :: cmessage1      ! error message of downwind routine
-  type(states)                  :: state          ! temporal state data structures
-  integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
-  integer(i4b)                  :: ntdh           ! dimension size
+    USE globalData, ONLY: meta_irf_bas              ! basin IRF routing
+    USE var_lookup, ONLY: ixIRFbas, nVarsIRFbas
+    implicit none
+    ! output
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b)                  :: ntdh           ! dimension size
 
-  ! initialize error control
-  ierr=0; message1='read_IRFbas_state/'
+    ! initialize error control
+    ierr=0; message1='read_IRFbas_state/'
 
-  call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh)%dimName, ntdh, ierr, cmessage1)
-  if(ierr/=0)then;  message1=trim(message1)//trim(cmessage1); return; endif
+    call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh)%dimName, ntdh, ierr, cmessage1)
+    if(ierr/=0)then;  message1=trim(message1)//trim(cmessage1); return; endif
 
-  allocate(state%var(nVarsIRFbas), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(state%var(nVarsIRFbas), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsIRFbas
-    select case(iVar)
-      case(ixIRFbas%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh, nens), stat=ierr)
-      case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state:'//trim(meta_irf_bas(iVar)%varName); return; endif
-  end do
+    do iVar=1,nVarsIRFbas
+      select case(iVar)
+        case(ixIRFbas%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh, nens), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state:'//trim(meta_irf_bas(iVar)%varName); return; endif
+    end do
 
-  do iVar=1,nVarsIRFbas
-    select case(iVar)
-      case(ixIRFbas%qfuture); call get_nc(ncidRestart, meta_irf_bas(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh,nens/), ierr, cmessage1)
-      case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF variable index for nc writing'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf_bas(iVar)%varName); return; endif
-  enddo
+    do iVar=1,nVarsIRFbas
+      select case(iVar)
+        case(ixIRFbas%qfuture); call get_nc(ncidRestart, meta_irf_bas(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh,nens/), ierr, cmessage1)
+        case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF variable index for nc writing'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf_bas(iVar)%varName); return; endif
+    enddo
 
-  do iens=1,nens
-    do iSeg=1,nSeg
-      allocate(RCHFLX(iens,iSeg)%QFUTURE(ntdh), stat=ierr, errmsg=cmessage1)
-      if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
-      do iVar=1,nVarsIRFbas
-        select case(iVar)
-          case(ixIRFbas%qfuture); RCHFLX(iens,iSeg)%QFUTURE(:)  = state%var(iVar)%array_3d_dp(iSeg,:,iens)
-          case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
-        end select
+    do iens=1,nens
+      do iSeg=1,nSeg
+        allocate(RCHFLX(iens,iSeg)%QFUTURE(ntdh), stat=ierr, errmsg=cmessage1)
+        if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+        do iVar=1,nVarsIRFbas
+          select case(iVar)
+            case(ixIRFbas%qfuture); RCHFLX(iens,iSeg)%QFUTURE(:)  = state%var(iVar)%array_3d_dp(iSeg,:,iens)
+            case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
+          end select
+        enddo
       enddo
     enddo
-  enddo
 
   END SUBROUTINE read_IRFbas_state
 
 
   SUBROUTINE read_IRF_state(ierr, message1)
-  ! meta data
-  USE globalData,  ONLY: meta_irf               ! IRF routing
-  ! Named variables
-  USE var_lookup,  ONLY: ixIRF, nVarsIRF
-  implicit none
-  integer(i4b), intent(out)     :: ierr           ! error code
-  character(*), intent(out)     :: message1       ! error message
-  ! local variables
-  character(len=strLen)         :: cmessage1      ! error message of downwind routine
-  type(states)                  :: state          ! temporal state data structures
-  integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
-  integer(i4b), allocatable     :: numQF(:,:)     ! number of future Q time steps for each ensemble and segment
-  integer(i4b)                  :: ntdh_irf       ! dimenion sizes
+    USE globalData,  ONLY: meta_irf               ! IRF routing
+    USE var_lookup,  ONLY: ixIRF, nVarsIRF
+    implicit none
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b), allocatable     :: numQF(:,:)     ! number of future Q time steps for each ensemble and segment
+    integer(i4b)                  :: ntdh_irf       ! dimenion sizes
 
-  ierr=0; message1='read_IRF_state/'
+    ierr=0; message1='read_IRF_state/'
 
-  call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh_irf)%dimName, ntdh_irf, ierr, cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%tdh_irf)%dimName, ntdh_irf, ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  allocate(state%var(nVarsIRF), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(state%var(nVarsIRF), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  allocate(numQF(nens,nSeg), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(numQF(nens,nSeg), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsIRF
-    select case(iVar)
-      case(ixIRF%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nens), stat=ierr)
-      case(ixIRF%irfVol);  allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
-      case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state:'//trim(meta_irf(iVar)%varName); return; endif
-  end do
+    do iVar=1,nVarsIRF
+      select case(iVar)
+        case(ixIRF%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nens), stat=ierr)
+        case(ixIRF%irfVol);  allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state:'//trim(meta_irf(iVar)%varName); return; endif
+    end do
 
-  call get_nc(ncidRestart,'numQF',numQF,(/1,1/),(/nSeg,nens/),ierr,cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf(iVar)%varName); return; endif
-
-  do iVar=1,nVarsIRF
-    select case(iVar)
-      case(ixIRF%qfuture); call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage1)
-      case(ixIRF%irfVol);  call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg, nens/), ierr, cmessage1)
-      case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc reading'; return
-    end select
+    call get_nc(ncidRestart,'numQF',numQF,(/1,1/),(/nSeg,nens/),ierr,cmessage1)
     if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf(iVar)%varName); return; endif
-  end do
 
-  do iens=1,nens
-    do iSeg=1,nSeg
-      allocate(RCHFLX(iens,iSeg)%QFUTURE_IRF(numQF(iens,iSeg)), stat=ierr, errmsg=cmessage1)
-      if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
-      do iVar=1,nVarsIRF
-        select case(iVar)
-          case(ixIRF%qfuture); RCHFLX(iens,iSeg)%QFUTURE_IRF  = state%var(iVar)%array_3d_dp(iSeg,1:numQF(iens,iSeg),iens)
-          case(ixIRF%irfVol);  RCHFLX(iens,iSeg)%REACH_VOL(1) = state%var(iVar)%array_2d_dp(iSeg,iens)
-          case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-        end select
-      enddo ! variable loop
-    enddo ! seg loop
-  enddo ! ensemble loop
+    do iVar=1,nVarsIRF
+      select case(iVar)
+        case(ixIRF%qfuture); call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage1)
+        case(ixIRF%irfVol);  call get_nc(ncidRestart, meta_irf(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg, nens/), ierr, cmessage1)
+        case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc reading'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf(iVar)%varName); return; endif
+    end do
+
+    do iens=1,nens
+      do iSeg=1,nSeg
+        allocate(RCHFLX(iens,iSeg)%QFUTURE_IRF(numQF(iens,iSeg)), stat=ierr, errmsg=cmessage1)
+        if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+        do iVar=1,nVarsIRF
+          select case(iVar)
+            case(ixIRF%qfuture); RCHFLX(iens,iSeg)%QFUTURE_IRF  = state%var(iVar)%array_3d_dp(iSeg,1:numQF(iens,iSeg),iens)
+            case(ixIRF%irfVol);  RCHFLX(iens,iSeg)%REACH_VOL(1) = state%var(iVar)%array_2d_dp(iSeg,iens)
+            case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+          end select
+        enddo ! variable loop
+      enddo ! seg loop
+    enddo ! ensemble loop
 
   END SUBROUTINE read_IRF_state
 
 
   SUBROUTINE read_KWT_state(ierr, message1)
-  ! meta data
-  USE globalData, ONLY: meta_kwt
-  ! Named variables
-  USE var_lookup, ONLY: ixKWT, nVarsKWT
-  implicit none
-  integer(i4b), intent(out)     :: ierr           ! error code
-  character(*), intent(out)     :: message1       ! error message
-  ! local
-  character(len=strLen)         :: cmessage1      ! error message of downwind routine
-  type(states)                  :: state          ! temporal state data structures
-  integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
-  integer(i4b)                  :: nwave          ! dimenion sizes
-  integer(i4b), allocatable     :: RFvec(:)       ! temporal vector
-  integer(i4b), allocatable     :: numWaves(:,:)  ! number of waves for each ensemble and segment
-  ! initialize error control
-  ierr=0; message1='read_KWT_state/'
+    USE globalData, ONLY: meta_kwt
+    USE var_lookup, ONLY: ixKWT, nVarsKWT
+    implicit none
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b)                  :: nwave          ! dimenion sizes
+    integer(i4b), allocatable     :: RFvec(:)       ! temporal vector
+    integer(i4b), allocatable     :: numWaves(:,:)  ! number of waves for each ensemble and segment
+    ! initialize error control
+    ierr=0; message1='read_KWT_state/'
 
-  allocate(state%var(nVarsKWT), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(state%var(nVarsKWT), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  allocate(numWaves(nens,nSeg), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(numWaves(nens,nSeg), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  ! get Dimension sizes
-  call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%wave)%dimName, nwave, ierr, cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    ! get Dimension sizes
+    call get_nc_dim_len(ncidRestart, meta_stateDims(ixStateDims%wave)%dimName, nwave, ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsKWT
+    do iVar=1,nVarsKWT
 
-    select case(iVar)
-     case(ixKWT%routed); allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
-     case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
-      allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
-     case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWT routing state:'//trim(meta_kwt(iVar)%varName); return; endif
-  end do
+      select case(iVar)
+       case(ixKWT%routed); allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
+       case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
+        allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
+       case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWT routing state:'//trim(meta_kwt(iVar)%varName); return; endif
+    end do
 
-  call get_nc(ncidRestart,'numWaves',numWaves, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    call get_nc(ncidRestart,'numWaves',numWaves, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsKWT
-    select case(iVar)
-      case(ixKWT%routed)
-        call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
-      case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
-        call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
-      case default; ierr=20; message1=trim(message1)//'unable to identify KWT variable index for nc reading'; return
-    end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_kwt(iVar)%varName); return; endif
-  end do
+    do iVar=1,nVarsKWT
+      select case(iVar)
+        case(ixKWT%routed)
+          call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
+        case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
+          call get_nc(ncidRestart, meta_kwt(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
+        case default; ierr=20; message1=trim(message1)//'unable to identify KWT variable index for nc reading'; return
+      end select
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_kwt(iVar)%varName); return; endif
+    end do
 
-  do iens=1,nens
-    do iSeg=1,nSeg
-      allocate(RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1), stat=ierr)
-      do iVar=1,nVarsKWT
-        select case(iVar)
-          case(ixKWT%tentry);    RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%TI = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-          case(ixKWT%texit);     RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%TR = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-          case(ixKWT%qwave);     RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%QF = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-          case(ixKWT%qwave_mod); RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%QM = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-          case(ixKWT%routed) ! this is suppposed to be logical variable, but put it as 0 or 1 in double now
-            if (allocated(RFvec)) deallocate(RFvec, stat=ierr)
-            allocate(RFvec(0:numWaves(iens,iSeg)-1),stat=ierr)
-            RFvec = nint(state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens))
-            RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.False.
-            where (RFvec==1_i4b) RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.True.
-          case default; ierr=20; message1=trim(message1)//'unable to identify KWT routing state variable index'; return
-        end select
+    do iens=1,nens
+      do iSeg=1,nSeg
+        allocate(RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1), stat=ierr)
+        do iVar=1,nVarsKWT
+          select case(iVar)
+            case(ixKWT%tentry);    RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%TI = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+            case(ixKWT%texit);     RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%TR = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+            case(ixKWT%qwave);     RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%QF = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+            case(ixKWT%qwave_mod); RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%QM = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+            case(ixKWT%routed) ! this is suppposed to be logical variable, but put it as 0 or 1 in double now
+              if (allocated(RFvec)) deallocate(RFvec, stat=ierr)
+              allocate(RFvec(0:numWaves(iens,iSeg)-1),stat=ierr)
+              RFvec = nint(state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens))
+              RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.False.
+              where (RFvec==1_i4b) RCHSTA(iens,iSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.True.
+            case default; ierr=20; message1=trim(message1)//'unable to identify KWT routing state variable index'; return
+          end select
+        end do
       end do
     end do
-  end do
 
   END SUBROUTINE read_KWT_state
+
+
+  SUBROUTINE read_MC_state(ierr, message1)
+    USE globalData, ONLY: meta_mc
+    USE globalData, ONLY: nMolecule
+    USE var_lookup, ONLY: ixMC, nVarsMC
+    implicit none
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+
+    ierr=0; message1='read_MC_state/'
+
+    allocate(state%var(nVarsMC), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+
+    ! get Dimension sizes
+    call get_nc_dim_len(ncidRestart, trim(meta_stateDims(ixStateDims%fdmesh)%dimName), nMolecule, ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+
+    do iVar=1,nVarsMC
+      select case(iVar)
+        case(ixMC%qsub); allocate(state%var(iVar)%array_3d_dp(nSeg, nMolecule, nens), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for MC routing state:'//trim(meta_mc(iVar)%varName); return; endif
+    end do
+
+    do iVar=1,nVarsMC
+      select case(iVar)
+        case(ixMC%qsub)
+          call get_nc(ncidRestart, trim(meta_mc(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMolecule,nens/), ierr, cmessage1)
+        case default; ierr=20; message1=trim(message1)//'unable to identify MC variable index for nc reading'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_mc(iVar)%varName); return; endif
+    end do
+
+    do iens=1,nens
+      do iSeg=1,nSeg
+        allocate(RCHSTA(iens,iSeg)%molecule%Q(nMolecule), stat=ierr)
+        do iVar=1,nVarsMC
+          select case(iVar)
+            case(ixMC%qsub); RCHSTA(iens,iSeg)%molecule%Q(1:nMolecule) = state%var(iVar)%array_3d_dp(iSeg,1:nMolecule,iens)
+            case default; ierr=20; message1=trim(message1)//'unable to identify MC routing state variable index'; return
+          end select
+        enddo
+      enddo
+    enddo
+
+  END SUBROUTINE read_MC_state
+
 
  END SUBROUTINE read_state_nc
 

--- a/route/build/src/write_simoutput.f90
+++ b/route/build/src/write_simoutput.f90
@@ -93,14 +93,17 @@ CONTAINS
   endif
 
   if (meta_rflx(ixRFLX%KWTroutedRunoff)%varFile) then
-   ! write routed runoff (m3/s)
    call write_nc(simout_nc%ncid, 'KWTroutedRunoff', RCHFLX(iens,:)%REACH_Q, (/1,jTime/), (/nRch,1/), ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
   if (meta_rflx(ixRFLX%IRFroutedRunoff)%varFile) then
-   ! write routed runoff (m3/s)
    call write_nc(simout_nc%ncid, 'IRFroutedRunoff', RCHFLX(iens,:)%REACH_Q_IRF, (/1,jTime/), (/nRch,1/), ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  endif
+
+  if (meta_rflx(ixRFLX%MCroutedRunoff)%varFile) then
+   call write_nc(simout_nc%ncid, 'MCroutedRunoff', RCHFLX(iens,:)%REACH_Q, (/1,jTime/), (/nRch,1/), ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
@@ -241,20 +244,28 @@ CONTAINS
  meta_qDims(ixQdims%hru)%dimLength = nHRU_in
  meta_qDims(ixQdims%ens)%dimLength = nEns_in
 
- ! Modify write option
- ! Routing option
- if (routOpt==kinematicWaveTracking) then
-  meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
- elseif (routOpt==impulseResponseFunc) then
-  meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
- endif
+ ! Make sure to turn off write option for routines not used
+ ! Routing options
+ ! ----- this (allRoutingMethods) is to be removed
+ if (routOpt==allRoutingMethods) then
+    meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.
+    meta_rflx(ixRFLX%KWroutedRunoff)%varFile = .false.
+    meta_rflx(ixRFLX%DWroutedRunoff)%varFile = .false.
+ end if
+ ! ----- this (allRoutingMethods) is to be removed
+ if (routOpt/=kinematicWaveTracking) meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
+ if (routOpt/=impulseResponseFunc) meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
+ if (routOpt/=muskingumCunge) meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.
+ if (routOpt/=kinematicWave) meta_rflx(ixRFLX%KWroutedRunoff)%varFile = .false.
+ if (routOpt/=diffusiveWave) meta_rflx(ixRFLX%DWroutedRunoff)%varFile = .false.
+
  ! runoff accumulation option
  if (doesAccumRunoff==0) then
-  meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile = .false.
+   meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile = .false.
  endif
  ! basin runoff routing option
  if (doesBasinRoute==0) then
-  meta_rflx(ixRFLX%instRunoff)%varFile = .false.
+   meta_rflx(ixRFLX%instRunoff)%varFile = .false.
  endif
 
  ! --------------------


### PR DESCRIPTION
1. Added per-reach mc routing routine (mc_route.f90)
2. Added restart I/O 
3. enabled mc routing option

`routOpt=4` to activate muskingum-cunge method (deactivate the other routing methods).  

Checked the followings: 
- [x ] Compilation with gnu
- [x ] Compilation with intel
- [x ] Tested with MERIT-Hydro global network with CLM5.0 runoff for year 1980 at daily step
- [x ] restart test with above setup.
- [x ] Tested with HDMA global network with CLM5.0 runoff for year 1980 at daily step. 
- [x ] restart test with above setup.

Restart test: 
1. run one year with monthly outputs for both history and restart files (restart is dropped 1st day of the month) for 12 months.
2. run again, starting at August 1st with August 1st restart file.
3. compare history files from 1 and 2 for history files (August through December) 

Detailed science evaluation (esp. numerical stability) is still needed 