### PR TITLE
update on output option control

### DIFF
--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -161,11 +161,11 @@ contains
  call meta_rflx(ixRFLX%instRunoff       )%init('instRunoff'       , 'instantaneous runoff in each reach'                , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%dlayRunoff       )%init('dlayRunoff'       , 'delayed runoff in each reach'                      , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%sumUpstreamRunoff)%init('sumUpstreamRunoff', 'sum of upstream runoff in each reach'              , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
- call meta_rflx(ixRFLX%KWTroutedRunoff  )%init('KWTroutedRunoff'  , 'routed runoff in reach - lagrangian kinematic wave', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
- call meta_rflx(ixRFLX%MCroutedRunoff   )%init('MCroutedRunoff'   , 'routed runoff in reach - muskingum-cunge'          , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
- call meta_rflx(ixRFLX%DWroutedRunoff   )%init('DWroutedRunoff'   , 'routed runoff in reach - diffusive wave'           , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
- call meta_rflx(ixRFLX%KWroutedRunoff   )%init('KWroutedRunoff'   , 'routed runoff in reach - lagrangian kinematic wave', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
- call meta_rflx(ixRFLX%IRFroutedRunoff  )%init('IRFroutedRunoff'  , 'routed runoff in reach - Impulse Response Function', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .false.)
+ call meta_rflx(ixRFLX%KWTroutedRunoff  )%init('KWTroutedRunoff'  , 'routed runoff in reach - lagrangian kinematic wave', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%MCroutedRunoff   )%init('MCroutedRunoff'   , 'routed runoff in reach - muskingum-cunge'          , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%DWroutedRunoff   )%init('DWroutedRunoff'   , 'routed runoff in reach - diffusive wave'           , 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%KWroutedRunoff   )%init('KWroutedRunoff'   , 'routed runoff in reach - lagrangian kinematic wave', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%IRFroutedRunoff  )%init('IRFroutedRunoff'  , 'routed runoff in reach - Impulse Response Function', 'm3/s', nf90_float, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%volume           )%init('volume'           , 'lake and stream volume'                            , 'm3'  , nf90_float, [ixQdims%seg,ixQdims%time], .false.)
 
  ! Lagrangian kinematic Wave restart state

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -295,6 +295,33 @@ contains
    err=81; return
  end select
 
+ ! ---------- output options --------------------------------------------------------------------------------------------
+ ! Make sure to turn off write option for routines not used
+ ! Routing options
+ if (routOpt==allRoutingMethods) then
+    meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = (.true. .and. meta_rflx(ixRFLX%KWTroutedRunoff)%varFile)
+    meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = (.true. .and. meta_rflx(ixRFLX%IRFroutedRunoff)%varFile)
+    meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.
+    meta_rflx(ixRFLX%KWroutedRunoff)%varFile = .false.
+    meta_rflx(ixRFLX%DWroutedRunoff)%varFile = .false.
+ else
+ ! ----- end: this (allRoutingMethods) is to be removed
+ if (routOpt/=kinematicWaveTracking) meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
+ if (routOpt/=impulseResponseFunc) meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
+ if (routOpt/=muskingumCunge) meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.
+ if (routOpt/=kinematicWave) meta_rflx(ixRFLX%KWroutedRunoff)%varFile = .false.
+ if (routOpt/=diffusiveWave) meta_rflx(ixRFLX%DWroutedRunoff)%varFile = .false.
+ endif
+
+ ! runoff accumulation option
+ if (doesAccumRunoff==0) then
+   meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile = .false.
+ endif
+ ! basin runoff routing option
+ if (doesBasinRoute==0) then
+   meta_rflx(ixRFLX%instRunoff)%varFile = .false.
+ endif
+
  end subroutine read_control
 
 end module read_control_module

--- a/route/build/src/write_simoutput.f90
+++ b/route/build/src/write_simoutput.f90
@@ -5,15 +5,6 @@ USE nrtype
 USE var_lookup,only: ixRFLX, nVarsRFLX
 USE public_var,only: iulog
 USE public_var,only: integerMissing
-USE public_var,only: routOpt                ! routing scheme options  0-> both, 1->IRF, 2->KWT, otherwise error
-USE public_var,only: doesBasinRoute         ! basin routing options   0-> no, 1->IRF, otherwise error
-USE public_var,only: doesAccumRunoff        ! option to delayed runoff accumulation over all the upstream reaches. 0->no, 1->yes
-USE public_var,only: kinematicWaveTracking  ! Lagrangian kinematic wave
-USE public_var,only: kinematicWave          ! kinematic wave
-USE public_var,only: diffusiveWave          ! diffusive wave
-USE public_var,only: muskingumCunge         ! muskingum cunge
-USE public_var,only: impulseResponseFunc    ! impulse response function
-USE public_var,only: allRoutingMethods      ! all routing methods
 USE globalData,only: meta_rflx
 USE globalData,only: simout_nc
 USE io_netcdf, only: ncd_int
@@ -253,30 +244,6 @@ CONTAINS
  meta_qDims(ixQdims%seg)%dimLength = nRch_in
  meta_qDims(ixQdims%hru)%dimLength = nHRU_in
  meta_qDims(ixQdims%ens)%dimLength = nEns_in
-
- ! Make sure to turn off write option for routines not used
- ! Routing options
- ! ----- beg: this (allRoutingMethods) is to be removed
- if (routOpt==allRoutingMethods) then
-    meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.
-    meta_rflx(ixRFLX%KWroutedRunoff)%varFile = .false.
-    meta_rflx(ixRFLX%DWroutedRunoff)%varFile = .false.
- end if
- ! ----- end: this (allRoutingMethods) is to be removed
- if (routOpt/=kinematicWaveTracking) meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
- if (routOpt/=impulseResponseFunc) meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
- if (routOpt/=muskingumCunge) meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.
- if (routOpt/=kinematicWave) meta_rflx(ixRFLX%KWroutedRunoff)%varFile = .false.
- if (routOpt/=diffusiveWave) meta_rflx(ixRFLX%DWroutedRunoff)%varFile = .false.
-
- ! runoff accumulation option
- if (doesAccumRunoff==0) then
-   meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile = .false.
- endif
- ! basin runoff routing option
- if (doesBasinRoute==0) then
-   meta_rflx(ixRFLX%instRunoff)%varFile = .false.
- endif
 
  ! --------------------
  ! define file


### PR DESCRIPTION
Make sure that the output option for the routed flow works as specified in the control file. The code turns off the output option for the methods not used.

routOpt =0 -> routing using IRF and KWT (to be removed). 
routOpt =1 -> routing using IRF.  
routOpt =2 -> routing using KWT.
routOpt =3 -> routing using KW.
routOpt =4 -> routing using MC.
routOpt =5 -> routing using DW