### PR TITLE
Completed kinematic wave routing implementation

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -158,6 +158,7 @@ CORE = \
     basinUH.f90 \
     irf_route.f90 \
     kwt_route.f90 \
+    kw_route.f90 \
     mc_route.f90 \
     main_route.f90 \
     model_setup.f90

--- a/route/build/src/kw_route.f90
+++ b/route/build/src/kw_route.f90
@@ -1,0 +1,374 @@
+MODULE kw_route_module
+
+USE nrtype
+! data types
+USE dataTypes, ONLY: STRFLX            ! fluxes in each reach
+USE dataTypes, ONLY: STRSTA            ! state in each reach
+USE dataTypes, ONLY: RCHTOPO           ! Network topology
+USE dataTypes, ONLY: RCHPRP            ! Reach parameter
+USE dataTypes, ONLY: subbasin_omp      ! mainstem+tributary data strucuture
+! global data
+USE public_var, ONLY: iulog             ! i/o logical unit number
+USE public_var, ONLY: realMissing       ! missing value for real number
+USE public_var, ONLY: integerMissing    ! missing value for integer number
+! subroutines: general
+USE model_finalize, ONLY : handle_err
+
+! privary
+implicit none
+private
+
+public::kw_route
+
+real(dp), parameter  :: critFactor=0.01
+
+contains
+
+ ! *********************************************************************
+ ! subroutine: route kinematic waves with Euler solution through the river network
+ ! *********************************************************************
+ SUBROUTINE kw_route(iens,                 & ! input: ensemble index
+                     river_basin,          & ! input: river basin information (mainstem, tributary outlet etc.)
+                     T0,T1,                & ! input: start and end of the time step
+                     ixDesire,             & ! input: reachID to be checked by on-screen pringing
+                     NETOPO_in,            & ! input: reach topology data structure
+                     RPARAM_in,            & ! input: reach parameter data structure
+                     RCHSTA_out,           & ! inout: reach state data structure
+                     RCHFLX_out,           & ! inout: reach flux data structure
+                     ierr,message,         & ! output: error control
+                     ixSubRch)               ! optional input: subset of reach indices to be processed
+
+   implicit none
+   ! Input
+   integer(i4b),       intent(in)                 :: iEns                 ! ensemble member
+   type(subbasin_omp), intent(in),    allocatable :: river_basin(:)       ! river basin information (mainstem, tributary outlet etc.)
+   real(dp),           intent(in)                 :: T0,T1                ! start and end of the time step (seconds)
+   integer(i4b),       intent(in)                 :: ixDesire             ! index of the reach for verbose output
+   type(RCHTOPO),      intent(in),    allocatable :: NETOPO_in(:)         ! River Network topology
+   type(RCHPRP),       intent(in),    allocatable :: RPARAM_in(:)         ! River reach parameter
+   ! inout
+   type(STRSTA),       intent(inout), allocatable :: RCHSTA_out(:,:)      ! reach state data
+   type(STRFLX),       intent(inout), allocatable :: RCHFLX_out(:,:)      ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
+   ! output variables
+   integer(i4b),       intent(out)                :: ierr                 ! error code
+   character(*),       intent(out)                :: message              ! error message
+   ! input (optional)
+   integer(i4b),       intent(in), optional       :: ixSubRch(:)          ! subset of reach indices to be processed
+   ! local variables
+   character(len=strLen)                          :: cmessage             ! error message for downwind routine
+   logical(lgt),                      allocatable :: doRoute(:)           ! logical to indicate which reaches are processed
+   integer(i4b)                                   :: LAKEFLAG=0           ! >0 if processing lakes
+   integer(i4b)                                   :: nOrder               ! number of stream order
+   integer(i4b)                                   :: nTrib                ! number of tributary basins
+   integer(i4b)                                   :: nSeg                 ! number of reaches in the network
+   integer(i4b)                                   :: iSeg, jSeg           ! loop indices - reach
+   integer(i4b)                                   :: iTrib                ! loop indices - branch
+   integer(i4b)                                   :: ix                   ! loop indices stream order
+
+   ! initialize error control
+   ierr=0; message='kw_route/'
+
+   ! number of reach check
+   if (size(NETOPO_in)/=size(RCHFLX_out(iens,:))) then
+    ierr=20; message=trim(message)//'sizes of NETOPO and RCHFLX mismatch'; return
+   endif
+
+   nSeg = size(RCHFLX_out(iens,:))
+
+   allocate(doRoute(nSeg), stat=ierr)
+
+   if (present(ixSubRch))then
+    doRoute(:)=.false.
+    doRoute(ixSubRch) = .true. ! only subset of reaches are on
+   else
+    doRoute(:)=.true. ! every reach is on
+   endif
+
+   nOrder = size(river_basin)
+
+   ! route kinematic waves through the river network
+   do ix = 1, nOrder
+
+     nTrib=size(river_basin(ix)%branch)
+
+!$OMP PARALLEL DO schedule(dynamic,1)                   & ! chunk size of 1
+!$OMP          private(jSeg, iSeg)                      & ! private for a given thread
+!$OMP          private(ierr, cmessage)                  & ! private for a given thread
+!$OMP          shared(T0,T1)                            & ! private for a given thread
+!$OMP          shared(LAKEFLAG)                         & ! private for a given thread
+!$OMP          shared(river_basin)                      & ! data structure shared
+!$OMP          shared(doRoute)                          & ! data array shared
+!$OMP          shared(NETOPO_in)                        & ! data structure shared
+!$OMP          shared(RPARAM_in)                        & ! data structure shared
+!$OMP          shared(RCHSTA_out)                       & ! data structure shared
+!$OMP          shared(RCHFLX_out)                       & ! data structure shared
+!$OMP          shared(ix, iEns, ixDesire)               & ! indices shared
+!$OMP          firstprivate(nTrib)
+     trib:do iTrib = 1,nTrib
+       seg:do iSeg=1,river_basin(ix)%branch(iTrib)%nRch
+         jSeg  = river_basin(ix)%branch(iTrib)%segIndex(iSeg)
+         if (.not. doRoute(jSeg)) cycle
+         call kw_rch(iEns,jSeg,           & ! input: array indices
+                     ixDesire,            & ! input: index of the desired reach
+                     T0,T1,               & ! input: start and end of the time step
+                     LAKEFLAG,            & ! input: flag if lakes are to be processed
+                     NETOPO_in,           & ! input: reach topology data structure
+                     RPARAM_in,           & ! input: reach parameter data structure
+                     RCHSTA_out,          & ! inout: reach state data structure
+                     RCHFLX_out,          & ! inout: reach flux data structure
+                     ierr,cmessage)         ! output: error control
+         if(ierr/=0) call handle_err(ierr, trim(message)//trim(cmessage))
+       end do  seg
+     end do trib
+!$OMP END PARALLEL DO
+
+   end do
+
+ END SUBROUTINE kw_route
+
+ ! *********************************************************************
+ ! subroutine: perform one segment route KW routing
+ ! *********************************************************************
+ SUBROUTINE kw_rch(iEns, segIndex, & ! input: index of runoff ensemble to be processed
+                   ixDesire,       & ! input: reachID to be checked by on-screen pringing
+                   T0,T1,          & ! input: start and end of the time step
+                   LAKEFLAG,       & ! input: flag if lakes are to be processed
+                   NETOPO_in,      & ! input: reach topology data structure
+                   RPARAM_in,      & ! input: reach parameter data structure
+                   RCHSTA_out,     & ! inout: reach state data structure
+                   RCHFLX_out,     & ! inout: reach flux data structure
+                   ierr, message)    ! output: error control
+
+ implicit none
+
+ ! Input
+ integer(i4b),  intent(in)                 :: iEns              ! runoff ensemble to be routed
+ integer(i4b),  intent(in)                 :: segIndex          ! segment where routing is performed
+ integer(i4b),  intent(in)                 :: ixDesire          ! index of the reach for verbose output
+ real(dp),      intent(in)                 :: T0,T1             ! start and end of the time step (seconds)
+ integer(i4b),  intent(in)                 :: LAKEFLAG          ! >0 if processing lakes
+ type(RCHTOPO), intent(in),    allocatable :: NETOPO_in(:)      ! River Network topology
+ type(RCHPRP),  intent(in),    allocatable :: RPARAM_in(:)      ! River reach parameter
+ ! inout
+ type(STRSTA),  intent(inout), allocatable :: RCHSTA_out(:,:)   ! reach state data
+ type(STRFLX),  intent(inout), allocatable :: RCHFLX_out(:,:)   ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
+ ! Output
+ integer(i4b),  intent(out)                :: ierr              ! error code
+ character(*),  intent(out)                :: message           ! error message
+ ! Local variables to
+ logical(lgt)                              :: doCheck           ! check details of variables
+ logical(lgt)                              :: isHW              ! headwater basin?
+ integer(i4b)                              :: nUps              ! number of upstream segment
+ integer(i4b)                              :: iUps              ! upstream reach index
+ integer(i4b)                              :: iRch_ups          ! index of upstream reach in NETOPO
+ real(dp)                                  :: q_upstream        ! total discharge at top of the reach being processed
+ character(len=strLen)                     :: cmessage          ! error message from subroutine
+
+ ! initialize error control
+ ierr=0; message='kw_rch/'
+
+ doCheck = .false.
+ if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+   doCheck = .true.
+ end if
+
+ ! get discharge coming from upstream
+ nUps = size(NETOPO_in(segIndex)%UREACHI)
+ isHW = .true.
+ q_upstream = 0.0_dp
+ if (nUps>0) then
+   isHW = .false.
+   do iUps = 1,nUps
+     iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%REACH_Q
+   end do
+ endif
+
+ if(doCheck)then
+   write(iulog,'(A)') 'CHECK Euler Kinematic wave'
+   if (nUps>0) then
+     do iUps = 1,nUps
+       write(iulog,'(A,X,I6,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, NETOPO_in(segIndex)%UREACHK(iUps))%REACH_Q
+     enddo
+   end if
+   write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iEns,segIndex)%BASIN_QR(1)=',RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
+ endif
+
+ ! perform river network KW routing
+ call kinematic_wave(RPARAM_in(segIndex),         &    ! input: parameter at segIndex reach
+                     T0,T1,                       &    ! input: start and end of the time step
+                     q_upstream,                  &    ! input: total discharge at top of the reach being processed
+                     isHW,                        &    ! input: is this headwater basin?
+                     RCHSTA_out(iens,segIndex),   &    ! inout:
+                     RCHFLX_out(iens,segIndex),   &    ! inout: updated fluxes at reach
+                     doCheck,                     &    ! input: reach index to be examined
+                     ierr, message)                    ! output: error control
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ if(doCheck)then
+  write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%REACH_Q
+ endif
+
+ END SUBROUTINE kw_rch
+
+
+ ! *********************************************************************
+ ! subroutine: route kinematic waves at one segment
+ ! *********************************************************************
+ SUBROUTINE kinematic_wave(rch_param,     & ! input: river parameter data structure
+                           T0,T1,         & ! input: start and end of the time step
+                           q_upstream,    & ! input: discharge from upstream
+                           isHW,          & ! input: is this headwater basin?
+                           rstate,        & ! inout: reach state at a reach
+                           rflux,         & ! inout: reach flux at a reach
+                           doCheck,       & ! input: reach index to be examined
+                           ierr,message)
+ ! ----------------------------------------------------------------------------------------
+ ! Kinematic wave equation is solved based on conservative form the equation
+ !
+ ! Method: Li, R.‐M., Simons, D. B., and Stevens, M. A. (1975), Nonlinear kinematic wave approximation for water routing,
+ !         Water Resour. Res., 11( 2), 245– 252, doi:10.1029/WR011i002p00245
+ !
+ ! * Use analytical solution (eq 29 in paper) for Q using the 2nd order Talor series of nonlinear kinematic equation: theta*Q + alpha*Q^beta = omega
+ ! * Use initial guess using explicit Euler solution of kinematic approximation equation to start iterative computation of Q
+ ! * iterative Q computation till LHS ~= RHS
+ !
+ ! state array:
+ ! (time:0:1, loc:0:1) 0-previous time step/inlet, 1-current time step/outlet.
+ ! Q or A(1,2,3,4): 1: (t=0,x=0), 2: (t=0,x=1), 3: (t=1,x=0), 4: (t=1,x=1)
+
+ IMPLICIT NONE
+ ! Input
+ type(RCHPRP), intent(in)                 :: rch_param    ! River reach parameter
+ real(dp),     intent(in)                 :: T0,T1        ! start and end of the time step (seconds)
+ real(dp),     intent(in)                 :: q_upstream   ! total discharge at top of the reach being processed
+ logical(lgt), intent(in)                 :: isHW         ! is this headwater basin?
+ logical(lgt), intent(in)                 :: doCheck      ! reach index to be examined
+ ! Input/Output
+ type(STRSTA), intent(inout)              :: rstate       ! curent reach states
+ type(STRFLX), intent(inout)              :: rflux        ! current Reach fluxes
+ ! Output
+ integer(i4b), intent(out)                :: ierr         ! error code
+ character(*), intent(out)                :: message      ! error message
+ ! LOCAL VAIRABLES
+ real(dp)                                 :: alpha        ! sqrt(slope)(/mannings N* width)
+ real(dp)                                 :: beta         ! constant, 5/3
+ real(dp)                                 :: alpha1       ! sqrt(slope)(/mannings N* width)
+ real(dp)                                 :: beta1        ! constant, 5/3
+ real(dp)                                 :: theta        ! dT/dX
+ real(dp)                                 :: omega        ! right-hand side of kw finite difference
+ real(dp)                                 :: f0,f1,f2     ! values of function f, 1st and 2nd derivatives at solution
+ real(dp)                                 :: X            !
+ real(dp)                                 :: dT           ! interval of time step [sec]
+ real(dp)                                 :: dX           ! length of segment [m]
+ real(dp)                                 :: Q(0:1,0:1)   !
+ real(dp)                                 :: Qtrial(2)    ! trial solution of kw equation
+ real(dp)                                 :: Abar         !
+ real(dp)                                 :: Qbar         !
+ real(dp)                                 :: absErr(2)    ! absolute error of nonliear equation solution
+ real(dp)                                 :: f0eval(2)    !
+ integer(i4b)                             :: imin         ! index at minimum value
+ integer(i4b)                             :: ix           ! loop index
+ character(len=strLen)                    :: cmessage     ! error message from subroutine
+
+ ierr=0; message='kinematic_wave/'
+
+ !  current time and inlet  3 (1,0) -> previous time and inlet  1 (0,0)
+ !  current time and outlet 4 (1,1) -> previous time and outlet 2 (0,1)
+ Q(0,0) = rstate%molecule%Q(1)
+ Q(0,1) = rstate%molecule%Q(2)
+
+ if (.not. isHW) then
+
+   Q(1,1) = realMissing
+
+   ! Get the reach parameters
+   ! A = (Q/alpha)**(1/beta)
+   ! Q = alpha*A**beta
+   alpha = sqrt(rch_param%R_SLOPE)/(rch_param%R_MAN_N*rch_param%R_WIDTH**(2._dp/3._dp))
+   beta  = 5._dp/3._dp
+   beta1  = 1._dp/beta
+   alpha1 = (1.0/alpha)**beta1
+   dX = rch_param%RLENGTH
+   dT = T1-T0
+   theta = dT/dX
+
+   ! compute total flow rate and flow area at upstream end at current time step
+   Q(1,0) = q_upstream
+
+   if (doCheck) then
+     write(iulog,'(3(A,X,G12.5))') ' R_SLOPE=',rch_param%R_SLOPE,' R_WIDTH=',rch_param%R_WIDTH,' R_MANN=',rch_param%R_MAN_N
+     write(iulog,'(3(A,X,G12.5))') ' Q(0,0)=',Q(0,0),' Q(0,1)=',Q(0,1),' Q(1,0)=',Q(1,0)
+   end if
+
+   ! ----------
+   ! solve flow rate and flow area at downstream end at current time step
+   ! ----------
+   ! initial guess
+   Qbar   = (Q(0,1) + Q(1,0))/2._dp
+   Q(1,1) = (theta*Q(1,0) + alpha1*beta1*Qbar**(beta1-1)*Q(0,1))/(theta + alpha1*beta1*Qbar**(beta1-1))
+
+   omega = theta*Q(1,0)+alpha1*Q(0,1)**(beta1)
+
+   f0eval(1) = theta*Q(1,1) + alpha1*Q(1,1)**beta1
+   absErr(1) = abs(f0eval(1)-omega)
+
+   if ( abs(Q(1,1)-0.0_dp) < epsilon(Q(1,1))) then
+     Q(1,1) = omega/(theta+alpha1)
+   else if (absErr(1) > critFactor*omega) then
+     ! iterative solution
+     do
+       f0 = theta*Q(1,1) + alpha1*Q(1,1)**beta1
+       f1 = theta + alpha1*beta1*Q(1,1)**(beta1-1)     ! 1st derivative of f w.r.t. Q
+       f2 = alpha1*beta1*(beta1-1)*Q(1,1)**(beta1-2)   ! 2nd derivative of f w.r.t. Q
+
+       X = (f1/f2)**2._dp - 2._dp*(f0-omega)/f2
+       if (X<0) X=0._dp
+
+       ! two solutions
+       Qtrial(1) = abs(Q(1,1) - f1/f2 + sqrt(X))
+       Qtrial(2) = abs(Q(1,1) - f1/f2 - sqrt(X))
+
+       f0eval = theta*Qtrial + alpha1*Qtrial**beta1
+       absErr = abs(f0eval-omega)
+       imin   = minloc(absErr,DIM=1)
+       Q(1,1) = Qtrial(imin)
+
+       if (absErr(imin) < critFactor*omega) exit
+     end do
+   endif
+
+   if (doCheck) then
+     write(iulog,'(1(A,X,G12.5))') ' Q(1,1)=',Q(1,1)
+   end if
+
+ else ! if head-water
+
+   Q(1,0) = 0._dp
+   Q(1,1) = 0._dp
+
+   if (doCheck) then
+     write(iulog,'(A)')            ' This is headwater '
+     write(iulog,'(1(A,X,G12.5))') ' Q(1,1)=',Q(1,1)
+   endif
+
+ endif
+
+ ! compute volume
+ rflux%REACH_VOL(0) = rflux%REACH_VOL(1)
+ rflux%REACH_VOL(1) = rflux%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dT
+ rflux%REACH_VOL(1) = max(rflux%REACH_VOL(1), 0._dp)
+
+ ! add catchment flow
+ rflux%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)
+
+ ! update state
+ do ix = 0,1
+   rstate%molecule%Q(1) = Q(1,0)
+   rstate%molecule%Q(2) = Q(1,1)
+ end do
+
+ END SUBROUTINE kinematic_wave
+
+
+END MODULE kw_route_module

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -173,6 +173,8 @@ contains
    case('<sumUpstreamRunoff>');    read(cData,*,iostat=io_error) meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile
    case('<KWTroutedRunoff>');      read(cData,*,iostat=io_error) meta_rflx(ixRFLX%KWTroutedRunoff  )%varFile
    case('<IRFroutedRunoff>');      read(cData,*,iostat=io_error) meta_rflx(ixRFLX%IRFroutedRunoff  )%varFile
+   case('<KWroutedRunoff>');       read(cData,*,iostat=io_error) meta_rflx(ixRFLX%KWroutedRunoff   )%varFile
+   case('<DWroutedRunoff>');       read(cData,*,iostat=io_error) meta_rflx(ixRFLX%DWroutedRunoff   )%varFile
    case('<MCroutedRunoff>');       read(cData,*,iostat=io_error) meta_rflx(ixRFLX%MCroutedRunoff   )%varFile
 
    ! VARIABLE NAMES for data (overwrite default name in popMeta.f90)

--- a/route/build/src/write_restart.f90
+++ b/route/build/src/write_restart.f90
@@ -294,6 +294,11 @@ CONTAINS
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
 
+ if (opt==kinematicWave) then
+   call define_KW_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
  if (opt==muskingumCunge) then
    call define_MC_state(ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -356,7 +361,7 @@ CONTAINS
    ! local
    integer(i4b)                      :: iVar,ixDim    ! index loop for variables
    integer(i4b)                      :: nDims         ! number of dimensions
-   character(len=strLen),allocatable :: dim_basinQ(:) ! dimensions combination
+   character(len=strLen),allocatable :: dim_set(:)    ! dimensions combination
 
    ! initialize error control
    ierr=0; message1='define_basinQ_state/'
@@ -366,14 +371,14 @@ CONTAINS
 
    do iVar=1,nVarsBasinQ
      nDims = size(meta_basinQ(iVar)%varDim)
-     if (allocated(dim_basinQ)) deallocate(dim_basinQ)
-     allocate(dim_basinQ(nDims))
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
 
      do ixDim = 1, nDims
-       dim_basinQ(ixDim) = meta_stateDims(meta_basinQ(iVar)%varDim(ixDim))%dimName
+       dim_set(ixDim) = meta_stateDims(meta_basinQ(iVar)%varDim(ixDim))%dimName
      end do
 
-     call def_var(ncid, meta_basinQ(iVar)%varName, dim_basinQ, meta_basinQ(iVar)%varType, ierr, cmessage, vdesc=meta_basinQ(iVar)%varDesc, vunit=meta_basinQ(iVar)%varUnit )
+     call def_var(ncid, meta_basinQ(iVar)%varName, dim_set, meta_basinQ(iVar)%varType, ierr, cmessage, vdesc=meta_basinQ(iVar)%varDesc, vunit=meta_basinQ(iVar)%varUnit )
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
   end associate
@@ -394,7 +399,7 @@ CONTAINS
    ! local
    integer(i4b)                      :: iVar,ixDim    ! index loop for variables
    integer(i4b)                      :: nDims         ! number of dimensions
-   character(len=strLen),allocatable :: dim_IRFbas(:) ! dimensions combination case 4
+   character(len=strLen),allocatable :: dim_set(:)    ! dimensions combination case 4
 
    ierr=0; message1='define_IRFbas_state/'
 
@@ -413,14 +418,14 @@ CONTAINS
 
    do iVar=1,nVarsIRFbas
      nDims = size(meta_irf_bas(iVar)%varDim)
-     if (allocated(dim_IRFbas)) deallocate(dim_IRFbas)
-     allocate(dim_IRFbas(nDims))
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
 
      do ixDim = 1, nDims
-       dim_IRFbas(ixDim) = meta_stateDims(meta_irf_bas(iVar)%varDim(ixDim))%dimName
+       dim_set(ixDim) = meta_stateDims(meta_irf_bas(iVar)%varDim(ixDim))%dimName
      end do
 
-     call def_var(ncid, meta_irf_bas(iVar)%varName, dim_IRFbas, meta_irf_bas(iVar)%varType, ierr, cmessage, vdesc=meta_irf_bas(iVar)%varDesc, vunit=meta_irf_bas(iVar)%varUnit )
+     call def_var(ncid, meta_irf_bas(iVar)%varName, dim_set, meta_irf_bas(iVar)%varType, ierr, cmessage, vdesc=meta_irf_bas(iVar)%varDesc, vunit=meta_irf_bas(iVar)%varUnit )
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
   end associate
@@ -441,7 +446,7 @@ CONTAINS
    ! local
    integer(i4b)                      :: iVar,ixDim  ! index loop for variables
    integer(i4b)                      :: nDims       ! number of dimensions
-   character(len=strLen),allocatable :: dim_kwt(:)  ! dimensions combination case 4
+   character(len=strLen),allocatable :: dim_set(:)  ! dimensions combination case 4
 
    ierr=0; message1='define_KWT_state/'
 
@@ -464,14 +469,14 @@ CONTAINS
 
    do iVar=1,nVarsKWT
      nDims = size(meta_kwt(iVar)%varDim)
-     if (allocated(dim_kwt)) deallocate(dim_kwt)
-     allocate(dim_kwt(nDims))
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
 
      do ixDim = 1, nDims
-       dim_kwt(ixDim) = meta_stateDims(meta_kwt(iVar)%varDim(ixDim))%dimName
+       dim_set(ixDim) = meta_stateDims(meta_kwt(iVar)%varDim(ixDim))%dimName
      end do
 
-     call def_var(ncid, meta_kwt(iVar)%varName, dim_kwt, meta_kwt(iVar)%varType, ierr, cmessage, vdesc=meta_kwt(iVar)%varDesc, vunit=meta_kwt(iVar)%varUnit)
+     call def_var(ncid, meta_kwt(iVar)%varName, dim_set, meta_kwt(iVar)%varType, ierr, cmessage, vdesc=meta_kwt(iVar)%varDesc, vunit=meta_kwt(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
 
@@ -493,7 +498,7 @@ CONTAINS
    ! local
    integer(i4b)                      :: iVar,ixDim  ! index loop for variables
    integer(i4b)                      :: nDims       ! number of dimensions
-   character(len=strLen),allocatable :: dim_irf(:)  ! dimensions combination case 4
+   character(len=strLen),allocatable :: dim_set(:)  ! dimensions combination case 4
 
    ierr=0; message1='define_IRF_state/'
 
@@ -516,20 +521,70 @@ CONTAINS
 
    do iVar=1,nVarsIRF
      nDims = size(meta_irf(iVar)%varDim)
-     if (allocated(dim_irf)) deallocate(dim_irf)
-     allocate(dim_irf(nDims))
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
 
      do ixDim = 1, nDims
-       dim_irf(ixDim) = meta_stateDims(meta_irf(iVar)%varDim(ixDim))%dimName
+       dim_set(ixDim) = meta_stateDims(meta_irf(iVar)%varDim(ixDim))%dimName
      end do
 
-     call def_var(ncid, meta_irf(iVar)%varName, dim_irf, meta_irf(iVar)%varType, ierr, cmessage, vdesc=meta_irf(iVar)%varDesc, vunit=meta_irf(iVar)%varUnit)
+     call def_var(ncid, meta_irf(iVar)%varName, dim_set, meta_irf(iVar)%varType, ierr, cmessage, vdesc=meta_irf(iVar)%varDesc, vunit=meta_irf(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
 
    end associate
 
   END SUBROUTINE define_IRF_state
+
+
+  SUBROUTINE define_KW_state(ierr, message1)
+
+   USE globalData, ONLY: meta_kw
+   USE var_lookup, ONLY: ixKW, nVarsKW
+
+   implicit none
+
+   ! output
+   integer(i4b), intent(out)         :: ierr        ! error code
+   character(*), intent(out)         :: message1    ! error message
+   ! local
+   integer(i4b)                      :: iVar,ixDim  ! index loop for variables
+   integer(i4b)                      :: nDims       ! number of dimensions
+   character(len=strLen),allocatable :: dim_set(:)  ! dimensions combination
+
+   ierr=0; message1='define_KW_state/'
+
+   associate(dim_seg  => meta_stateDims(ixStateDims%seg)%dimName,     &
+             dim_ens  => meta_stateDims(ixStateDims%ens)%dimName,     &
+             dim_mesh => meta_stateDims(ixStateDims%fdmesh)%dimName)
+
+   ! Check dimension length is populated
+   if (meta_stateDims(ixStateDims%fdmesh)%dimLength == integerMissing) then
+     call set_dim_len(ixStateDims%fdmesh, ierr, cmessage)
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage)//' for '//trim(meta_stateDims(ixStateDims%fdmesh)%dimName); return; endif
+   end if
+
+   ! Define dimension needed for this routing specific state variables
+   call def_dim(ncid, meta_stateDims(ixStateDims%fdmesh)%dimName, meta_stateDims(ixStateDims%fdmesh)%dimLength, meta_stateDims(ixStateDims%fdmesh)%dimId, ierr, cmessage)
+   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+
+   do iVar=1,nVarsKW
+     nDims = size(meta_kw(iVar)%varDim)
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
+
+     do ixDim = 1, nDims
+       dim_set(ixDim) = meta_stateDims(meta_kw(iVar)%varDim(ixDim))%dimName
+     end do
+
+     call def_var(ncid, meta_kw(iVar)%varName, dim_set, meta_kw(iVar)%varType, ierr, cmessage, vdesc=meta_kw(iVar)%varDesc, vunit=meta_kw(iVar)%varUnit)
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+   end do
+
+   end associate
+
+  END SUBROUTINE define_KW_state
+
 
   SUBROUTINE define_MC_state(ierr, message1)
 
@@ -544,7 +599,7 @@ CONTAINS
    ! local
    integer(i4b)                      :: iVar,ixDim  ! index loop for variables
    integer(i4b)                      :: nDims       ! number of dimensions
-   character(len=strLen),allocatable :: dim_mc(:)   ! dimensions combination case 4
+   character(len=strLen),allocatable :: dim_set(:)   ! dimensions combination case 4
 
    ierr=0; message1='define_MC_state/'
 
@@ -564,14 +619,14 @@ CONTAINS
 
    do iVar=1,nVarsMC
      nDims = size(meta_mc(iVar)%varDim)
-     if (allocated(dim_mc)) deallocate(dim_mc)
-     allocate(dim_mc(nDims))
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
 
      do ixDim = 1, nDims
-       dim_mc(ixDim) = meta_stateDims(meta_mc(iVar)%varDim(ixDim))%dimName
+       dim_set(ixDim) = meta_stateDims(meta_mc(iVar)%varDim(ixDim))%dimName
      end do
 
-     call def_var(ncid, meta_mc(iVar)%varName, dim_mc, meta_mc(iVar)%varType, ierr, cmessage, vdesc=meta_mc(iVar)%varDesc, vunit=meta_mc(iVar)%varUnit)
+     call def_var(ncid, meta_mc(iVar)%varName, dim_set, meta_mc(iVar)%varType, ierr, cmessage, vdesc=meta_mc(iVar)%varDesc, vunit=meta_mc(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
 
@@ -643,6 +698,11 @@ CONTAINS
 
  if (opt==allRoutingMethods .or. opt==kinematicWaveTracking)then
    call write_KWT_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
+ if (opt==kinematicWave)then
+   call write_KW_state(ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
 
@@ -934,6 +994,67 @@ CONTAINS
   end associate
 
   END SUBROUTINE write_IRF_state
+
+  ! KW writing procedures
+  SUBROUTINE write_KW_state(ierr, message1)
+
+    USE globalData,   ONLY: meta_kw
+    USE var_lookup,   ONLY: ixKW, nVarsKW
+
+    implicit none
+
+    ! output
+    integer(i4b), intent(out)  :: ierr            ! error code
+    character(*), intent(out)  :: message1        ! error message
+    ! local variables
+    type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
+    integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
+
+    ierr=0; message1='write_KW_state/'
+
+    associate(nSeg  => size(RCHFLX),                         &
+              nEns  => meta_stateDims(ixStateDims%ens)%dimLength,  &
+              nMesh => meta_stateDims(ixStateDims%fdmesh)%dimLength) ! number of computing molecule used for finite difference
+
+    allocate(state%var(nVarsKW), stat=ierr, errmsg=cmessage)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+
+    do iVar=1,nVarsKW
+      select case(iVar)
+       case(ixKW%qsub)
+        allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nEns), stat=ierr)
+       case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KW routing state '//trim(meta_kw(iVar)%varName); return; endif
+    end do
+
+    ! --Convert data structures to arrays
+    do iens=1,nEns
+      do iSeg=1,nSeg
+        do iVar=1,nVarsKW
+          select case(iVar)
+            case(ixKW%qsub)
+              state%var(iVar)%array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA(iens, iSeg)%molecule%Q(1:nMesh)
+            case default; ierr=20; message1=trim(message1)//'unable to identify KW routing state variable index'; return
+          end select
+        enddo ! variable loop
+      enddo ! seg loop
+    enddo ! ensemble loop
+
+    ! Writing netCDF
+    do iVar=1,nVarsKW
+      select case(iVar)
+       case(ixKW%qsub)
+         call write_nc(ncid, trim(meta_kw(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMesh,nens/), ierr, cmessage)
+       case default; ierr=20; message1=trim(message1)//'unable to identify KW variable index for nc writing'; return
+      end select
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+
+    end do
+
+    end associate
+
+  END SUBROUTINE write_KW_state
 
   ! MC writing procedures
   SUBROUTINE write_MC_state(ierr, message1)

--- a/route/build/src/write_simoutput.f90
+++ b/route/build/src/write_simoutput.f90
@@ -102,6 +102,11 @@ CONTAINS
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
+  if (meta_rflx(ixRFLX%KWroutedRunoff)%varFile) then
+   call write_nc(simout_nc%ncid, 'KWroutedRunoff', RCHFLX(iens,:)%REACH_Q, (/1,jTime/), (/nRch,1/), ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  endif
+
   if (meta_rflx(ixRFLX%MCroutedRunoff)%varFile) then
    call write_nc(simout_nc%ncid, 'MCroutedRunoff', RCHFLX(iens,:)%REACH_Q, (/1,jTime/), (/nRch,1/), ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -246,13 +251,13 @@ CONTAINS
 
  ! Make sure to turn off write option for routines not used
  ! Routing options
- ! ----- this (allRoutingMethods) is to be removed
+ ! ----- beg: this (allRoutingMethods) is to be removed
  if (routOpt==allRoutingMethods) then
     meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.
     meta_rflx(ixRFLX%KWroutedRunoff)%varFile = .false.
     meta_rflx(ixRFLX%DWroutedRunoff)%varFile = .false.
  end if
- ! ----- this (allRoutingMethods) is to be removed
+ ! ----- end: this (allRoutingMethods) is to be removed
  if (routOpt/=kinematicWaveTracking) meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
  if (routOpt/=impulseResponseFunc) meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
  if (routOpt/=muskingumCunge) meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.


### PR DESCRIPTION
1. added per-reach kw routine routine (kw_route.f90)
2. restart I/O
3. activated kw routing option

routOpt=3 to activate kinematic wave method (this deactivates the other routing methods).

Checked the followings:

[x ] Compilation with gnu
[x ] Compilation with intel
[x ] Tested functionality with MERIT-Hydro global network with CLM5.0 runoff for year 1980 at daily step
[x ] restart test with above setup.
[x ] Tested with HDMA global network with CLM5.0 runoff for year 1980 at daily step.
[x ] restart test with above setup.

Restart test:
run one year with monthly outputs for both history and restart files (restart is dropped 1st day of the month) for 12 months.
run again, starting at August 1st with August 1st restart file.
compare history files from 1 and 2 for history files (August through December)

Detailed science evaluation (inc. numerical stability) is still needed
