### PR TITLE
Adding muskingum-cunge and diffusive wave routing methods

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -183,6 +183,8 @@ CORE = \
     irf_route.f90 \
     kwt_route.f90 \
     kwe_route.f90 \
+    mc_route.f90 \
+    dfw_route.f90 \
     main_route.f90 \
     mpi_process.f90 \
     init_model_data.f90 \

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -294,11 +294,12 @@ implicit none
   type(FPOINT),allocatable             :: KWAVE(:)
  END TYPE LKWRCH
 
- ! ---------- Eulerian kinematic wave ---------------------------------
- type, public :: EKWRCH
-   real(dp)    :: Q(1:4)          ! Discharge at upstream and downstream of reach at current and previous time step(m3/s)
-   real(dp)    :: A(1:4)          ! Flow area at upstream and downstream of reach at current and previous time step(m3/s)
- end type EKWRCH
+ ! ---------- computational node kw, dw, and mc ---------------------------------
+ type, public :: SUBRCH
+   real(dp), allocatable  :: Q(:)        ! Discharge at sub-reaches at current step (m3/s)
+   real(dp), allocatable  :: A(:)        ! Flow area at sub-reach at current step (m2)
+   real(dp), allocatable  :: H(:)        ! Flow height at sub-reach at current step (m)
+ end type SUBRCH
 
  ! ---------- irf states (future flow series ) ---------------------------------
  ! Future flow series
@@ -309,7 +310,7 @@ implicit none
  type, public :: STRSTA
   type(IRFRCH)       :: IRF_ROUTE
   type(LKWRCH)       :: LKW_ROUTE
-  type(EKWRCH)       :: EKW_ROUTE
+  type(SUBRCH)       :: molecule
  end type STRSTA
 
 

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -1,0 +1,510 @@
+MODULE dfw_route_module
+
+USE nrtype
+! data types
+USE dataTypes,   ONLY: STRFLX            ! fluxes in each reach
+USE dataTypes,   ONLY: STRSTA            ! state in each reach
+USE dataTypes,   ONLY: RCHTOPO           ! Network topology
+USE dataTypes,   ONLY: RCHPRP            ! Reach parameter
+USE dataTypes,   ONLY: subbasin_omp      ! mainstem+tributary data strucuture
+! global data
+USE public_var,  ONLY: iulog             ! i/o logical unit number
+USE public_var,  ONLY: realMissing       ! missing value for real number
+USE public_var,  ONLY: integerMissing    ! missing value for integer number
+! subroutines: general
+USE perf_mod,    ONLY: t_startf,t_stopf   ! timing start/stop
+USE model_utils, ONLY: handle_err
+
+! privary
+implicit none
+private
+
+public::dfw_route
+
+CONTAINS
+
+ ! *********************************************************************
+ ! subroutine: perform diffusive wave routing through the river network
+ ! *********************************************************************
+ SUBROUTINE dfw_route(iens,                 & ! input: ensemble index
+                      river_basin,          & ! input: river basin information (mainstem, tributary outlet etc.)
+                      T0,T1,                & ! input: start and end of the time step
+                      ixDesire,             & ! input: reachID to be checked by on-screen pringing
+                      NETOPO_in,            & ! input: reach topology data structure
+                      RPARAM_in,            & ! input: reach parameter data structure
+                      RCHSTA_out,           & ! inout: reach state data structure
+                      RCHFLX_out,           & ! inout: reach flux data structure
+                      ierr,message,         & ! output: error control
+                      ixSubRch)               ! optional input: subset of reach indices to be processed
+
+   implicit none
+   ! Input
+   integer(i4b),       intent(in)                 :: iEns                 ! ensemble member
+   type(subbasin_omp), intent(in),    allocatable :: river_basin(:)       ! river basin information (mainstem, tributary outlet etc.)
+   real(dp),           intent(in)                 :: T0,T1                ! start and end of the time step (seconds)
+   integer(i4b),       intent(in)                 :: ixDesire             ! index of the reach for verbose output
+   type(RCHTOPO),      intent(in),    allocatable :: NETOPO_in(:)         ! River Network topology
+   type(RCHPRP),       intent(in),    allocatable :: RPARAM_in(:)         ! River reach parameter
+   ! inout
+   type(STRSTA),       intent(inout), allocatable :: RCHSTA_out(:,:)      ! reach state data
+   type(STRFLX),       intent(inout), allocatable :: RCHFLX_out(:,:)      ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
+   ! output variables
+   integer(i4b),       intent(out)                :: ierr                 ! error code
+   character(*),       intent(out)                :: message              ! error message
+   ! input (optional)
+   integer(i4b),       intent(in), optional       :: ixSubRch(:)          ! subset of reach indices to be processed
+   ! local variables
+   character(len=strLen)                          :: cmessage             ! error message for downwind routine
+   logical(lgt),                      allocatable :: doRoute(:)           ! logical to indicate which reaches are processed
+   integer(i4b)                                   :: LAKEFLAG=0           ! >0 if processing lakes
+   integer(i4b)                                   :: nOrder               ! number of stream order
+   integer(i4b)                                   :: nTrib                ! number of tributary basins
+   integer(i4b)                                   :: nSeg                 ! number of reaches in the network
+   integer(i4b)                                   :: iSeg, jSeg           ! loop indices - reach
+   integer(i4b)                                   :: iTrib                ! loop indices - branch
+   integer(i4b)                                   :: ix                   ! loop indices stream order
+
+   ! initialize error control
+   ierr=0; message='dfw_route/'
+
+   ! number of reach check
+   if (size(NETOPO_in)/=size(RCHFLX_out(iens,:))) then
+    ierr=20; message=trim(message)//'sizes of NETOPO and RCHFLX mismatch'; return
+   endif
+
+   nSeg = size(RCHFLX_out(iens,:))
+
+   allocate(doRoute(nSeg), stat=ierr)
+
+   if (present(ixSubRch))then
+    doRoute(:)=.false.
+    doRoute(ixSubRch) = .true. ! only subset of reaches are on
+   else
+    doRoute(:)=.true. ! every reach is on
+   endif
+
+   nOrder = size(river_basin)
+
+   call t_startf('route/dfw')
+
+   do ix = 1, nOrder
+
+     nTrib=size(river_basin(ix)%branch)
+
+!$OMP PARALLEL DO schedule(dynamic,1)                   & ! chunk size of 1
+!$OMP          private(jSeg, iSeg)                      & ! private for a given thread
+!$OMP          private(ierr, cmessage)                  & ! private for a given thread
+!$OMP          shared(T0,T1)                            & ! private for a given thread
+!$OMP          shared(LAKEFLAG)                         & ! private for a given thread
+!$OMP          shared(river_basin)                      & ! data structure shared
+!$OMP          shared(doRoute)                          & ! data array shared
+!$OMP          shared(NETOPO_in)                        & ! data structure shared
+!$OMP          shared(RPARAM_in)                        & ! data structure shared
+!$OMP          shared(RCHSTA_out)                       & ! data structure shared
+!$OMP          shared(RCHFLX_out)                       & ! data structure shared
+!$OMP          shared(ix, iEns, ixDesire)               & ! indices shared
+!$OMP          firstprivate(nTrib)
+     trib:do iTrib = 1,nTrib
+       seg:do iSeg=1,river_basin(ix)%branch(iTrib)%nRch
+         jSeg  = river_basin(ix)%branch(iTrib)%segIndex(iSeg)
+         if (.not. doRoute(jSeg)) cycle
+         call dfw_rch(iEns,jSeg,           & ! input: array indices
+                      ixDesire,            & ! input: index of the desired reach
+                      T0,T1,               & ! input: start and end of the time step
+                      LAKEFLAG,            & ! input: flag if lakes are to be processed
+                      NETOPO_in,           & ! input: reach topology data structure
+                      RPARAM_in,           & ! input: reach parameter data structure
+                      RCHSTA_out,          & ! inout: reach state data structure
+                      RCHFLX_out,          & ! inout: reach flux data structure
+                      ierr,cmessage)         ! output: error control
+         if(ierr/=0) call handle_err(ierr, trim(message)//trim(cmessage))
+       end do  seg
+     end do trib
+!$OMP END PARALLEL DO
+
+   end do
+
+   call t_stopf('route/dfw')
+
+ END SUBROUTINE dfw_route
+
+ ! *********************************************************************
+ ! subroutine: perform diffusive wave routing for one segment
+ ! *********************************************************************
+ SUBROUTINE dfw_rch(iEns, segIndex, & ! input: index of runoff ensemble to be processed
+                    ixDesire,       & ! input: reachID to be checked by on-screen pringing
+                    T0,T1,          & ! input: start and end of the time step
+                    LAKEFLAG,       & ! input: flag if lakes are to be processed
+                    NETOPO_in,      & ! input: reach topology data structure
+                    RPARAM_in,      & ! input: reach parameter data structure
+                    RCHSTA_out,     & ! inout: reach state data structure
+                    RCHFLX_out,     & ! inout: reach flux data structure
+                    ierr, message)    ! output: error control
+
+ implicit none
+
+ ! Input
+ integer(i4b),  intent(in)                 :: iEns              ! runoff ensemble to be routed
+ integer(i4b),  intent(in)                 :: segIndex          ! segment where routing is performed
+ integer(i4b),  intent(in)                 :: ixDesire          ! index of the reach for verbose output
+ real(dp),      intent(in)                 :: T0,T1             ! start and end of the time step (seconds)
+ integer(i4b),  intent(in)                 :: LAKEFLAG          ! >0 if processing lakes
+ type(RCHTOPO), intent(in),    allocatable :: NETOPO_in(:)      ! River Network topology
+ type(RCHPRP),  intent(in),    allocatable :: RPARAM_in(:)      ! River reach parameter
+ ! inout
+ type(STRSTA),  intent(inout), allocatable :: RCHSTA_out(:,:)   ! reach state data
+ type(STRFLX),  intent(inout), allocatable :: RCHFLX_out(:,:)   ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
+ ! Output
+ integer(i4b),  intent(out)                :: ierr              ! error code
+ character(*),  intent(out)                :: message           ! error message
+ ! Local variables to
+ logical(lgt)                              :: doCheck           ! check details of variables
+ logical(lgt)                              :: isHW              ! headwater basin?
+ integer(i4b)                              :: nUps              ! number of upstream segment
+ integer(i4b)                              :: iUps              ! upstream reach index
+ integer(i4b)                              :: iRch_ups          ! index of upstream reach in NETOPO
+ real(dp)                                  :: q_upstream        ! total discharge at top of the reach being processed
+ character(len=strLen)                     :: cmessage          ! error message from subroutine
+
+ ierr=0; message='dfw_rch/'
+
+ doCheck = .false.
+ if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+   doCheck = .true.
+ end if
+
+ ! get discharge coming from upstream
+ nUps = size(NETOPO_in(segIndex)%UREACHI)
+ isHW = .true.
+ q_upstream = 0.0_dp
+ if (nUps>0) then
+   isHW = .false.
+   do iUps = 1,nUps
+     iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%REACH_Q
+   end do
+ endif
+
+ if(doCheck)then
+   write(iulog,'(A)') 'CHECK diffusive wave routing'
+   if (nUps>0) then
+     do iUps = 1,nUps
+       iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+       write(iulog,'(A,X,I12,X,G15.4)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%REACH_Q
+     enddo
+   end if
+   write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iEns,segIndex)%BASIN_QR(1)=',RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
+ endif
+
+ ! solve diffusive wave equation
+ call diffusive_wave(RPARAM_in(segIndex),         &    ! input: parameter at segIndex reach
+                     T0,T1,                       &    ! input: start and end of the time step
+                     q_upstream,                  &    ! input: total discharge at top of the reach being processed
+                     isHW,                        &    ! input: is this headwater basin?
+                     RCHSTA_out(iens,segIndex),   &    ! inout:
+                     RCHFLX_out(iens,segIndex),   &    ! inout: updated fluxes at reach
+                     doCheck,                     &    ! input: reach index to be examined
+                     ierr, cmessage)                    ! output: error control
+ if(ierr/=0)then
+    write(message, '(A,X,I12,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage)
+    return
+ endif
+
+ if(doCheck)then
+  write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%REACH_Q
+ endif
+
+ END SUBROUTINE dfw_rch
+
+
+ ! *********************************************************************
+ ! subroutine: solve diffuisve wave equation
+ ! *********************************************************************
+ SUBROUTINE diffusive_wave(rch_param,     & ! input: river parameter data structure
+                           T0,T1,         & ! input: start and end of the time step
+                           q_upstream,    & ! input: discharge from upstream
+                           isHW,          & ! input: is this headwater basin?
+                           rstate,        & ! inout: reach state at a reach
+                           rflux,         & ! inout: reach flux at a reach
+                           doCheck,       & ! input: reach index to be examined
+                           ierr,message)
+ ! ----------------------------------------------------------------------------------------
+ ! Solve linearlized diffusive wave equation per reach and time step.
+ !  dQ/dt + ck*dQ/dx = dk*d2Q/dx2  - a)
+ !
+ !  ck (celerity) and dk (diffusivity) are computed with previous inflow and outflow and current inflow
+ !
+ !  1) dQ/dt   = (Q(t,x) - Q(t-1,x))/dt
+ !  2) dQ/dx   = [(1-wck)(Q(t-1,x+1)-Q(t-1,x-1)) + wck*(Q(t,x+1)-Q(t,x-1))]/2dx
+ !  3) d2Q/dx2 = [(1-wdk)(Q(t-1,x+1)-2Q(t-1,x)+Q(t-1,x-1)) + wdk*(Q(t,x+1)-2Q(t,x)+Q(t,x-1))]/2dx
+ !
+ !  upstream B.C:   Dirchlet BC with inflow at current time-step,t, from upstream basin
+ !  downstream B.C: Neumann BC with prescribed Q gradient (Sbc)
+ !                  dQ/dx|x=N = Sbc ->  4) Q(t,N)-Q(t,N-1)) = Sbc*dx
+ !  Another downstream B.C option is absorbing boundary condition
+ !                  dQ/dt|x=N + ck*dQ/dx|x=N = 0
+ !
+ !  Inserting 1), 2), 3) and 4) into a) and moving Q(t,*) terms to left-hand side and Q(t-1,*) terms to the righ-hand side
+ !  results in tridiagonal matrix equation A*Q = b
+ !  where A is [N x N] matrix, Q is [N x 1] vector to be solved (next time step Q) and b is [N x 1] vector
+ !  N (nMolecule is used in the code) is the number of internal nodes including upstream and downstream boundaries
+ !
+ !  Since A is a tridiagonal matrix, the code stores only three diagnoal elements - upper, diagonal, and lower
+ !  solving the matrix equation use thomas algorithm
+ !
+ ! ----------------------------------------------------------------------------------------
+ USE globalData, ONLY : nMolecule   ! number of internal nodes for finite difference (including upstream and downstream boundaries)
+ IMPLICIT NONE
+ ! Input
+ type(RCHPRP), intent(in)        :: rch_param      ! River reach parameter
+ real(dp),     intent(in)        :: T0,T1          ! start and end of the time step (seconds)
+ real(dp),     intent(in)        :: q_upstream     ! total discharge at top of the reach being processed
+ logical(lgt), intent(in)        :: isHW           ! is this headwater basin?
+ logical(lgt), intent(in)        :: doCheck        ! reach index to be examined
+ ! Input/Output
+ type(STRSTA), intent(inout)     :: rstate         ! curent reach states
+ type(STRFLX), intent(inout)     :: rflux          ! current Reach fluxes
+ ! Output
+ integer(i4b), intent(out)       :: ierr           ! error code
+ character(*), intent(out)       :: message        ! error message
+ ! Local variables
+ real(dp)                        :: alpha          ! sqrt(slope)(/mannings N* width)
+ real(dp)                        :: beta           ! constant, 5/3
+ real(dp)                        :: Cd             ! Fourier number
+ real(dp)                        :: Ca             ! Courant number
+ real(dp)                        :: dt             ! interval of time step [sec]
+ real(dp)                        :: dx             ! length of segment [m]
+ real(dp)                        :: Qbar           ! 3-point average discharge [m3/s]
+ real(dp)                        :: Abar           ! 3-point average flow area [m2]
+ real(dp)                        :: Vbar           ! 3-point average velocity [m/s]
+ real(dp)                        :: ck             ! kinematic wave celerity [m/s]
+ real(dp)                        :: dk             ! diffusivity [m2/s]
+ real(dp)                        :: Sbc            ! neumann BC slope
+ real(dp), allocatable           :: diagonal(:,:)  ! diagonal part of matrix
+ real(dp), allocatable           :: b(:)           ! right-hand side of the matrix equation
+ real(dp), allocatable           :: Qlocal(:,:)    ! sub-reach & sub-time step discharge at previous and current time step [m3/s]
+ real(dp), allocatable           :: Qprev(:)       ! sub-reach discharge at previous time step [m3/s]
+ real(dp)                        :: dTsub          ! time inteval for sub time-step [sec]
+ real(dp)                        :: wck            ! weight for advection
+ real(dp)                        :: wdk            ! weight for diffusion
+ integer(i4b)                    :: ix,it          ! loop index
+ integer(i4b)                    :: ntSub          ! number of sub time-step
+ integer(i4b)                    :: Nx             ! number of internal reach segments
+ integer(i4b)                    :: downstreamBC   ! method of B.C condition - absorbing or Neumann
+ character(len=strLen)           :: fmt1           ! format string
+ character(len=strLen)           :: cmessage       ! error message from subroutine
+ ! Local parameters
+ integer(i4b), parameter         :: absorbingBC=1
+ integer(i4b), parameter         :: neumannBC=2
+
+ ierr=0; message='diffusive_wave/'
+
+ ! hard-coded parameters
+ downstreamBC = neumannBC
+ Sbc = 0._dp
+
+ ntSub = 1  ! number of sub-time step
+ wck = 1.0  ! weight in advection term
+ wdk = 1.0  ! weight in diffusion term 0.0-> fully explicit, 0.5-> Crank-Nicolson, 1.0 -> fully implicit
+
+ Nx = nMolecule - 1  ! Nx: number of internal reach segments
+
+ if (.not. isHW) then
+
+   allocate(Qprev(nMolecule), stat=ierr, errmsg=cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+   allocate(b(nMolecule), stat=ierr, errmsg=cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+   allocate(diagonal(nMolecule,3), stat=ierr, errmsg=cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+   ! initialize previous time step flow
+   Qprev(1:nMolecule) = rstate%molecule%Q     ! flow state at previous time step
+
+   ! Get the reach parameters
+   ! A = (Q/alpha)**(1/beta)
+   ! Q = alpha*A**beta
+   alpha = sqrt(rch_param%R_SLOPE)/(rch_param%R_MAN_N*rch_param%R_WIDTH**(2._dp/3._dp))
+   beta  = 5._dp/3._dp
+   dx = rch_param%RLENGTH/Nx
+   dt = T1-T0
+
+   if (doCheck) then
+     write(iulog,'(4(A,X,G15.4))') ' length [m] =',rch_param%RLENGTH,'slope [-] =',rch_param%R_SLOPE,'channel width [m] =',rch_param%R_WIDTH,'manning coef =',rch_param%R_MAN_N
+   end if
+
+   ! time-step adjustment so Courant number is less than 1
+   dTsub = dt/ntSub
+
+   if (doCheck) then
+     write(iulog,'(A,X,I3,A,X,G12.5)') ' No. sub timestep=',nTsub,' sub time-step [sec]=',dTsub
+   end if
+
+   allocate(Qlocal(0:1, 1:nMolecule), stat=ierr, errmsg=cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   Qlocal(0:1,:) = realMissing
+   Qlocal(0,1:nMolecule) = Qprev ! previous time step
+   Qlocal(1,1)  = q_upstream     ! infllow at sub-time step in current time step
+
+   do it = 1, nTsub
+
+     Qbar = (Qlocal(1,1)+Qlocal(0,1)+Qlocal(0,nMolecule))/3.0 ! 3 point average discharge [m3/s]
+     Abar = (abs(Qbar)/alpha)**(1/beta)                            ! flow area [m2] (manning equation)
+     Vbar = 0._dp
+     if (Abar>0._dp) Vbar = Qbar/Abar                     ! average velocity [m/s]
+     ck   = beta*Vbar                                     ! kinematic wave celerity [m/s]
+     dk   = Qbar/(2*rch_param%R_WIDTH*rch_param%R_SLOPE)  ! diffusivity [m2/s]
+
+     Cd = dk*dTsub/dx**2
+     Ca = ck*dTsub/dx
+
+     ! create a matrix - current time step
+     ! populate tridiagonal elements
+     ! diagonal
+     diagonal(1,2)             = 1._dp
+     diagonal(2:nMolecule-1,2) = 2._dp + 4*wdk*Cd
+     if (downstreamBC == absorbingBC) then
+       diagonal(nMolecule,2)     = 1._dp + wck*Ca
+     else if (downstreamBC == neumannBC) then
+       diagonal(nMolecule,2)     = 1._dp
+     end if
+
+     ! upper
+     diagonal(:,1)           = 0._dp
+     diagonal(3:nMolecule,1) = wck*Ca - 2._dp*wdk*Cd
+
+     ! lower
+     diagonal(:,3)             = 0._dp
+     diagonal(1:nMolecule-2,3) = -wck*Ca - 2._dp*wdk*Cd
+     if (downstreamBC == absorbingBC) then
+       diagonal(nMolecule-1,3)   = -wck*Ca
+     else if (downstreamBC == neumannBC) then
+       diagonal(nMolecule-1,3)     = -1._dp
+     end if
+
+     ! populate left-hand side
+     ! upstream boundary condition
+     b(1)             = Qlocal(1,1)
+     ! downstream boundary condition
+     if (downstreamBC == absorbingBC) then
+       b(nMolecule)     = (1._dp-(1._dp-wck)*Ca)*Qlocal(0,nMolecule) + (1-wck)*Ca*Qlocal(0,nMolecule-1)
+     else if (downstreamBC == neumannBC) then
+       b(nMolecule)     = Sbc*dx
+     end if
+     ! internal node points
+     b(2:nMolecule-1) = ((1._dp-wck)*Ca+2._dp*(1._dp-wdk))*Cd*Qlocal(0,1:nMolecule-2)  &
+                      + (2._dp-4._dp*(1._dp-wdk)*Cd)*Qlocal(0,2:nMolecule-1)           &
+                      - ((1._dp-wck)*Ca - (1._dp-wdk)*Cd)*Qlocal(0,3:nMolecule)
+
+     ! solve matrix equation - get updated Qlocal
+     call TDMA(nMolecule, diagonal, b, Qlocal(1,:))
+
+     if (doCheck) then
+       write(fmt1,'(A,I5,A)') '(A,1X',nMolecule,'(1X,F15.7))'
+       write(*,fmt1) ' Q sub_reqch=', (Qlocal(1,ix), ix=1,nMolecule)
+     end if
+
+     Qlocal(0,:) = Qlocal(1,:)
+   end do
+
+   ! store final outflow in data structure
+   rflux%REACH_Q = Qlocal(1, nMolecule) + rflux%BASIN_QR(1)
+
+   if (doCheck) then
+     write(iulog,*) 'rflux%REACH_Q= ', rflux%REACH_Q
+     write(iulog,*) 'Qprev(1:nMolecule)= ', Qprev(1:nMolecule)
+     write(iulog,*) 'Qbar, Abar, Vbar, ck, dk= ',Qbar, Abar, Vbar, ck, dk
+     write(iulog,*) 'Cd, Ca= ', Cd, Ca
+     write(iulog,*) 'diagonal(:,1)= ', diagonal(:,1)
+     write(iulog,*) 'diagonal(:,2)= ', diagonal(:,2)
+     write(iulog,*) 'diagonal(:,3)= ', diagonal(:,3)
+     write(iulog,*) 'b= ', b(1:nMolecule)
+   end if
+
+   ! compute volume
+   rflux%REACH_VOL(0) = rflux%REACH_VOL(1)
+   rflux%REACH_VOL(1) = rflux%REACH_VOL(0) + (Qlocal(1,1) - Qlocal(1,nMolecule))*dT
+
+   ! update state
+   rstate%molecule%Q = Qlocal(1,:)
+
+ else ! if head-water
+
+   rflux%REACH_Q = rflux%BASIN_QR(1)
+
+   rflux%REACH_VOL(0) = 0._dp
+   rflux%REACH_VOL(1) = 0._dp
+
+   rstate%molecule%Q(1:nMolecule) = 0._dp
+   rstate%molecule%Q(nMolecule) = rflux%REACH_Q
+
+   if (doCheck) then
+     write(iulog,'(A)')            ' This is headwater '
+   endif
+
+ endif
+
+ if (doCheck) then
+   write(iulog,'(A,X,G12.5)') ' Qout(t) =', rflux%REACH_Q
+ endif
+
+ END SUBROUTINE diffusive_wave
+
+ SUBROUTINE TDMA(NX,MAT,b,T)
+ ! Solve tridiagonal matrix system of linear equation
+ ! NX is the number of unknowns (gridblocks minus boundaries)
+ ! Solve system of linear equations, A*T = b where A is tridiagonal matrix
+ ! MAT = NX x 3 array holding tri-diagonal portion of A
+ ! MAT(NX,1) - uppder diagonals for matrix A
+ ! MAT(NX,2) - diagonals for matrix A
+ ! MAT(NX,3) - lower diagonals for matrix A
+ ! b(NX) - vector of the right hand coefficients b
+ ! T(NX) - The solution matrix
+ !
+ ! example, A
+ ! d u 0 0 0
+ ! l d u 0 0
+ ! 0 l d u 0
+ ! 0 0 l d u
+ ! 0 0 0 l d
+ !
+ ! MAT(:,1) = [0, u, u, u, u]
+ ! MAT(:,2) = [d, d, d, d, d]
+ ! MAT(:,3) = [l, l, l, l, 0]
+
+   IMPLICIT NONE
+   ! Input
+   integer(i4b),  intent(in)     :: NX     ! number of unknown (= number of matrix size, grid point minus two end points)
+   real(dp),      intent(in)     :: MAT(NX,3)
+   real(dp),      intent(in)     :: b(NX)
+   ! Output
+   real(dp),      intent(inout)  :: T(NX)
+   ! Local
+   integer(i4b)                  :: ix
+   real(dp)                      :: U(NX)
+   real(dp)                      :: D(NX)
+   real(dp)                      :: L(NX)
+   real(dp)                      :: b1(NX)
+   real(dp)                      :: coef
+
+   U(1:NX) = MAT(1:NX,1)
+   D(1:NX) = MAT(1:NX,2)
+   L(1:NX) = MAT(1:NX,3)
+   b1(1:NX) = b(1:NX)
+   do ix = 2, NX
+     coef  = L(ix-1)/D(ix-1)
+     D(ix) = D(ix)-coef*U(ix)
+     b1(ix) = b1(ix)-coef*b1(ix-1)
+   end do
+
+   T(NX) = b1(NX)/D(NX) ! Starts the countdown of answers
+   do ix = NX-1, 1, -1
+       T(ix) = (b1(ix) - U(ix+1)*T(ix+1))/D(ix)
+   end do
+
+ END SUBROUTINE TDMA
+
+
+END MODULE dfw_route_module

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -56,7 +56,9 @@ module globalData
   USE var_lookup, ONLY: nVarsIRFbas
   USE var_lookup, ONLY: nVarsIRF
   USE var_lookup, ONLY: nVarsKWT
-  USE var_lookup, ONLY: nVarsKWE
+  USE var_lookup, ONLY: nVarsKW
+  USE var_lookup, ONLY: nVarsDW
+  USE var_lookup, ONLY: nVarsMC
 
   implicit none
 
@@ -97,6 +99,8 @@ module globalData
   integer(i4b)                   , public :: ixPrint(1:2)=integerMissing    ! index of desired reach to be on-screen print
   ! ennsemble number (maybe to be removed)
   integer(i4b)                   , public :: nEns=1                    ! number of ensemble
+  ! numerical computing
+  integer(i4b)                   , public :: nMolecule                ! number of computational molecule (used for KW, MC, DW)
 
   ! ---------- MPI/OMP/PIO variables ----------------------------------------------------------------
 
@@ -146,9 +150,11 @@ module globalData
   type(var_info_new)             , public :: meta_rflx   (nVarsRFLX   ) ! reach flux variables
   type(var_info_new)             , public :: meta_basinQ (nVarsBasinQ ) ! reach inflow from basin
   type(var_info_new)             , public :: meta_irf_bas(nVarsIRFbas ) ! basin IRF routing fluxes/states
-  type(var_info_new)             , public :: meta_kwt    (nVarsKWT    ) ! KWT routing fluxes/states
   type(var_info_new)             , public :: meta_irf    (nVarsIRF    ) ! IRF routing fluxes/states
-  type(var_info_new)             , public :: meta_kwe    (nVarsKWE    ) ! KWE routing fluxes/states
+  type(var_info_new)             , public :: meta_kwt    (nVarsKWT    ) ! KWT routing fluxes/states
+  type(var_info_new)             , public :: meta_kw     (nVarsKW     ) ! KW routing fluxes/states
+  type(var_info_new)             , public :: meta_mc     (nVarsMC     ) ! MC routing restart fluxes/states
+  type(var_info_new)             , public :: meta_dw     (nVarsDW     ) ! DW routing restart fluxes/states
 
   ! ---------- shared data structures ----------------------------------------------------------------------
 

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -1,0 +1,393 @@
+MODULE mc_route_module
+
+! muskingum-cunge routing
+
+USE nrtype
+! data types
+USE dataTypes,   ONLY: STRFLX            ! fluxes in each reach
+USE dataTypes,   ONLY: STRSTA            ! state in each reach
+USE dataTypes,   ONLY: RCHTOPO           ! Network topology
+USE dataTypes,   ONLY: RCHPRP            ! Reach parameter
+USE dataTypes,   ONLY: subbasin_omp      ! mainstem+tributary data strucuture
+! global data
+USE public_var,  ONLY: iulog             ! i/o logical unit number
+USE public_var,  ONLY: realMissing       ! missing value for real number
+USE public_var,  ONLY: integerMissing    ! missing value for integer number
+! subroutines: general
+USE perf_mod,    ONLY: t_startf,t_stopf   ! timing start/stop
+USE model_utils, ONLY: handle_err
+
+! privary
+implicit none
+private
+
+public::mc_route
+
+contains
+
+ ! *********************************************************************
+ ! subroutine: perform muskingum-cunge routing through the river network
+ ! *********************************************************************
+ SUBROUTINE mc_route(iens,                 & ! input: ensemble index
+                     river_basin,          & ! input: river basin information (mainstem, tributary outlet etc.)
+                     T0,T1,                & ! input: start and end of the time step
+                     ixDesire,             & ! input: reachID to be checked by on-screen pringing
+                     NETOPO_in,            & ! input: reach topology data structure
+                     RPARAM_in,            & ! input: reach parameter data structure
+                     RCHSTA_out,           & ! inout: reach state data structure
+                     RCHFLX_out,           & ! inout: reach flux data structure
+                     ierr,message,         & ! output: error control
+                     ixSubRch)               ! optional input: subset of reach indices to be processed
+
+   implicit none
+
+   ! Input
+   integer(i4b),       intent(in)                 :: iEns                 ! ensemble member
+   type(subbasin_omp), intent(in),    allocatable :: river_basin(:)       ! river basin information (mainstem, tributary outlet etc.)
+   real(dp),           intent(in)                 :: T0,T1                ! start and end of the time step (seconds)
+   integer(i4b),       intent(in)                 :: ixDesire             ! index of the reach for verbose output
+   type(RCHTOPO),      intent(in),    allocatable :: NETOPO_in(:)         ! River Network topology
+   type(RCHPRP),       intent(in),    allocatable :: RPARAM_in(:)         ! River reach parameter
+   ! inout
+   type(STRSTA),       intent(inout), allocatable :: RCHSTA_out(:,:)      ! reach state data
+   type(STRFLX),       intent(inout), allocatable :: RCHFLX_out(:,:)      ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
+   ! output variables
+   integer(i4b),       intent(out)                :: ierr                 ! error code
+   character(*),       intent(out)                :: message              ! error message
+   ! input (optional)
+   integer(i4b),       intent(in), optional       :: ixSubRch(:)          ! subset of reach indices to be processed
+   ! local variables
+   character(len=strLen)                          :: cmessage             ! error message for downwind routine
+   logical(lgt),                      allocatable :: doRoute(:)           ! logical to indicate which reaches are processed
+   integer(i4b)                                   :: LAKEFLAG=0           ! >0 if processing lakes
+   integer(i4b)                                   :: nOrder               ! number of stream order
+   integer(i4b)                                   :: nTrib                ! number of tributary basins
+   integer(i4b)                                   :: nSeg                 ! number of reaches in the network
+   integer(i4b)                                   :: iSeg, jSeg           ! loop indices - reach
+   integer(i4b)                                   :: iTrib                ! loop indices - branch
+   integer(i4b)                                   :: ix                   ! loop indices stream order
+
+   ierr=0; message='mc_route/'
+
+   ! number of reach check
+   if (size(NETOPO_in)/=size(RCHFLX_out(iens,:))) then
+    ierr=20; message=trim(message)//'sizes of NETOPO and RCHFLX mismatch'; return
+   endif
+
+   nSeg = size(NETOPO_in)
+
+   allocate(doRoute(nSeg), stat=ierr)
+
+   if (present(ixSubRch))then
+    doRoute(:)=.false.
+    doRoute(ixSubRch) = .true. ! only subset of reaches are on
+   else
+    doRoute(:)=.true. ! every reach is on
+   endif
+
+   nOrder = size(river_basin)
+
+   call t_startf('route/mc')
+
+   do ix = 1, nOrder
+
+     nTrib=size(river_basin(ix)%branch)
+
+!$OMP PARALLEL DO schedule(dynamic,1)                   & ! chunk size of 1
+!$OMP          private(jSeg, iSeg)                      & ! private for a given thread
+!$OMP          private(ierr, cmessage)                  & ! private for a given thread
+!$OMP          shared(T0,T1)                            & ! private for a given thread
+!$OMP          shared(LAKEFLAG)                         & ! private for a given thread
+!$OMP          shared(river_basin)                      & ! data structure shared
+!$OMP          shared(doRoute)                          & ! data array shared
+!$OMP          shared(NETOPO_in)                        & ! data structure shared
+!$OMP          shared(RPARAM_in)                        & ! data structure shared
+!$OMP          shared(RCHSTA_out)                       & ! data structure shared
+!$OMP          shared(RCHFLX_out)                       & ! data structure shared
+!$OMP          shared(ix, iEns, ixDesire)               & ! indices shared
+!$OMP          firstprivate(nTrib)
+     trib:do iTrib = 1,nTrib
+       seg:do iSeg=1,river_basin(ix)%branch(iTrib)%nRch
+         jSeg  = river_basin(ix)%branch(iTrib)%segIndex(iSeg)
+         if (.not. doRoute(jSeg)) cycle
+         call mc_rch(iEns,jSeg,           & ! input: array indices
+                     ixDesire,            & ! input: index of the desired reach
+                     T0,T1,               & ! input: start and end of the time step
+                     LAKEFLAG,            & ! input: flag if lakes are to be processed
+                     NETOPO_in,           & ! input: reach topology data structure
+                     RPARAM_in,           & ! input: reach parameter data structure
+                     RCHSTA_out,          & ! inout: reach state data structure
+                     RCHFLX_out,          & ! inout: reach flux data structure
+                     ierr,cmessage)         ! output: error control
+         if(ierr/=0) call handle_err(ierr, trim(message)//trim(cmessage))
+       end do  seg
+     end do trib
+!$OMP END PARALLEL DO
+
+   end do
+
+   call t_stopf('route/mc')
+
+ END SUBROUTINE mc_route
+
+ ! *********************************************************************
+ ! subroutine: perform muskingum-cunge routing for one segment
+ ! *********************************************************************
+ SUBROUTINE mc_rch(iEns, segIndex, & ! input: index of runoff ensemble to be processed
+                   ixDesire,       & ! input: reachID to be checked by on-screen pringing
+                   T0,T1,          & ! input: start and end of the time step
+                   LAKEFLAG,       & ! input: flag if lakes are to be processed
+                   NETOPO_in,      & ! input: reach topology data structure
+                   RPARAM_in,      & ! input: reach parameter data structure
+                   RCHSTA_out,     & ! inout: reach state data structure
+                   RCHFLX_out,     & ! inout: reach flux data structure
+                   ierr, message)    ! output: error control
+
+ implicit none
+
+ ! Input
+ integer(i4b),  intent(in)                 :: iEns              ! runoff ensemble to be routed
+ integer(i4b),  intent(in)                 :: segIndex          ! segment where routing is performed
+ integer(i4b),  intent(in)                 :: ixDesire          ! index of the reach for verbose output
+ real(dp),      intent(in)                 :: T0,T1             ! start and end of the time step (seconds)
+ integer(i4b),  intent(in)                 :: LAKEFLAG          ! >0 if processing lakes
+ type(RCHTOPO), intent(in),    allocatable :: NETOPO_in(:)      ! River Network topology
+ type(RCHPRP),  intent(in),    allocatable :: RPARAM_in(:)      ! River reach parameter
+ ! inout
+ type(STRSTA),  intent(inout), allocatable :: RCHSTA_out(:,:)   ! reach state data
+ type(STRFLX),  intent(inout), allocatable :: RCHFLX_out(:,:)   ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
+ ! Output
+ integer(i4b),  intent(out)                :: ierr              ! error code
+ character(*),  intent(out)                :: message           ! error message
+ ! Local variables to
+ logical(lgt)                              :: doCheck           ! check details of variables
+ logical(lgt)                              :: isHW              ! headwater basin?
+ integer(i4b)                              :: nUps              ! number of upstream segment
+ integer(i4b)                              :: iUps              ! upstream reach index
+ integer(i4b)                              :: iRch_ups          ! index of upstream reach in NETOPO
+ real(dp)                                  :: q_upstream        ! total discharge at top of the reach being processed
+ character(len=strLen)                     :: cmessage          ! error message from subroutine
+
+ ierr=0; message='mc_rch/'
+
+ doCheck = .false.
+ if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+   doCheck = .true.
+ end if
+
+ ! get discharge coming from upstream
+ nUps = size(NETOPO_in(segIndex)%UREACHI)
+ isHW = .true.
+ q_upstream = 0.0_dp
+ if (nUps>0) then
+   isHW = .false.
+   do iUps = 1,nUps
+     iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%REACH_Q
+   end do
+ endif
+
+ if(doCheck)then
+   write(iulog,'(A)') 'CHECK muskingum-cunge routing'
+   if (nUps>0) then
+     do iUps = 1,nUps
+       iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+       write(iulog,'(A,X,I6,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%REACH_Q
+     enddo
+   end if
+   write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iEns,segIndex)%BASIN_QR(1)=',RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
+ endif
+
+ ! solve muskingum-cunge alogorithm
+ call muskingum_cunge(RPARAM_in(segIndex),         &    ! input: parameter at segIndex reach
+                      T0,T1,                       &    ! input: start and end of the time step
+                      q_upstream,                  &    ! input: total discharge at top of the reach being processed
+                      isHW,                        &    ! input: is this headwater basin?
+                      RCHSTA_out(iens,segIndex),   &    ! inout:
+                      RCHFLX_out(iens,segIndex),   &    ! inout: updated fluxes at reach
+                      doCheck,                     &    ! input: reach index to be examined
+                      ierr, cmessage)                    ! output: error control
+ if(ierr/=0)then
+    write(message, '(A,X,I10,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage)
+    return
+ endif
+
+ if(doCheck)then
+  write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%REACH_Q
+ endif
+
+ END SUBROUTINE mc_rch
+
+
+ ! *********************************************************************
+ ! subroutine: solve muskingum equation
+ ! *********************************************************************
+ SUBROUTINE muskingum_cunge(rch_param,     & ! input: river parameter data structure
+                            T0,T1,         & ! input: start and end of the time step
+                            q_upstream,    & ! input: discharge from upstream
+                            isHW,          & ! input: is this headwater basin?
+                            rstate,        & ! inout: reach state at a reach
+                            rflux,         & ! inout: reach flux at a reach
+                            doCheck,       & ! input: reach index to be examined
+                            ierr,message)
+ ! ----------------------------------------------------------------------------------------
+ ! Perform muskingum-cunge routing
+ !
+ !
+ !
+ !
+ ! *
+ ! *
+ ! *
+ !
+ ! state array:
+ ! (time:0:1, loc:0:1) 0-previous time step/inlet, 1-current time step/outlet.
+ ! Q or A(1,2,3,4): 1: (t=0,x=0), 2: (t=0,x=1), 3: (t=1,x=0), 4: (t=1,x=1)
+
+ IMPLICIT NONE
+ ! Input
+ type(RCHPRP), intent(in)                 :: rch_param    ! River reach parameter
+ real(dp),     intent(in)                 :: T0,T1        ! start and end of the time step (seconds)
+ real(dp),     intent(in)                 :: q_upstream   ! total discharge at top of the reach being processed
+ logical(lgt), intent(in)                 :: isHW         ! is this headwater basin?
+ logical(lgt), intent(in)                 :: doCheck      ! reach index to be examined
+ ! Input/Output
+ type(STRSTA), intent(inout)              :: rstate       ! curent reach states
+ type(STRFLX), intent(inout)              :: rflux        ! current Reach fluxes
+ ! Output
+ integer(i4b), intent(out)                :: ierr         ! error code
+ character(*), intent(out)                :: message      ! error message
+ ! LOCAL VAIRABLES
+ real(dp)                                 :: alpha        ! sqrt(slope)(/mannings N* width)
+ real(dp)                                 :: beta         ! constant, 5/3
+ real(dp)                                 :: theta        ! dT/dX
+ real(dp)                                 :: X            ! X-factor in descreterized kinematic wave
+ real(dp)                                 :: dt           ! interval of time step [sec]
+ real(dp)                                 :: dx           ! length of segment [m]
+ real(dp)                                 :: Q(0:1,0:1)   ! discharge at computational molecule
+ real(dp)                                 :: Qbar         ! 3-point average discharge [m3/s]
+ real(dp)                                 :: Abar         ! 3-point average flow area [m2]
+ real(dp)                                 :: Vbar         ! 3-point average velocity [m/s]
+ real(dp)                                 :: Ybar         ! 3-point average flow depth [m]
+ real(dp)                                 :: B            ! flow top width [m]
+ real(dp)                                 :: ck           ! kinematic wave celerity [m/s]
+ real(dp)                                 :: Cn           ! Courant number [-]
+ real(dp)                                 :: dTsub        ! time inteval for sut time-step [sec]
+ real(dp)                                 :: C0,C1,C2     ! muskingum parameters
+ real(dp), allocatable                    :: QoutLocal(:) ! out discharge [m3/s] at sub time step
+ real(dp), allocatable                    :: QinLocal(:)  ! in discharge [m3/s] at sub time step
+ integer(i4b)                             :: ix           ! loop index
+ integer(i4b)                             :: ntSub        ! number of sub time-step
+ character(len=strLen)                    :: cmessage     ! error message from subroutine
+ real(dp), parameter                      :: Y = 0.5      ! muskingum parameter Y (this is fixed)
+
+ ierr=0; message='muskingum-cunge/'
+
+ Q(0,0) = rstate%molecule%Q(1) ! inflow at previous time step (t-1)
+ Q(0,1) = rstate%molecule%Q(2) ! outflow at previous time step (t-1)
+ Q(1,1) = realMissing
+
+ if (.not. isHW) then
+
+   ! Get the reach parameters
+   ! A = (Q/alpha)**(1/beta)
+   ! Q = alpha*A**beta
+   alpha = sqrt(rch_param%R_SLOPE)/(rch_param%R_MAN_N*rch_param%R_WIDTH**(2._dp/3._dp))
+   beta  = 5._dp/3._dp
+   dx = rch_param%RLENGTH
+   dt = T1-T0
+   theta = dt/dx     ! [s/m]
+
+   ! compute total flow rate and flow area at upstream end at current time step
+   Q(1,0) = q_upstream
+
+   if (doCheck) then
+     write(iulog,'(4(A,X,G12.5))') ' length [m] =',rch_param%RLENGTH,'slope [-] =',rch_param%R_SLOPE,'channel width [m] =',rch_param%R_WIDTH,'manning coef =',rch_param%R_MAN_N
+     write(iulog,'(3(A,X,G12.5))') ' Qin(t-1) Q(0,0)=',Q(0,0),' Qin(t) Q(0,1)=',Q(0,1),' Qout(t-1) Q(1,0)=',Q(1,0)
+   end if
+
+   ! first, using 3-point average in computational molecule, check Cournat number is less than 1, otherwise subcycle within one time step
+   Qbar = (Q(0,0)+Q(1,0)+Q(0,1))/3.0  ! average discharge [m3/s]
+   Abar = (Qbar/alpha)**(1/beta)      ! average flow area [m2] (from manning equation)
+   Vbar = Qbar/Abar                   ! average velocity [m/s]
+   ck   = beta*Vbar                   ! kinematic wave celerity [m/s]
+   Cn   = ck*theta                    ! Courant number [-]
+
+   ! time-step adjustment so Courant number is less than 1
+   ntSub = 1
+   dTsub = dt
+   if (Cn>1.0_dp) then
+     ntSub = ceiling(dt/dx*cK)
+     dTsub = dt/ntSub
+   end if
+   if (doCheck) then
+     write(iulog,'(A,X,I3,A,X,G12.5)') ' No. sub timestep=',nTsub,' sub time-step [sec]=',dTsub
+   end if
+
+   allocate(QoutLocal(0:ntSub), QinLocal(0:ntSub), stat=ierr, errmsg=cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   QoutLocal(:) = realMissing
+   QoutLocal(0) = Q(0,1)        ! outfloe last time step
+   QinLocal(0)  = Q(0,0)        ! inflow at last time step
+   QinLocal(1:ntSub)  = Q(1,0)  ! infllow at sub-time step in current time step
+
+   do ix = 1, nTsub
+
+     Qbar = (QinLocal(ix)+QinLocal(ix-1)+QoutLocal(ix-1))/3.0 ! 3 point average discharge [m3/s]
+     Abar = (Qbar/alpha)**(1/beta)                            ! flow area [m2] (manning equation)
+     Ybar = Abar/rch_param%R_WIDTH                            ! flow depth [m] (rectangular channel)
+     B = rch_param%R_WIDTH                                    ! top width at water level [m] (rectangular channel)
+     ck = beta*(Qbar/Abar)                                    ! kinematic wave celerity [m/s]
+
+     X = 0.5*(1.0 - Qbar/(B*rch_param%R_SLOPE*ck*dX))         ! X factor for descreterized kinematic wave equation
+     Cn = ck*dTsub/dx                                         ! Courant number [-]
+
+     C0 = (-X+Cn*(1-Y))/(1-X+Cn*(1-Y))
+     C1 = (X+Cn*Y)/(1-X+Cn*(1-Y))
+     C2 = (1-X-Cn*Y)/(1-X+Cn*(1-Y))
+
+     QoutLocal(ix) = C0* QinLocal(ix)+ C1* QinLocal(ix-1)+ C2* QoutLocal(ix-1)
+     QoutLocal(ix) = max(0.0, QoutLocal(ix))
+
+     if (isnan(QoutLocal(ix))) then
+       ierr=10; message=trim(message)//'QoutLocal is Nan; activate vodose for this segment for diagnosis';return
+     end if
+
+     if (doCheck) then
+       write(iulog,'(A,I3,X,A,G12.5,X,A,G12.5)') '   sub time-step= ',ix,'Courant number= ',Cn, 'Q= ',QoutLocal(ix)
+     end if
+   end do
+
+   Q(1,1) = sum(QoutLocal(1:nTsub))/real(nTsub,kind=dp)
+
+ else ! if head-water
+
+   Q(1,0) = 0._dp
+   Q(1,1) = 0._dp
+
+   if (doCheck) then
+     write(iulog,'(A)')            ' This is headwater '
+   endif
+
+ endif
+
+ ! compute volume
+ rflux%REACH_VOL(0) = rflux%REACH_VOL(1)
+ rflux%REACH_VOL(1) = rflux%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dT
+ rflux%REACH_VOL(1) = max(rflux%REACH_VOL(1), 0._dp)
+
+ ! add catchment flow
+ rflux%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)
+
+ if (doCheck) then
+   write(iulog,'(A,X,G12.5)') ' Qout(t)=',Q(1,1)
+ endif
+
+ ! save inflow (index 1) and outflow (index 2) at current time step
+ rstate%molecule%Q(1) = Q(1,0)
+ rstate%molecule%Q(2) = Q(1,1)
+
+ END SUBROUTINE muskingum_cunge
+
+
+END MODULE mc_route_module

--- a/route/build/src/process_ntopo.f90
+++ b/route/build/src/process_ntopo.f90
@@ -12,14 +12,16 @@ USE public_var, ONLY: iulog              ! i/o logical unit number
 USE public_var, ONLY: idSegOut           ! ID for stream segment at the bottom of the subset
 
 ! options
-USE public_var, ONLY: topoNetworkOption  ! option to compute network topology
-USE public_var, ONLY: computeReachList   ! option to compute reach list
-USE public_var, ONLY: hydGeometryOption  ! option to obtain routing parameters
-USE public_var, ONLY: routOpt            ! option for desired routing method
-USE public_var, ONLY: allRoutingMethods  ! option for routing methods - all the methods
-USE public_var, ONLY: kinematicWave      ! option for routing methods - Lagrangian kinematic wave only
-USE public_var, ONLY: kinematicWaveEuler ! option for routing methods - Euler kinematic wave only
-USE public_var, ONLY: impulseResponseFunc! option for routing methods - IRF only
+USE public_var, ONLY: topoNetworkOption     ! option to compute network topology
+USE public_var, ONLY: computeReachList      ! option to compute reach list
+USE public_var, ONLY: hydGeometryOption     ! option to obtain routing parameters
+USE public_var, ONLY: routOpt               ! option for desired routing method
+USE public_var, ONLY: allRoutingMethods     ! option for routing methods - all the methods
+USE public_var, ONLY: impulseResponseFunc   ! option for routing methods - IRF
+USE public_var, ONLY: kinematicWaveTracking ! option for routing methods - Lagrangian kinematic wave
+USE public_var, ONLY: kinematicWave         ! option for routing methods - kinematic wave
+USE public_var, ONLY: muskingumCunge        ! option for routing methods - muskingum-cunge
+USE public_var, ONLY: kinematicWave         ! option for routing methods - diffusive wave
 
 ! named variables
 USE public_var, ONLY: true,false         ! named integers for true/false
@@ -229,8 +231,8 @@ contains
  ! compute hydraulic geometry (width and Manning's "n")
  if(hydGeometryOption==compute)then
 
-  ! (hydraulic geometry only needed for the kinematic wave method)
-  if (routOpt==allRoutingMethods .or. routOpt==kinematicWave .or. routOpt==kinematicWaveEuler) then
+  ! (hydraulic geometry needed for all the routing methods except impulse response function)
+  if (routOpt/=impulseResponseFunc) then
    do iSeg=1,nSeg
     structSEG(iSeg)%var(ixSEG%width)%dat(1) = wscale * sqrt(structSEG(iSeg)%var(ixSEG%totalArea)%dat(1))  ! channel width (m)
     structSEG(iSeg)%var(ixSEG%man_n)%dat(1) = mann_n                                                      ! Manning's "n" paramater (unitless)

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -70,10 +70,12 @@ module public_var
   integer(i4b), parameter,public  :: readFromFile=0         ! read given variable from a file
 
   ! routing methods
-  integer(i4b), parameter,public  :: allRoutingMethods=0    ! all routing methods
-  integer(i4b), parameter,public  :: impulseResponseFunc=1  ! impulse response function
-  integer(i4b), parameter,public  :: kinematicWave=2        ! kinematic wave
-  integer(i4b), parameter,public  :: kinematicWaveEuler=3   ! kinematic wave euler
+  integer(i4b), parameter,public  :: allRoutingMethods=0     ! all routing methods
+  integer(i4b), parameter,public  :: impulseResponseFunc=1   ! impulse response function
+  integer(i4b), parameter,public  :: kinematicWaveTracking=2 ! Lagrangian kinematic wave
+  integer(i4b), parameter,public  :: kinematicWave=3         ! kinematic wave
+  integer(i4b), parameter,public  :: muskingumCunge=4        ! muskingum-cunge
+  integer(i4b), parameter,public  :: diffusiveWave=5         ! diffusiveWave
 
   ! ---------- variables in the control file --------------------------------------------------------
 

--- a/route/build/src/read_restart.f90
+++ b/route/build/src/read_restart.f90
@@ -85,366 +85,451 @@ CONTAINS
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return;endif
  endif
 
- if (opt==allRoutingMethods .or. opt==kinematicWave) then
-  call read_KWT_state(ierr, cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
- endif
-
- if (opt==kinematicWaveEuler) then
-  call read_KWE_state(ierr, cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
+ if (opt==allRoutingMethods .or. opt==impulseResponseFunc) then
+   call read_IRF_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
  end if
 
- if (opt==allRoutingMethods .or. opt==impulseResponseFunc) then
-  call read_IRF_state(ierr, cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
+ if (opt==allRoutingMethods .or. opt==kinematicWaveTracking) then
+   call read_KWT_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
+ endif
+
+ if (opt==kinematicWave) then
+   call read_KW_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
+ end if
+
+ if (opt==muskingumCunge) then
+   call read_MC_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
+ end if
+
+ if (opt==diffusiveWave) then
+   call read_DW_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
  end if
 
  CONTAINS
 
   SUBROUTINE read_basinQ_state(ierr, message1)
-  ! meta data
-  USE globalData, ONLY: meta_basinQ              ! reach inflow from basin at previous time step
-  ! State/flux data structures
-  USE globalData, ONLY: RCHFLX                    ! To get q future for basin IRF and IRF (these should not be in this data strucuture)
-  ! Named variables
-  USE var_lookup, ONLY: ixBasinQ, nVarsBasinQ
-  implicit none
-  ! output
-  integer(i4b), intent(out)     :: ierr           ! error code
-  character(*), intent(out)     :: message1       ! error message
-  ! local variables
-  character(len=strLen)         :: cmessage1      ! error message of downwind routine
-  type(states)                  :: state          ! temporal state data structures
-  integer(i4b)                  :: iVar,iens,iSeg ! loop indices for variables, ensembles, reaches respectively
-  integer(i4b)                  :: jSeg           ! sorted index for reaches
 
-  ! initialize error control
-  ierr=0; message1='read_basinQ_state/'
+    USE globalData, ONLY: meta_basinQ              ! reach inflow from basin at previous time step
+    USE globalData, ONLY: RCHFLX                    ! To get q future for basin IRF and IRF (these should not be in this data strucuture)
+    USE var_lookup, ONLY: ixBasinQ, nVarsBasinQ
+    implicit none
+    ! output
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! loop indices for variables, ensembles, reaches respectively
+    integer(i4b)                  :: jSeg           ! sorted index for reaches
 
-  allocate(state%var(nVarsBasinQ), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    ! initialize error control
+    ierr=0; message1='read_basinQ_state/'
 
-  do iVar=1,nVarsBasinQ
-    select case(iVar)
-      case(ixBasinQ%q); allocate(state%var(iVar)%array_2d_dp(nSeg, nens),       stat=ierr)
-      case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for reach inflow:'//trim(meta_basinQ(iVar)%varName); return; endif
-  end do
+    allocate(state%var(nVarsBasinQ), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsBasinQ
-    select case(iVar)
-      case(ixBasinQ%q); call get_nc(fname, meta_basinQ(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
-      case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index for nc writing'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_basinQ(iVar)%varName); return; endif
-  enddo
+    do iVar=1,nVarsBasinQ
+      select case(iVar)
+        case(ixBasinQ%q); allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for reach inflow:'//trim(meta_basinQ(iVar)%varName); return; endif
+    end do
 
-  do iens=1,nens
-    do iSeg=1,nSeg
-      jSeg = ixRch_order(iSeg)
-      do iVar=1,nVarsBasinQ
-        select case(iVar)
-          case(ixBasinQ%q); RCHFLX(iens,jSeg)%BASIN_QR(1) = state%var(iVar)%array_2d_dp(iSeg,iens)
-          case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index'; return
-        end select
+    do iVar=1,nVarsBasinQ
+      select case(iVar)
+        case(ixBasinQ%q); call get_nc(fname, meta_basinQ(iVar)%varName, state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
+        case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index for nc writing'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_basinQ(iVar)%varName); return; endif
+    enddo
+
+    do iens=1,nens
+      do iSeg=1,nSeg
+        jSeg = ixRch_order(iSeg)
+        do iVar=1,nVarsBasinQ
+          select case(iVar)
+            case(ixBasinQ%q); RCHFLX(iens,jSeg)%BASIN_QR(1) = state%var(iVar)%array_2d_dp(iSeg,iens)
+            case default; ierr=20; message1=trim(message1)//'unable to identify previous time step reach inflow variable index'; return
+          end select
+        enddo
       enddo
     enddo
-  enddo
 
   END SUBROUTINE read_basinQ_state
 
   SUBROUTINE read_IRFbas_state(ierr, message1)
-  ! meta data
-  USE globalData, ONLY: meta_irf_bas              ! basin IRF routing
-  ! Named variables
-  USE var_lookup, ONLY: ixIRFbas, nVarsIRFbas
-  implicit none
-  ! output
-  integer(i4b), intent(out)     :: ierr           ! error code
-  character(*), intent(out)     :: message1       ! error message
-  ! local variables
-  character(len=strLen)         :: cmessage1      ! error message of downwind routine
-  type(states)                  :: state          ! temporal state data structures
-  integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
-  integer(i4b)                  :: jSeg           ! index loops for reaches respectively
-  integer(i4b)                  :: ntdh           ! dimension size
 
-  ierr=0; message1='read_IRFbas_state/'
+    USE globalData, ONLY: meta_irf_bas              ! basin IRF routing
+    USE var_lookup, ONLY: ixIRFbas, nVarsIRFbas
+    implicit none
+    ! output
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b)                  :: jSeg           ! index loops for reaches respectively
+    integer(i4b)                  :: ntdh           ! dimension size
 
-  call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%tdh)%dimName), ntdh, ierr, cmessage1)
-  if(ierr/=0)then;  message1=trim(message1)//trim(cmessage1); return; endif
+    ierr=0; message1='read_IRFbas_state/'
 
-  allocate(state%var(nVarsIRFbas), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%tdh)%dimName), ntdh, ierr, cmessage1)
+    if(ierr/=0)then;  message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsIRFbas
-
-   select case(iVar)
-    case(ixIRFbas%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh, nens), stat=ierr)
-    case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
-   end select
-   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state:'//trim(meta_irf_bas(iVar)%varName); return; endif
-
-  end do
-
-  do iVar=1,nVarsIRFbas
-
-   select case(iVar)
-    case(ixIRFbas%qfuture); call get_nc(fname, meta_irf_bas(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh,nens/), ierr, cmessage1)
-    case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF variable index for nc writing'; return
-   end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf_bas(iVar)%varName); return; endif
-
-  enddo
-
-  do iens=1,nens
-   do iSeg=1,nSeg
-
-    jSeg = ixRch_order(iSeg)
-
-    allocate(RCHFLX(iens,jSeg)%QFUTURE(ntdh), stat=ierr, errmsg=cmessage1)
+    allocate(state%var(nVarsIRFbas), stat=ierr, errmsg=cmessage1)
     if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
     do iVar=1,nVarsIRFbas
+      select case(iVar)
+        case(ixIRFbas%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh, nens), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state:'//trim(meta_irf_bas(iVar)%varName); return; endif
+    end do
 
-     select case(iVar)
-      case(ixIRFbas%qfuture); RCHFLX(iens,jSeg)%QFUTURE(:)  = state%var(iVar)%array_3d_dp(iSeg,:,iens)
-      case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
-     end select
-
+    do iVar=1,nVarsIRFbas
+      select case(iVar)
+        case(ixIRFbas%qfuture); call get_nc(fname, meta_irf_bas(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh,nens/), ierr, cmessage1)
+        case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF variable index for nc writing'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf_bas(iVar)%varName); return; endif
     enddo
-   enddo
-  enddo
+
+    do iens=1,nens
+      do iSeg=1,nSeg
+        jSeg = ixRch_order(iSeg)
+        allocate(RCHFLX(iens,jSeg)%QFUTURE(ntdh), stat=ierr, errmsg=cmessage1)
+        if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+        do iVar=1,nVarsIRFbas
+          select case(iVar)
+            case(ixIRFbas%qfuture); RCHFLX(iens,jSeg)%QFUTURE(:)  = state%var(iVar)%array_3d_dp(iSeg,:,iens)
+            case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
+          end select
+        enddo
+      enddo
+    enddo
 
   END SUBROUTINE read_IRFbas_state
 
 
   SUBROUTINE read_IRF_state(ierr, message1)
-  ! meta data
-  USE globalData,  ONLY: meta_irf               ! IRF routing
-  ! Named variables
-  USE var_lookup,  ONLY: ixIRF, nVarsIRF
-  implicit none
-  integer(i4b), intent(out)     :: ierr           ! error code
-  character(*), intent(out)     :: message1       ! error message
-  ! local variables
-  character(len=strLen)         :: cmessage1      ! error message of downwind routine
-  type(states)                  :: state          ! temporal state data structures
-  integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
-  integer(i4b)                  :: jSeg           ! index loops for reaches respectively
-  integer(i4b), allocatable     :: numQF(:,:)     ! number of future Q time steps for each ensemble and segment
-  integer(i4b)                  :: ntdh_irf       ! dimenion sizes
-  integer(i4b)                  :: nTbound=2      ! dimenion sizes
 
-  ierr=0; message1='read_IRF_state/'
+    USE globalData,  ONLY: meta_irf               ! IRF routing
+    USE var_lookup,  ONLY: ixIRF, nVarsIRF
+    implicit none
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b)                  :: jSeg           ! index loops for reaches respectively
+    integer(i4b), allocatable     :: numQF(:,:)     ! number of future Q time steps for each ensemble and segment
+    integer(i4b)                  :: ntdh_irf       ! dimenion sizes
+    integer(i4b)                  :: nTbound=2      ! dimenion sizes
 
-  call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%tdh_irf)%dimName), ntdh_irf, ierr, cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    ierr=0; message1='read_IRF_state/'
 
-  allocate(state%var(nVarsIRF), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%tdh_irf)%dimName), ntdh_irf, ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  allocate(numQF(nens,nSeg), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(state%var(nVarsIRF), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsIRF
-
-   select case(iVar)
-    case(ixIRF%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nens), stat=ierr)
-    case(ixIRF%irfVol);  allocate(state%var(iVar)%array_3d_dp(nSeg, nTbound, nens), stat=ierr)
-    case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-   end select
-   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state:'//trim(meta_irf(iVar)%varName); return; endif
-
-  end do
-
-  call get_nc(fname,'numQF',numQF,(/1,1/),(/nSeg,nens/),ierr,cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':numQF'; return; endif
-
-  do iVar=1,nVarsIRF
-
-   select case(iVar)
-    case(ixIRF%qfuture); call get_nc(fname, meta_irf(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage1)
-    case(ixIRF%irfVol);  call get_nc(fname, meta_irf(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nTbound, nens/), ierr, cmessage1)
-    case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc reading'; return
-   end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf(iVar)%varName); return; endif
-
-  end do
-
-  do iens=1,nens
-   do iSeg=1,nSeg
-
-    jSeg = ixRch_order(iSeg)
-
-    allocate(RCHFLX(iens,jSeg)%QFUTURE_IRF(numQF(iens,iSeg)), stat=ierr, errmsg=cmessage1)
+    allocate(numQF(nens,nSeg), stat=ierr, errmsg=cmessage1)
     if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
     do iVar=1,nVarsIRF
+      select case(iVar)
+        case(ixIRF%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nens), stat=ierr)
+        case(ixIRF%vol);     allocate(state%var(iVar)%array_3d_dp(nSeg, nTbound, nens), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state:'//trim(meta_irf(iVar)%varName); return; endif
+    end do
 
-     select case(iVar)
-      case(ixIRF%qfuture); RCHFLX(iens,jSeg)%QFUTURE_IRF    = state%var(iVar)%array_3d_dp(iSeg,1:numQF(iens,iSeg),iens)
-      case(ixIRF%irfVol);  RCHFLX(iens,jSeg)%REACH_VOL(0:1) = state%var(iVar)%array_3d_dp(iSeg,1:2,iens)
-      case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-     end select
+    call get_nc(fname,'numQF',numQF,(/1,1/),(/nSeg,nens/),ierr,cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':numQF'; return; endif
 
-    enddo ! variable loop
-   enddo ! seg loop
-  enddo ! ensemble loop
+    do iVar=1,nVarsIRF
+      select case(iVar)
+        case(ixIRF%qfuture); call get_nc(fname, meta_irf(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage1)
+        case(ixIRF%vol);     call get_nc(fname, meta_irf(iVar)%varName, state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nTbound, nens/), ierr, cmessage1)
+        case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc reading'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_irf(iVar)%varName); return; endif
+    end do
+
+    do iens=1,nens
+      do iSeg=1,nSeg
+        jSeg = ixRch_order(iSeg)
+        allocate(RCHFLX(iens,jSeg)%QFUTURE_IRF(numQF(iens,iSeg)), stat=ierr, errmsg=cmessage1)
+        if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+        do iVar=1,nVarsIRF
+          select case(iVar)
+            case(ixIRF%qfuture); RCHFLX(iens,jSeg)%QFUTURE_IRF    = state%var(iVar)%array_3d_dp(iSeg,1:numQF(iens,iSeg),iens)
+            case(ixIRF%vol);     RCHFLX(iens,jSeg)%REACH_VOL(0:1) = state%var(iVar)%array_3d_dp(iSeg,1:2,iens)
+            case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+          end select
+        enddo ! variable loop
+      enddo ! seg loop
+    enddo ! ensemble loop
 
   END SUBROUTINE read_IRF_state
 
-
   SUBROUTINE read_KWT_state(ierr, message1)
-  ! meta data
-  USE globalData, ONLY: meta_kwt                  ! kwt routing
-  ! Named variables
-  USE var_lookup, ONLY: ixKWT, nVarsKWT
-  implicit none
-  integer(i4b), intent(out)     :: ierr           ! error code
-  character(*), intent(out)     :: message1       ! error message
-  ! local variables
-  character(len=strLen)         :: cmessage1      ! error message of downwind routine
-  type(states)                  :: state          ! temporal state data structures
-  integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
-  integer(i4b)                  :: jSeg           ! index loops for reaches respectively
-  integer(i4b)                  :: nwave          ! dimenion sizes
-  integer(i4b), allocatable     :: RFvec(:)       ! temporal vector
-  integer(i4b), allocatable     :: numWaves(:,:)  ! number of waves for each ensemble and segment
 
-  ierr=0; message1='read_KWT_state/'
+    USE globalData, ONLY: meta_kwt                  ! kwt routing
+    USE var_lookup, ONLY: ixKWT, nVarsKWT
+    implicit none
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b)                  :: jSeg           ! index loops for reaches respectively
+    integer(i4b)                  :: nwave          ! dimenion sizes
+    integer(i4b), allocatable     :: RFvec(:)       ! temporal vector
+    integer(i4b), allocatable     :: numWaves(:,:)  ! number of waves for each ensemble and segment
 
-  allocate(state%var(nVarsKWT), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    ierr=0; message1='read_KWT_state/'
 
-  allocate(numWaves(nens,nSeg), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(state%var(nVarsKWT), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  ! get Dimension sizes
-  call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%wave)%dimName), nwave, ierr, cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(numWaves(nens,nSeg), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsKWT
-
-    select case(iVar)
-     case(ixKWT%routed); allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
-     case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
-      allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
-     case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWT routing state:'//trim(meta_kwt(iVar)%varName); return; endif
-  end do
-
-  call get_nc(fname,'numWaves',numWaves, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//'numWaves'; return; endif
-
-  do iVar=1,nVarsKWT
-
-    select case(iVar)
-     case(ixKWT%routed)
-      call get_nc(fname,trim(meta_kwt(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
-     case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
-      call get_nc(fname,trim(meta_kwt(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
-     case default; ierr=20; message1=trim(message1)//'unable to identify KWT variable index for nc reading'; return
-    end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_kwt(iVar)%varName); return; endif
-  end do
-
-  do iens=1,nens
-   do iSeg=1,nSeg
-
-    jSeg = ixRch_order(iSeg)
-
-    allocate(RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1), stat=ierr)
+    ! get Dimension sizes
+    call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%wave)%dimName), nwave, ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
     do iVar=1,nVarsKWT
+      select case(iVar)
+        case(ixKWT%routed); allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
+        case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
+          allocate(state%var(iVar)%array_3d_dp(nSeg, nwave, nens), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWT routing state:'//trim(meta_kwt(iVar)%varName); return; endif
+    end do
 
-     select case(iVar)
-      case(ixKWT%tentry);    RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%TI = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-      case(ixKWT%texit);     RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%TR = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-      case(ixKWT%qwave);     RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%QF = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-      case(ixKWT%qwave_mod); RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%QM = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
-      case(ixKWT%routed) ! this is suppposed to be logical variable, but put it as 0 or 1 in double now
-       if (allocated(RFvec)) deallocate(RFvec, stat=ierr)
-       allocate(RFvec(0:numWaves(iens,iSeg)-1),stat=ierr)
-       RFvec = nint(state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens))
-       RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.False.
-       where (RFvec==1_i4b) RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.True.
-      case default; ierr=20; message1=trim(message1)//'unable to identify KWT routing state variable index'; return
-     end select
+    call get_nc(fname,'numWaves',numWaves, (/1,1/), (/nSeg,nens/), ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//'numWaves'; return; endif
 
+    do iVar=1,nVarsKWT
+      select case(iVar)
+        case(ixKWT%routed)
+          call get_nc(fname,trim(meta_kwt(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
+        case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
+          call get_nc(fname,trim(meta_kwt(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nwave,nens/), ierr, cmessage1)
+        case default; ierr=20; message1=trim(message1)//'unable to identify KWT variable index for nc reading'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_kwt(iVar)%varName); return; endif
+    end do
+
+    do iens=1,nens
+      do iSeg=1,nSeg
+        jSeg = ixRch_order(iSeg)
+        allocate(RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1), stat=ierr)
+        do iVar=1,nVarsKWT
+          select case(iVar)
+            case(ixKWT%tentry);    RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%TI = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+            case(ixKWT%texit);     RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%TR = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+            case(ixKWT%qwave);     RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%QF = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+            case(ixKWT%qwave_mod); RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%QM = state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens)
+            case(ixKWT%routed) ! this is suppposed to be logical variable, but put it as 0 or 1 in double now
+              if (allocated(RFvec)) deallocate(RFvec, stat=ierr)
+              allocate(RFvec(0:numWaves(iens,iSeg)-1),stat=ierr)
+              RFvec = nint(state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens))
+              RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.False.
+              where (RFvec==1_i4b) RCHSTA(iens,jSeg)%LKW_ROUTE%KWAVE(0:numWaves(iens,iSeg)-1)%RF=.True.
+            case default; ierr=20; message1=trim(message1)//'unable to identify KWT routing state variable index'; return
+          end select
+        enddo
+      enddo
     enddo
-   enddo
-  enddo
 
   END SUBROUTINE read_KWT_state
 
-  SUBROUTINE read_KWE_state(ierr, message1)
-  ! meta data
-  USE globalData, ONLY: meta_kwe                  ! kwt routing
-  ! Named variables
-  USE var_lookup, ONLY: ixKWE, nVarsKWE
-  implicit none
-  integer(i4b), intent(out)     :: ierr           ! error code
-  character(*), intent(out)     :: message1       ! error message
-  ! local variables
-  character(len=strLen)         :: cmessage1      ! error message of downwind routine
-  type(states)                  :: state          ! temporal state data structures
-  integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
-  integer(i4b)                  :: jSeg           ! index loops for reaches respectively
-  integer(i4b)                  :: nMesh          ! dimenion sizes
+  SUBROUTINE read_KW_state(ierr, message1)
 
-  ierr=0; message1='read_KWE_state/'
+    USE globalData, ONLY: meta_kw
+    USE globalData, ONLY: nMolecule
+    USE var_lookup, ONLY: ixKW, nVarsKW
+    implicit none
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b)                  :: jSeg           ! index loops for reaches respectively
 
-  allocate(state%var(nVarsKWE), stat=ierr, errmsg=cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    ierr=0; message1='read_KW_state/'
 
-  ! get Dimension sizes
-  call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%fdmesh)%dimName), nMesh, ierr, cmessage1)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+    allocate(state%var(nVarsKW), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-  do iVar=1,nVarsKWE
+    ! get Dimension sizes
+    call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%fdmesh)%dimName), nMolecule, ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
 
-    select case(iVar)
-     case(ixKWE%a); allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nens), stat=ierr)
-     case(ixKWE%q); allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nens), stat=ierr)
-     case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWE routing state:'//trim(meta_kwe(iVar)%varName); return; endif
-  end do
+    do iVar=1,nVarsKW
+      select case(iVar)
+        case(ixKW%qsub); allocate(state%var(iVar)%array_3d_dp(nSeg, nMolecule, nens), stat=ierr)
+        case(ixKW%vol)
+        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KW routing state:'//trim(meta_kw(iVar)%varName); return; endif
+    end do
 
-  do iVar=1,nVarsKWE
+    do iVar=1,nVarsKW
+      select case(iVar)
+        case(ixKW%qsub); call get_nc(fname,trim(meta_kw(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMolecule,nens/), ierr, cmessage1)
+        case(ixKW%vol)
+        case default; ierr=20; message1=trim(message1)//'unable to identify KW variable index for nc reading'; return
+      end select
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_kw(iVar)%varName); return; endif
+    end do
 
-    select case(iVar)
-     case(ixKWE%a)
-      call get_nc(fname,trim(meta_kwe(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMesh,nens/), ierr, cmessage1)
-     case(ixKWE%q)
-      call get_nc(fname,trim(meta_kwe(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMesh,nens/), ierr, cmessage1)
-     case default; ierr=20; message1=trim(message1)//'unable to identify KWE variable index for nc reading'; return
-    end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_kwe(iVar)%varName); return; endif
-  end do
-
-  do iens=1,nens
-   do iSeg=1,nSeg
-
-    jSeg = ixRch_order(iSeg)
-
-    do iVar=1,nVarsKWE
-
-     select case(iVar)
-      case(ixKWE%a);    RCHSTA(iens,jSeg)%EKW_ROUTE%A(:) = state%var(iVar)%array_3d_dp(iSeg,1:4,iens)
-      case(ixKWE%q);    RCHSTA(iens,jSeg)%EKW_ROUTE%Q(:) = state%var(iVar)%array_3d_dp(iSeg,1:4,iens)
-      case default; ierr=20; message1=trim(message1)//'unable to identify KWE routing state variable index'; return
-     end select
-
+    do iens=1,nens
+      do iSeg=1,nSeg
+        jSeg = ixRch_order(iSeg)
+        allocate(RCHSTA(iens,jSeg)%molecule%Q(nMolecule), stat=ierr, errmsg=cmessage1)
+        do iVar=1,nVarsKW
+          select case(iVar)
+            case(ixKW%qsub); RCHSTA(iens,jSeg)%molecule%Q(1:nMolecule) = state%var(iVar)%array_3d_dp(iSeg,1:nMolecule,iens)
+            case(ixKW%vol)
+            case default; ierr=20; message1=trim(message1)//'unable to identify KW routing state variable index'; return
+          end select
+        enddo
+      enddo
     enddo
-   enddo
-  enddo
 
-  END SUBROUTINE read_KWE_state
+  END SUBROUTINE read_KW_state
+
+  SUBROUTINE read_MC_state(ierr, message1)
+
+    USE globalData, ONLY: meta_mc
+    USE globalData, ONLY: nMolecule
+    USE var_lookup, ONLY: ixMC, nVarsMC
+    implicit none
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b)                  :: jSeg           ! index loops for reaches respectively
+
+    ierr=0; message1='read_MC_state/'
+
+    allocate(state%var(nVarsMC), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+
+    ! get Dimension sizes
+    call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%fdmesh)%dimName), nMolecule, ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+
+    do iVar=1,nVarsMC
+      select case(iVar)
+        case(ixMC%qsub); allocate(state%var(iVar)%array_3d_dp(nSeg, nMolecule, nens), stat=ierr)
+        case(ixMC%vol)
+        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for MC routing state:'//trim(meta_mc(iVar)%varName); return; endif
+    end do
+
+    do iVar=1,nVarsMC
+      select case(iVar)
+        case(ixMC%qsub); call get_nc(fname,trim(meta_mc(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMolecule,nens/), ierr, cmessage1)
+        case(ixMC%vol)
+        case default; ierr=20; message1=trim(message1)//'unable to identify MC variable index for nc reading'; return
+      end select
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_mc(iVar)%varName); return; endif
+    end do
+
+    do iens=1,nens
+      do iSeg=1,nSeg
+        jSeg = ixRch_order(iSeg)
+        allocate(RCHSTA(iens,jSeg)%molecule%Q(nMolecule), stat=ierr, errmsg=cmessage1)
+        do iVar=1,nVarsMC
+          select case(iVar)
+            case(ixMC%qsub); RCHSTA(iens,jSeg)%molecule%Q(:) = state%var(iVar)%array_3d_dp(iSeg,1:nMolecule,iens)
+            case(ixMC%vol)
+            case default; ierr=20; message1=trim(message1)//'unable to identify MC routing state variable index'; return
+          end select
+        enddo
+      enddo
+    enddo
+
+  END SUBROUTINE read_MC_state
+
+  SUBROUTINE read_DW_state(ierr, message1)
+
+    USE globalData, ONLY: meta_dw
+    USE globalData, ONLY: nMolecule
+    USE var_lookup, ONLY: ixDW, nVarsDW
+    implicit none
+    integer(i4b), intent(out)     :: ierr           ! error code
+    character(*), intent(out)     :: message1       ! error message
+    ! local variables
+    character(len=strLen)         :: cmessage1      ! error message of downwind routine
+    type(states)                  :: state          ! temporal state data structures
+    integer(i4b)                  :: iVar,iens,iSeg ! index loops for variables, ensembles, reaches respectively
+    integer(i4b)                  :: jSeg           ! index loops for reaches respectively
+
+    ierr=0; message1='read_DW_state/'
+
+    allocate(state%var(nVarsDW), stat=ierr, errmsg=cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+
+    ! get Dimension sizes
+    call get_nc_dim_len(fname, trim(meta_stateDims(ixStateDims%fdmesh)%dimName), nMolecule, ierr, cmessage1)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
+
+    do iVar=1,nVarsDW
+      select case(iVar)
+        case(ixDW%qsub); allocate(state%var(iVar)%array_3d_dp(nSeg, nMolecule, nens), stat=ierr)
+        case(ixDW%vol)
+        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for DW routing state:'//trim(meta_dw(iVar)%varName); return; endif
+    end do
+
+    do iVar=1,nVarsDW
+      select case(iVar)
+        case(ixDW%qsub); call get_nc(fname,trim(meta_dw(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMolecule,nens/), ierr, cmessage1)
+        case(ixDW%vol)
+        case default; ierr=20; message1=trim(message1)//'unable to identify DW variable index for nc reading'; return
+      end select
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage1)//':'//trim(meta_dw(iVar)%varName); return; endif
+    end do
+
+    do iens=1,nens
+      do iSeg=1,nSeg
+        jSeg = ixRch_order(iSeg)
+        allocate(RCHSTA(iens,jSeg)%molecule%Q(nMolecule), stat=ierr, errmsg=cmessage1)
+        do iVar=1,nVarsDW
+          select case(iVar)
+            case(ixDW%qsub); RCHSTA(iens,jSeg)%molecule%Q(:) = state%var(iVar)%array_3d_dp(iSeg,1:nMolecule,iens)
+            case(ixDW%vol)
+            case default; ierr=20; message1=trim(message1)//'unable to identify DW routing state variable index'; return
+          end select
+        enddo
+      enddo
+    enddo
+
+  END SUBROUTINE read_DW_state
 
  END SUBROUTINE read_state_nc
 

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -4,10 +4,12 @@ MODULE write_restart_pio
 USE nrtype
 
 USE var_lookup,        ONLY: ixStateDims, nStateDims
-USE var_lookup,        ONLY: ixIRF, nVarsIRF
 USE var_lookup,        ONLY: ixIRFbas, nVarsIRFbas
-USE var_lookup,        ONLY: ixKWE, nVarsKWE
+USE var_lookup,        ONLY: ixIRF, nVarsIRF
 USE var_lookup,        ONLY: ixKWT, nVarsKWT
+USE var_lookup,        ONLY: ixKW, nVarsKW
+USE var_lookup,        ONLY: ixMC, nVarsMC
+USE var_lookup,        ONLY: ixDW, nVarsDW
 USE var_lookup,        ONLY: ixIRFbas, nVarsIRFbas
 USE var_lookup,        ONLY: ixBasinQ, nVarsBasinQ
 
@@ -24,11 +26,13 @@ USE public_var,        ONLY: verySmall
 USE public_var,        ONLY: rpntfil           ! ascii containing last restart file (used in coupled mode)
 
 USE globalData,        ONLY: meta_stateDims  ! states dimension meta
-USE globalData,        ONLY: meta_irf        ! IRF routing
 USE globalData,        ONLY: meta_irf_bas
 USE globalData,        ONLY: meta_basinQ
+USE globalData,        ONLY: meta_irf
 USE globalData,        ONLY: meta_kwt
-USE globalData,        ONLY: meta_kwe
+USE globalData,        ONLY: meta_kw
+USE globalData,        ONLY: meta_mc
+USE globalData,        ONLY: meta_dw
 
 USE globalData,        ONLY: pid, nNodes
 USE globalData,        ONLY: masterproc
@@ -177,7 +181,7 @@ CONTAINS
   call define_state_nc(fnameRestart, ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-  call write_state_nc(fnameRestart, ierr, message)
+  call write_state_nc(fnameRestart, ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   open (1, file = trim(restart_dir)//trim(rpntfil), status='replace', action='write')
@@ -247,9 +251,11 @@ CONTAINS
  USE public_var, ONLY: routOpt
  USE public_var, ONLY: allRoutingMethods
  USE public_var, ONLY: doesBasinRoute
- USE public_var, ONLY: kinematicWave
- USE public_var, ONLY: kinematicWaveEuler
  USE public_var, ONLY: impulseResponseFunc
+ USE public_var, ONLY: kinematicWaveTracking
+ USE public_var, ONLY: kinematicWave
+ USE public_var, ONLY: muskingumCunge
+ USE public_var, ONLY: diffusiveWave
  USE globalData, ONLY: rch_per_proc             ! number of reaches assigned to each proc (size = num of procs+1)
  USE globalData, ONLY: nRch                     ! number of ensembles and river reaches
 
@@ -320,33 +326,40 @@ CONTAINS
 
  end associate
 
- ! Routing specific variables --------------
  ! previous-time step hru inflow into reach
  call define_basinQ_state(ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
+ ! Routing specific variables --------------
  ! basin IRF
  if (doesBasinRoute == 1) then
-  call define_IRFbas_state(ierr, cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   call define_IRFbas_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
 
- ! KWT routing
- if (routOpt==allRoutingMethods .or. routOpt==kinematicWave) then
-  call define_KWT_state(ierr, cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
- end if
-
- ! KWE routing
- if (routOpt==kinematicWaveEuler) then
-  call define_KWE_state(ierr, cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
- end if
-
- ! IRF routing
  if (routOpt==allRoutingMethods .or. routOpt==impulseResponseFunc) then
-  call define_IRF_state(ierr, cmessage)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   call define_IRF_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
+ if (routOpt==allRoutingMethods .or. routOpt==kinematicWaveTracking) then
+   call define_KWT_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
+ if (routOpt==kinematicWave) then
+   call define_KW_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
+ if (routOpt==muskingumCunge) then
+   call define_MC_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
+ if (routOpt==diffusiveWave) then
+   call define_DW_state(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
 
  ! ----------------------------------
@@ -382,29 +395,13 @@ CONTAINS
                  ixRch(ix1:ix2),         & ! input:
                  iodesc_state_int)
 
- if (routOpt==allRoutingMethods .or. routOpt==kinematicWave) then
-   ! type: int, dim: [dim_seg, dim_wave, dim_ens]
-   call pio_decomp(pioSystem,              & ! input: pio system descriptor
-                   ncd_int,                & ! input: data type (pio_int, pio_real, pio_double, pio_char)
-                   [nSeg,nWave,nEns],      & ! input: dimension length == global array size
-                   ixRch(ix1:ix2),         & ! input:
-                   iodesc_wave_int)
-
-   ! type: float, dim: [dim_seg, dim_wave, dim_ens]
+ if (doesBasinRoute == 1) then
+   ! type: float dim: [dim_seg, dim_tdh_irf, dim_ens]
    call pio_decomp(pioSystem,              & ! input: pio system descriptor
                    ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
-                   [nSeg,nWave,nEns],      & ! input: dimension length == global array size
+                   [nSeg,ntdh,nEns],       & ! input: dimension length == global array size
                    ixRch(ix1:ix2),         & ! input:
-                   iodesc_wave_double)
- end if
-
- if (routOpt==kinematicWaveEuler) then
-   ! type: float, dim: [dim_seg, dim_fdmesh, dim_ens]
-   call pio_decomp(pioSystem,              & ! input: pio system descriptor
-                   ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
-                   [nSeg,nFdmesh,nEns],    & ! input: dimension length == global array size
-                   ixRch(ix1:ix2),         & ! input:
-                   iodesc_mesh_double)
+                   iodesc_irf_bas_double)
  end if
 
  if (routOpt==allRoutingMethods .or. routOpt==impulseResponseFunc) then
@@ -423,13 +420,29 @@ CONTAINS
                    iodesc_vol_double)
  end if
 
- if (doesBasinRoute == 1) then
-   ! type: float dim: [dim_seg, dim_tdh_irf, dim_ens]
+ if (routOpt==allRoutingMethods .or. routOpt==kinematicWaveTracking) then
+   ! type: int, dim: [dim_seg, dim_wave, dim_ens]
+   call pio_decomp(pioSystem,              & ! input: pio system descriptor
+                   ncd_int,                & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                   [nSeg,nWave,nEns],      & ! input: dimension length == global array size
+                   ixRch(ix1:ix2),         & ! input:
+                   iodesc_wave_int)
+
+   ! type: float, dim: [dim_seg, dim_wave, dim_ens]
    call pio_decomp(pioSystem,              & ! input: pio system descriptor
                    ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
-                   [nSeg,ntdh,nEns],       & ! input: dimension length == global array size
+                   [nSeg,nWave,nEns],      & ! input: dimension length == global array size
                    ixRch(ix1:ix2),         & ! input:
-                   iodesc_irf_bas_double)
+                   iodesc_wave_double)
+ end if
+
+ if (routOpt==kinematicWave .or. routOpt==muskingumCunge .or. routOpt==diffusiveWave) then
+   ! type: float, dim: [dim_seg, dim_fdmesh, dim_ens]
+   call pio_decomp(pioSystem,              & ! input: pio system descriptor
+                   ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                   [nSeg,nFdmesh,nEns],    & ! input: dimension length == global array size
+                   ixRch(ix1:ix2),         & ! input:
+                   iodesc_mesh_double)
  end if
 
  end associate
@@ -443,6 +456,7 @@ CONTAINS
   SUBROUTINE set_dim_len(ixDim, ierr, message1)
    ! populate state netCDF dimension size
    USE public_var, ONLY: MAXQPAR
+   USE globalData, ONLY: nMolecule
    USE globalData, ONLY: FRAC_FUTURE     ! To get size of q future for basin IRF
    USE globalData, ONLY: nEns, nRch      ! number of ensembles and river reaches
    implicit none
@@ -450,7 +464,7 @@ CONTAINS
    integer(i4b), intent(in)   :: ixDim    ! ixDim
    ! output
    integer(i4b), intent(out)  :: ierr     ! error code
-   character(*), intent(out)  :: message1  ! error message
+   character(*), intent(out)  :: message1 ! error message
 
    ierr=0; message1='set_dim_len/'
 
@@ -460,7 +474,7 @@ CONTAINS
     case(ixStateDims%tbound);  meta_stateDims(ixStateDims%tbound)%dimLength  = 2
     case(ixStateDims%tdh);     meta_stateDims(ixStateDims%tdh)%dimLength     = size(FRAC_FUTURE)
     case(ixStateDims%tdh_irf); meta_stateDims(ixStateDims%tdh_irf)%dimLength = 20   !just temporarily
-    case(ixStateDims%fdmesh);  meta_stateDims(ixStateDims%fdmesh)%dimLength  = 4
+    case(ixStateDims%fdmesh);  meta_stateDims(ixStateDims%fdmesh)%dimLength  = nMolecule
     case(ixStateDims%wave);    meta_stateDims(ixStateDims%wave)%dimLength    = MAXQPAR
     case default; ierr=20; message1=trim(message1)//'unable to identify dimension variable index'; return
    end select
@@ -538,45 +552,49 @@ CONTAINS
 
   END SUBROUTINE define_IRFbas_state
 
-  SUBROUTINE define_KWE_state(ierr, message1)
+  SUBROUTINE define_IRF_state(ierr, message1)
    implicit none
    ! output
-   integer(i4b), intent(out)         :: ierr          ! error code
-   character(*), intent(out)         :: message1      ! error message
+   integer(i4b), intent(out)         :: ierr        ! error code
+   character(*), intent(out)         :: message1    ! error message
    ! local
-   integer(i4b)                      :: iVar,ixDim    ! index loop for variables
-   integer(i4b)                      :: nDims         ! number of dimensions
-   integer(i4b),allocatable          :: dim_KWE(:)    ! dimension Id array
+   integer(i4b)                      :: iVar,ixDim  ! index loop for variables
+   integer(i4b)                      :: nDims       ! number of dimensions
+   integer(i4b),allocatable          :: dim_set(:)  ! dimensions combination case 4
 
-   ierr=0; message1='define_KWE_state/'
+   ierr=0; message1='define_IRF_state/'
 
-   ! Check dimension length is populated
-   if (meta_stateDims(ixStateDims%fdmesh)%dimLength == integerMissing) then
-     call set_dim_len(ixStateDims%fdmesh, ierr, cmessage)
-     if(ierr/=0)then; message1=trim(message1)//trim(cmessage)//' for '//trim(meta_stateDims(ixStateDims%fdmesh)%dimName); return; endif
-   end if
+   ! Define dimension needed for this routing specific state variables
+   if (meta_stateDims(ixStateDims%tdh_irf)%dimLength == integerMissing) then
+     call set_dim_len(ixStateDims%tdh_irf, ierr, cmessage)
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage)//' for '//trim(meta_stateDims(ixStateDims%tdh_irf)%dimName); return; endif
+   endif
 
-   call def_dim(pioFileDescState, trim(meta_stateDims(ixStateDims%fdmesh)%dimName), meta_stateDims(ixStateDims%fdmesh)%dimLength, meta_stateDims(ixStateDims%fdmesh)%dimId)
+   call def_dim(pioFileDescState, trim(meta_stateDims(ixStateDims%tdh_irf)%dimName), meta_stateDims(ixStateDims%tdh_irf)%dimLength, meta_stateDims(ixStateDims%tdh_irf)%dimId)
    if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
 
-   do iVar=1,nVarsKWE
+   associate(dim_seg     => meta_stateDims(ixStateDims%seg)%dimId,     &
+             dim_ens     => meta_stateDims(ixStateDims%ens)%dimId,     &
+             dim_tdh_irf => meta_stateDims(ixStateDims%tdh_irf)%dimId)
 
-     nDims = size(meta_KWE(iVar)%varDim)
-     if (allocated(dim_KWE)) then
-       deallocate(dim_KWE)
-     end if
-     allocate(dim_KWE(nDims))
+   call def_var(pioFileDescState, 'numQF', ncd_int, ierr, cmessage, pioDimId=[dim_seg,dim_ens], vdesc='number of future q time steps in a reach', vunit='-')
+   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
+   do iVar=1,nVarsIRF
+     nDims = size(meta_irf(iVar)%varDim)
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
      do ixDim = 1, nDims
-       dim_KWE(ixDim) = meta_stateDims(meta_KWE(iVar)%varDim(ixDim))%dimId
+       dim_set(ixDim) = meta_stateDims(meta_irf(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, trim(meta_KWE(iVar)%varName), meta_KWE(iVar)%varType, ierr, cmessage, pioDimId=dim_KWE, vdesc=trim(meta_KWE(iVar)%varDesc), vunit=trim(meta_KWE(iVar)%varUnit))
+     call def_var(pioFileDescState, trim(meta_irf(iVar)%varName), meta_irf(iVar)%varType, ierr, cmessage, pioDimId=dim_set, vdesc=trim(meta_irf(iVar)%varDesc), vunit=trim(meta_irf(iVar)%varUnit))
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-
    end do
 
-  END SUBROUTINE define_KWE_state
+   end associate
+
+  END SUBROUTINE define_IRF_state
 
   SUBROUTINE define_KWT_state(ierr, message1)
    implicit none
@@ -586,7 +604,7 @@ CONTAINS
    ! local
    integer(i4b)                      :: iVar,ixDim  ! index loop for variables
    integer(i4b)                      :: nDims       ! number of dimensions
-   integer(i4b),allocatable          :: dim_kwt(:)  ! dimensions ID array
+   integer(i4b),allocatable          :: dim_set(:)  ! dimensions ID array
 
    ierr=0; message1='define_KWT_state/'
 
@@ -608,72 +626,128 @@ CONTAINS
    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
    do iVar=1,nVarsKWT
-
      nDims = size(meta_kwt(iVar)%varDim)
-     if (allocated(dim_kwt)) then
-       deallocate(dim_kwt)
-     endif
-     allocate(dim_kwt(nDims))
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
      do ixDim = 1, nDims
-       dim_kwt(ixDim) = meta_stateDims(meta_kwt(iVar)%varDim(ixDim))%dimId
+       dim_set(ixDim) = meta_stateDims(meta_kwt(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, trim(meta_kwt(iVar)%varName), meta_kwt(iVar)%varType, ierr, cmessage, pioDimId=dim_kwt, vdesc=trim(meta_kwt(iVar)%varDesc), vunit=trim(meta_kwt(iVar)%varUnit))
+     call def_var(pioFileDescState, trim(meta_kwt(iVar)%varName), meta_kwt(iVar)%varType, ierr, cmessage, pioDimId=dim_set, vdesc=trim(meta_kwt(iVar)%varDesc), vunit=trim(meta_kwt(iVar)%varUnit))
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-
    end do
 
    end associate
 
   END SUBROUTINE define_KWT_state
 
-  SUBROUTINE define_IRF_state(ierr, message1)
+  SUBROUTINE define_KW_state(ierr, message1)
    implicit none
    ! output
-   integer(i4b), intent(out)         :: ierr        ! error code
-   character(*), intent(out)         :: message1    ! error message
+   integer(i4b), intent(out)         :: ierr          ! error code
+   character(*), intent(out)         :: message1      ! error message
    ! local
-   integer(i4b)                      :: iVar,ixDim  ! index loop for variables
-   integer(i4b)                      :: nDims       ! number of dimensions
-   integer(i4b),allocatable          :: dim_irf(:)  ! dimensions combination case 4
+   integer(i4b)                      :: iVar,ixDim    ! index loop for variables
+   integer(i4b)                      :: nDims         ! number of dimensions
+   integer(i4b),allocatable          :: dim_set(:)    ! dimension Id array
 
-   ierr=0; message1='define_IRF_state/'
+   ierr=0; message1='define_KW_state/'
 
-   ! Define dimension needed for this routing specific state variables
-   if (meta_stateDims(ixStateDims%tdh_irf)%dimLength == integerMissing) then
-     call set_dim_len(ixStateDims%tdh_irf, ierr, cmessage)
-     if(ierr/=0)then; message1=trim(message1)//trim(cmessage)//' for '//trim(meta_stateDims(ixStateDims%tdh_irf)%dimName); return; endif
-   endif
+   ! Check dimension length is populated
+   if (meta_stateDims(ixStateDims%fdmesh)%dimLength == integerMissing) then
+     call set_dim_len(ixStateDims%fdmesh, ierr, cmessage)
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage)//' for '//trim(meta_stateDims(ixStateDims%fdmesh)%dimName); return; endif
+   end if
 
-   call def_dim(pioFileDescState, trim(meta_stateDims(ixStateDims%tdh_irf)%dimName), meta_stateDims(ixStateDims%tdh_irf)%dimLength, meta_stateDims(ixStateDims%tdh_irf)%dimId)
+   call def_dim(pioFileDescState, trim(meta_stateDims(ixStateDims%fdmesh)%dimName), meta_stateDims(ixStateDims%fdmesh)%dimLength, meta_stateDims(ixStateDims%fdmesh)%dimId)
    if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
 
-   associate(dim_seg     => meta_stateDims(ixStateDims%seg)%dimId,     &
-             dim_ens     => meta_stateDims(ixStateDims%ens)%dimId,     &
-             dim_tdh_irf => meta_stateDims(ixStateDims%tdh_irf)%dimId)
+   do iVar=1,nVarsKW
+     nDims = size(meta_KW(iVar)%varDim)
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
 
-   call def_var(pioFileDescState, 'numQF', ncd_int, ierr, cmessage, pioDimId=[dim_seg,dim_ens], vdesc='number of future q time steps in a reach', vunit='-')
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-
-   do iVar=1,nVarsIRF
-
-     nDims = size(meta_irf(iVar)%varDim)
-     if (allocated(dim_irf)) then
-       deallocate(dim_irf)
-     endif
-     allocate(dim_irf(nDims))
      do ixDim = 1, nDims
-       dim_irf(ixDim) = meta_stateDims(meta_irf(iVar)%varDim(ixDim))%dimId
+       dim_set(ixDim) = meta_stateDims(meta_KW(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, trim(meta_irf(iVar)%varName), meta_irf(iVar)%varType, ierr, cmessage, pioDimId=dim_irf, vdesc=trim(meta_irf(iVar)%varDesc), vunit=trim(meta_irf(iVar)%varUnit))
+     call def_var(pioFileDescState, trim(meta_KW(iVar)%varName), meta_KW(iVar)%varType, ierr, cmessage, pioDimId=dim_set, vdesc=trim(meta_KW(iVar)%varDesc), vunit=trim(meta_KW(iVar)%varUnit))
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-
    end do
 
-   end associate
+  END SUBROUTINE define_KW_state
 
-  END SUBROUTINE define_IRF_state
+  SUBROUTINE define_MC_state(ierr, message1)
+   implicit none
+   ! output
+   integer(i4b), intent(out)         :: ierr          ! error code
+   character(*), intent(out)         :: message1      ! error message
+   ! local
+   integer(i4b)                      :: iVar,ixDim    ! index loop for variables
+   integer(i4b)                      :: nDims         ! number of dimensions
+   integer(i4b),allocatable          :: dim_set(:)    ! dimension Id array
+
+   ierr=0; message1='define_MC_state/'
+
+   ! Check dimension length is populated
+   if (meta_stateDims(ixStateDims%fdmesh)%dimLength == integerMissing) then
+     call set_dim_len(ixStateDims%fdmesh, ierr, cmessage)
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage)//' for '//trim(meta_stateDims(ixStateDims%fdmesh)%dimName); return; endif
+   end if
+
+   call def_dim(pioFileDescState, trim(meta_stateDims(ixStateDims%fdmesh)%dimName), meta_stateDims(ixStateDims%fdmesh)%dimLength, meta_stateDims(ixStateDims%fdmesh)%dimId)
+   if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
+
+   do iVar=1,nVarsMC
+     nDims = size(meta_mc(iVar)%varDim)
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
+
+     do ixDim = 1, nDims
+       dim_set(ixDim) = meta_stateDims(meta_mc(iVar)%varDim(ixDim))%dimId
+     end do
+
+     call def_var(pioFileDescState, trim(meta_mc(iVar)%varName), meta_mc(iVar)%varType, ierr, cmessage, pioDimId=dim_set, vdesc=trim(meta_mc(iVar)%varDesc), vunit=trim(meta_mc(iVar)%varUnit))
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+   end do
+
+  END SUBROUTINE define_MC_state
+
+  SUBROUTINE define_DW_state(ierr, message1)
+   implicit none
+   ! output
+   integer(i4b), intent(out)         :: ierr          ! error code
+   character(*), intent(out)         :: message1      ! error message
+   ! local
+   integer(i4b)                      :: iVar,ixDim    ! index loop for variables
+   integer(i4b)                      :: nDims         ! number of dimensions
+   integer(i4b),allocatable          :: dim_set(:)    ! dimension Id array
+
+   ierr=0; message1='define_DW_state/'
+
+   ! Check dimension length is populated
+   if (meta_stateDims(ixStateDims%fdmesh)%dimLength == integerMissing) then
+     call set_dim_len(ixStateDims%fdmesh, ierr, cmessage)
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage)//' for '//trim(meta_stateDims(ixStateDims%fdmesh)%dimName); return; endif
+   end if
+
+   call def_dim(pioFileDescState, trim(meta_stateDims(ixStateDims%fdmesh)%dimName), meta_stateDims(ixStateDims%fdmesh)%dimLength, meta_stateDims(ixStateDims%fdmesh)%dimId)
+   if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
+
+   do iVar=1,nVarsDW
+     nDims = size(meta_dw(iVar)%varDim)
+     if (allocated(dim_set)) deallocate(dim_set)
+     allocate(dim_set(nDims))
+
+     do ixDim = 1, nDims
+       dim_set(ixDim) = meta_stateDims(meta_dw(iVar)%varDim(ixDim))%dimId
+     end do
+
+     call def_var(pioFileDescState, trim(meta_dw(iVar)%varName), meta_dw(iVar)%varType, ierr, cmessage, pioDimId=dim_set, vdesc=trim(meta_dw(iVar)%varDesc), vunit=trim(meta_dw(iVar)%varUnit))
+     if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+   end do
+
+  END SUBROUTINE define_DW_state
 
  END SUBROUTINE define_state_nc
 
@@ -689,9 +763,11 @@ CONTAINS
  USE public_var, ONLY: routOpt
  USE public_var, ONLY: doesBasinRoute
  USE public_var, ONLY: allRoutingMethods
- USE public_var, ONLY: kinematicWave
- USE public_var, ONLY: kinematicWaveEuler
  USE public_var, ONLY: impulseResponseFunc
+ USE public_var, ONLY: kinematicWaveTracking
+ USE public_var, ONLY: kinematicWave
+ USE public_var, ONLY: muskingumCunge
+ USE public_var, ONLY: diffusiveWave
  USE globalData, ONLY: RCHFLX_main         ! mainstem reach fluxes (ensembles, reaches)
  USE globalData, ONLY: RCHFLX_trib         ! tributary reach fluxes (ensembles, reaches)
  USE globalData, ONLY: NETOPO_main         ! mainstem reach topology
@@ -792,13 +868,23 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
 
- if (routOpt==kinematicWaveEuler) then
-  call write_KWE_state(ierr, cmessage)
+ if (routOpt==allRoutingMethods .or. routOpt==kinematicWaveTracking) then
+  call write_KWT_state(ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
 
- if (routOpt==allRoutingMethods .or. routOpt==kinematicWave) then
-  call write_KWT_state(ierr, cmessage)
+ if (routOpt==kinematicWave) then
+  call write_KW_state(ierr, cmessage)
+  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
+ if (routOpt==muskingumCunge) then
+  call write_MC_state(ierr, cmessage)
+  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
+
+ if (routOpt==diffusiveWave) then
+  call write_DW_state(ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
 
@@ -806,173 +892,177 @@ CONTAINS
 
  CONTAINS
 
-  ! reach inflow writing procedure
   SUBROUTINE write_basinQ_state(ierr, message1)
-  implicit none
-  ! output
-  integer(i4b), intent(out)  :: ierr            ! error code
-  character(*), intent(out)  :: message1        ! error message
-  ! local variables
-  type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
-  integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
+    implicit none
+    ! output
+    integer(i4b), intent(out)  :: ierr            ! error code
+    character(*), intent(out)  :: message1        ! error message
+    ! local variables
+    type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
+    integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
 
-  ! initialize error control
-  ierr=0; message1='write_basinQ_state/'
+    ! initialize error control
+    ierr=0; message1='write_basinQ_state/'
 
-  associate(nSeg     => size(RCHFLX_local),                         &
-            nens     => meta_stateDims(ixStateDims%ens)%dimLength)
+    associate(nSeg     => size(RCHFLX_local),                         &
+              nens     => meta_stateDims(ixStateDims%ens)%dimLength)
 
-  allocate(state%var(nVarsBasinQ), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    allocate(state%var(nVarsBasinQ), stat=ierr, errmsg=cmessage)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
-  do iVar=1,nVarsBasinQ
-    select case(iVar)
-      case(ixBasinQ%q); allocate(state%var(iVar)%array_2d_dp(nSeg, nEns), stat=ierr)
-      case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state '//trim(meta_basinQ(iVar)%varName); return; endif
-  end do
+    do iVar=1,nVarsBasinQ
+      select case(iVar)
+        case(ixBasinQ%q); allocate(state%var(iVar)%array_2d_dp(nSeg, nEns), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state '//trim(meta_basinQ(iVar)%varName); return; endif
+    end do
 
- ! --Convert data structures to arrays
-  do iens=1,nens
-    do iSeg=1,nSeg
-      do iVar=1,nVarsBasinQ
-        select case(iVar)
-          case(ixBasinQ%q); state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX_local(iSeg)%BASIN_QR(1)
-          case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
-        end select
+    ! --Convert data structures to arrays
+    do iens=1,nens
+      do iSeg=1,nSeg
+        do iVar=1,nVarsBasinQ
+          select case(iVar)
+            case(ixBasinQ%q); state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX_local(iSeg)%BASIN_QR(1)
+            case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
+          end select
+        enddo
       enddo
     enddo
-  enddo
 
-  do iVar=1,nVarsBasinQ
-     select case(iVar)
-      case(ixBasinQ%q); call write_pnetcdf(pioFileDescState, meta_basinQ(iVar)%varName, state%var(iVar)%array_2d_dp, iodesc_state_double, ierr, cmessage)
-      case default; ierr=20; message1=trim(message1)//'unable to identify reach inflow variable index for nc writing'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-  end do
+    do iVar=1,nVarsBasinQ
+      select case(iVar)
+        case(ixBasinQ%q); call write_pnetcdf(pioFileDescState, meta_basinQ(iVar)%varName, state%var(iVar)%array_2d_dp, iodesc_state_double, ierr, cmessage)
+        case default; ierr=20; message1=trim(message1)//'unable to identify reach inflow variable index for nc writing'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    end do
 
-  end associate
+    end associate
 
   END SUBROUTINE write_basinQ_state
 
-  ! Basin IRF writing procedures
   SUBROUTINE write_IRFbas_state(ierr, message1)
-  implicit none
-  ! output
-  integer(i4b), intent(out)  :: ierr            ! error code
-  character(*), intent(out)  :: message1        ! error message
-  ! local variables
-  type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
-  integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
+    implicit none
+    ! output
+    integer(i4b), intent(out)  :: ierr            ! error code
+    character(*), intent(out)  :: message1        ! error message
+    ! local variables
+    type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
+    integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
 
-  ierr=0; message1='write_IRFbas_state/'
+    ierr=0; message1='write_IRFbas_state/'
 
-  associate(nSeg     => size(RCHFLX_local),                         &
-            nEns     => meta_stateDims(ixStateDims%ens)%dimLength,  &
-            ntdh     => meta_stateDims(ixStateDims%tdh)%dimLength)      ! maximum future q time steps among basins
+    associate(nSeg     => size(RCHFLX_local),                         &
+              nEns     => meta_stateDims(ixStateDims%ens)%dimLength,  &
+              ntdh     => meta_stateDims(ixStateDims%tdh)%dimLength)      ! maximum future q time steps among basins
 
-  allocate(state%var(nVarsIRFbas), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    allocate(state%var(nVarsIRFbas), stat=ierr, errmsg=cmessage)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
-  do iVar=1,nVarsIRFbas
+    do iVar=1,nVarsIRFbas
 
-   select case(iVar)
-    case(ixIRFbas%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh, nEns), stat=ierr)
-    case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
-   end select
-   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state '//trim(meta_irf_bas(iVar)%varName); return; endif
+     select case(iVar)
+      case(ixIRFbas%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh, nEns), stat=ierr)
+      case default; ierr=20; message1=trim(message1)//'unable to identify basin routing variable index'; return
+     end select
+     if(ierr/=0)then; message1=trim(message1)//'problem allocating space for basin IRF routing state '//trim(meta_irf_bas(iVar)%varName); return; endif
 
-  end do
+    end do
 
- ! --Convert data structures to arrays
-  do iens=1,nEns
-   do iSeg=1,nSeg
-     do iVar=1,nVarsIRFbas
-      select case(iVar)
-       case(ixIRFbas%qfuture); state%var(iVar)%array_3d_dp(iSeg,:,iens) = RCHFLX_local(iSeg)%QFUTURE
-       case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
-      end select
+    ! --Convert data structures to arrays
+    do iens=1,nEns
+      do iSeg=1,nSeg
+        do iVar=1,nVarsIRFbas
+          select case(iVar)
+            case(ixIRFbas%qfuture); state%var(iVar)%array_3d_dp(iSeg,:,iens) = RCHFLX_local(iSeg)%QFUTURE
+            case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
+          end select
+        enddo
+      enddo
     enddo
-   enddo
-  enddo
 
-  do iVar=1,nVarsIRFbas
+    do iVar=1,nVarsIRFbas
+      select case(iVar)
+        case(ixIRFbas%qfuture); call write_pnetcdf(pioFileDescState, meta_irf_bas(iVar)%varName, state%var(iVar)%array_3d_dp, iodesc_irf_bas_double, ierr, cmessage)
+        case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF variable index for nc writing'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    enddo
 
-   select case(iVar)
-    case(ixIRFbas%qfuture); call write_pnetcdf(pioFileDescState, meta_irf_bas(iVar)%varName, state%var(iVar)%array_3d_dp, iodesc_irf_bas_double, ierr, cmessage)
-    case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF variable index for nc writing'; return
-   end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-
-  enddo
-
-  end associate
+    end associate
 
   END SUBROUTINE write_IRFbas_state
 
-  ! KWE writing procedures
-  SUBROUTINE write_KWE_state(ierr, message1)
-  implicit none
-  ! output
-  integer(i4b), intent(out)  :: ierr            ! error code
-  character(*), intent(out)  :: message1        ! error message
-  ! local variables
-  type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
-  integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
+  SUBROUTINE write_IRF_state(ierr, message1)
+    implicit none
+    ! output
+    integer(i4b), intent(out)  :: ierr            ! error code
+    character(*), intent(out)  :: message1        ! error message
+    ! local variables
+    type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
+    integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
+    integer(i4b), allocatable  :: numQF(:,:)      ! number of future Q time steps for each ensemble and segment
 
-  ierr=0; message1='write_KWE_state/'
+    ierr=0; message1='write_IRF_state/'
 
-  associate(nSeg     => size(RCHFLX_local),                         &
-            nEns     => meta_stateDims(ixStateDims%ens)%dimLength,  &
-            nMesh    => meta_stateDims(ixStateDims%fdmesh)%dimLength)     ! maximum waves allowed in a reach
+    associate(nSeg     => size(RCHFLX_local),                         &
+              nEns     => meta_stateDims(ixStateDims%ens)%dimLength,  &
+              nTbound  => meta_stateDims(ixStateDims%tbound)%dimLength, &
+              ntdh_irf => meta_stateDims(ixStateDims%tdh_irf)%dimLength)    ! maximum future q time steps among reaches
 
-  allocate(state%var(nVarsKWE), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    allocate(state%var(nVarsIRF), stat=ierr, errmsg=cmessage)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
-  do iVar=1,nVarsKWE
-    select case(iVar)
-     case(ixKWE%a, ixKWE%q)
-      allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nEns), stat=ierr)
-     case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-    end select
-    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWE routing state '//trim(meta_kwe(iVar)%varName); return; endif
-  end do
+    ! array to store number of wave per segment and ensemble
+    allocate(numQF(nEns,nSeg), stat=ierr)
+    if(ierr/=0)then; message1=trim(message1)//'problem allocating space for numQF'; return; endif
 
-  ! --Convert data structures to arrays
-  do iens=1,nEns
-   do iSeg=1,nSeg
+    do iVar=1,nVarsIRF
+      select case(iVar)
+        case(ixIRF%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nEns), stat=ierr)
+        case(ixIRF%vol);     allocate(state%var(iVar)%array_3d_dp(nSeg, nTbound, nEns), stat=ierr)
+        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state '//trim(meta_irf(iVar)%varName); return; endif
+    end do
 
-    do iVar=1,nVarsKWE
-     select case(iVar)
-      case(ixKWE%a)
-       state%var(iVar)%array_3d_dp(iSeg,1:4,iens) = RCHSTA_local(iSeg)%EKW_ROUTE%A(:)
-      case(ixKWE%q)
-       state%var(iVar)%array_3d_dp(iSeg,1:4,iens) = RCHSTA_local(iSeg)%EKW_ROUTE%Q(:)
-      case default; ierr=20; message1=trim(message1)//'unable to identify KWE routing state variable index'; return
-     end select
-    enddo ! variable loop
-   enddo ! seg loop
-  enddo ! ensemble loop
+    ! --Convert data structures to arrays
+    do iens=1,nEns
+      do iSeg=1,nSeg
+        numQF(iens,iseg) = size(NETOPO_local(iSeg)%UH)
+        do iVar=1,nVarsIRF
+          select case(iVar)
+            case(ixIRF%qfuture)
+              state%var(iVar)%array_3d_dp(iSeg,1:numQF(iens,iSeg),iens) = RCHFLX_local(iSeg)%QFUTURE_IRF
+              state%var(iVar)%array_3d_dp(iSeg,numQF(iens,iSeg)+1:ntdh_irf,iens) = realMissing
+            case(ixIRF%vol)
+              state%var(iVar)%array_3d_dp(iSeg,1:nTbound,iens) = RCHFLX_local(iSeg)%REACH_VOL(0:1)
+            case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+          end select
+        enddo ! variable loop
+      enddo ! seg loop
+    enddo ! ensemble loop
 
-  ! Writing netCDF
-  do iVar=1,nVarsKWE
-    select case(iVar)
-     case(ixKWE%a, ixKWE%q)
-       call write_pnetcdf(pioFileDescState, trim(meta_kwe(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_mesh_double, ierr, cmessage)
-     case default; ierr=20; message1=trim(message1)//'unable to identify KWE variable index for nc writing'; return
-    end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    ! writing netcdf
+    call write_pnetcdf(pioFileDescState, 'numQF', numQF, iodesc_state_int, ierr, cmessage)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
-  end do
+    do iVar=1,nVarsIRF
+      select case(iVar)
+        case(ixIRF%qfuture)
+          call write_pnetcdf(pioFileDescState, trim(meta_irf(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_irf_double, ierr, cmessage)
+        case(ixIRF%vol)
+          call write_pnetcdf(pioFileDescState, trim(meta_irf(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_vol_double, ierr, cmessage)
+        case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc writing'; return
+        if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+      end select
+    end do
 
-  end associate
+    end associate
 
-  END SUBROUTINE write_KWE_state
+  END SUBROUTINE write_IRF_state
 
-
-  ! KWT writing procedures
   SUBROUTINE write_KWT_state(ierr, message1)
   implicit none
   ! output
@@ -998,47 +1088,43 @@ CONTAINS
   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
   do iVar=1,nVarsKWT
-
     select case(iVar)
-     case(ixKWT%routed); allocate(state%var(iVar)%array_3d_int(nSeg, nWave, nEns), stat=ierr)
-     case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
-      allocate(state%var(iVar)%array_3d_dp(nSeg, nWave, nEns), stat=ierr)
-     case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      case(ixKWT%routed); allocate(state%var(iVar)%array_3d_int(nSeg, nWave, nEns), stat=ierr)
+      case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
+        allocate(state%var(iVar)%array_3d_dp(nSeg, nWave, nEns), stat=ierr)
+      case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
     end select
     if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KWT routing state '//trim(meta_kwt(iVar)%varName); return; endif
   end do
 
   ! --Convert data structures to arrays
   do iens=1,nEns
-   do iSeg=1,nSeg
-
-    numWaves(iens,iseg) = size(RCHSTA_local(iseg)%LKW_ROUTE%KWAVE)
-
-    do iVar=1,nVarsKWT
-
-     select case(iVar)
-      case(ixKWT%tentry)
-       state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens) = RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%TI
-       state%var(iVar)%array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
-      case(ixKWT%texit)
-       state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens) = RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%TR
-       state%var(iVar)%array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
-      case(ixKWT%qwave)
-       state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens) = RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%QF
-       state%var(iVar)%array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
-      case(ixKWT%qwave_mod)
-       state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens) = RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%QM
-       state%var(iVar)%array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
-      case(ixKWT%routed) ! this is suppposed to be logical variable, but put it as 0 or 1 in double now
-       if (allocated(RFvec)) deallocate(RFvec, stat=ierr)
-       allocate(RFvec(numWaves(iens,iSeg)),stat=ierr); RFvec=0_i4b
-       where (RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%RF) RFvec=1_i4b
-       state%var(iVar)%array_3d_int(iSeg,1:numWaves(iens,iSeg),iens) = RFvec
-       state%var(iVar)%array_3d_int(iSeg,numWaves(iens,iSeg)+1:,iens) = integerMissing
-      case default; ierr=20; message1=trim(message1)//'unable to identify KWT routing state variable index'; return
-     end select
-    enddo ! variable loop
-   enddo ! seg loop
+    do iSeg=1,nSeg
+      numWaves(iens,iseg) = size(RCHSTA_local(iseg)%LKW_ROUTE%KWAVE)
+      do iVar=1,nVarsKWT
+        select case(iVar)
+          case(ixKWT%tentry)
+            state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens) = RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%TI
+            state%var(iVar)%array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
+          case(ixKWT%texit)
+            state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens) = RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%TR
+            state%var(iVar)%array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
+          case(ixKWT%qwave)
+            state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens) = RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%QF
+            state%var(iVar)%array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
+          case(ixKWT%qwave_mod)
+            state%var(iVar)%array_3d_dp(iSeg,1:numWaves(iens,iSeg),iens) = RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%QM
+            state%var(iVar)%array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
+          case(ixKWT%routed) ! this is suppposed to be logical variable, but put it as 0 or 1 in double now
+            if (allocated(RFvec)) deallocate(RFvec, stat=ierr)
+            allocate(RFvec(numWaves(iens,iSeg)),stat=ierr); RFvec=0_i4b
+            where (RCHSTA_local(iSeg)%LKW_ROUTE%KWAVE(:)%RF) RFvec=1_i4b
+            state%var(iVar)%array_3d_int(iSeg,1:numWaves(iens,iSeg),iens) = RFvec
+            state%var(iVar)%array_3d_int(iSeg,numWaves(iens,iSeg)+1:,iens) = integerMissing
+          case default; ierr=20; message1=trim(message1)//'unable to identify KWT routing state variable index'; return
+        end select
+      enddo ! variable loop
+    enddo ! seg loop
   enddo ! ensemble loop
 
   ! Writing netCDF
@@ -1046,98 +1132,186 @@ CONTAINS
   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
   do iVar=1,nVarsKWT
-
     select case(iVar)
-     case(ixKWT%routed)
-       call write_pnetcdf(pioFileDescState, trim(meta_kwt(iVar)%varName), state%var(iVar)%array_3d_int, iodesc_wave_int, ierr, cmessage)
-     case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
-       call write_pnetcdf(pioFileDescState, trim(meta_kwt(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_wave_double, ierr, cmessage)
-     case default; ierr=20; message1=trim(message1)//'unable to identify KWT variable index for nc writing'; return
+      case(ixKWT%routed)
+        call write_pnetcdf(pioFileDescState, trim(meta_kwt(iVar)%varName), state%var(iVar)%array_3d_int, iodesc_wave_int, ierr, cmessage)
+      case(ixKWT%tentry, ixKWT%texit, ixKWT%qwave, ixKWT%qwave_mod)
+        call write_pnetcdf(pioFileDescState, trim(meta_kwt(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_wave_double, ierr, cmessage)
+      case default; ierr=20; message1=trim(message1)//'unable to identify KWT variable index for nc writing'; return
     end select
-   if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
   end do
 
   end associate
 
   END SUBROUTINE write_KWT_state
 
+  SUBROUTINE write_KW_state(ierr, message1)
+    implicit none
+    ! output
+    integer(i4b), intent(out)  :: ierr            ! error code
+    character(*), intent(out)  :: message1        ! error message
+    ! local variables
+    type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
+    integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
 
-  ! IRF writing procedures
-  SUBROUTINE write_IRF_state(ierr, message1)
-  implicit none
-  ! output
-  integer(i4b), intent(out)  :: ierr            ! error code
-  character(*), intent(out)  :: message1        ! error message
-  ! local variables
-  type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
-  integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
-  integer(i4b), allocatable  :: numQF(:,:)      ! number of future Q time steps for each ensemble and segment
+    ierr=0; message1='write_KW_state/'
 
-  ierr=0; message1='write_IRF_state/'
+    associate(nSeg     => size(RCHFLX_local),                         &
+              nEns     => meta_stateDims(ixStateDims%ens)%dimLength,  &
+              nMesh    => meta_stateDims(ixStateDims%fdmesh)%dimLength)     ! maximum waves allowed in a reach
 
-  associate(nSeg     => size(RCHFLX_local),                         &
-            nEns     => meta_stateDims(ixStateDims%ens)%dimLength,  &
-            nTbound  => meta_stateDims(ixStateDims%tbound)%dimLength, &
-            ntdh_irf => meta_stateDims(ixStateDims%tdh_irf)%dimLength)    ! maximum future q time steps among reaches
-
-  allocate(state%var(nVarsIRF), stat=ierr, errmsg=cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-
-  ! array to store number of wave per segment and ensemble
-  allocate(numQF(nEns,nSeg), stat=ierr)
-  if(ierr/=0)then; message1=trim(message1)//'problem allocating space for numQF'; return; endif
-
-  do iVar=1,nVarsIRF
-   select case(iVar)
-    case(ixIRF%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nEns), stat=ierr)
-    case(ixIRF%irfVol);  allocate(state%var(iVar)%array_3d_dp(nSeg, nTbound, nEns), stat=ierr)
-    case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-   end select
-   if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state '//trim(meta_irf(iVar)%varName); return; endif
-  end do
-
-  ! --Convert data structures to arrays
-  do iens=1,nEns
-   do iSeg=1,nSeg
-
-    numQF(iens,iseg) = size(NETOPO_local(iSeg)%UH)
-
-    do iVar=1,nVarsIRF
-
-     select case(iVar)
-      case(ixIRF%qfuture)
-       state%var(iVar)%array_3d_dp(iSeg,1:numQF(iens,iSeg),iens) = RCHFLX_local(iSeg)%QFUTURE_IRF
-       state%var(iVar)%array_3d_dp(iSeg,numQF(iens,iSeg)+1:ntdh_irf,iens) = realMissing
-      case(ixIRF%irfVol)
-       state%var(iVar)%array_3d_dp(iSeg,1:nTbound,iens) = RCHFLX_local(iSeg)%REACH_VOL(0:1)
-      case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
-     end select
-
-    enddo ! variable loop
-   enddo ! seg loop
-  enddo ! ensemble loop
-
-  ! writing netcdf
-  call write_pnetcdf(pioFileDescState, 'numQF', numQF, iodesc_state_int, ierr, cmessage)
-  if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-
-  do iVar=1,nVarsIRF
-
-   select case(iVar)
-    case(ixIRF%qfuture)
-     call write_pnetcdf(pioFileDescState, trim(meta_irf(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_irf_double, ierr, cmessage)
-    case(ixIRF%irfVol)
-     call write_pnetcdf(pioFileDescState, trim(meta_irf(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_vol_double, ierr, cmessage)
-    case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc writing'; return
+    allocate(state%var(nVarsKW), stat=ierr, errmsg=cmessage)
     if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
-   end select
 
-  end do
+    do iVar=1,nVarsKW
+      select case(iVar)
+       case(ixKW%qsub); allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nEns), stat=ierr)
+       case(ixKW%vol)
+       case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KW routing state '//trim(meta_kw(iVar)%varName); return; endif
+    end do
 
-  end associate
+    ! --Convert data structures to arrays
+    do iens=1,nEns
+      do iSeg=1,nSeg
+        do iVar=1,nVarsKW
+          select case(iVar)
+            case(ixKW%qsub); state%var(iVar)%array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA_local(iSeg)%molecule%Q(1:nMesh)
+            case(ixKW%vol)
+            case default; ierr=20; message1=trim(message1)//'unable to identify KW routing state variable index'; return
+          end select
+        enddo ! variable loop
+      enddo ! seg loop
+    enddo ! ensemble loop
 
-  END SUBROUTINE write_IRF_state
+    ! Writing netCDF
+    do iVar=1,nVarsKW
+      select case(iVar)
+       case(ixKW%qsub)
+         call write_pnetcdf(pioFileDescState, trim(meta_kw(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_mesh_double, ierr, cmessage)
+       case(ixKW%vol)
+       case default; ierr=20; message1=trim(message1)//'unable to identify KW variable index for nc writing'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    end do
+
+    end associate
+
+  END SUBROUTINE write_KW_state
+
+  SUBROUTINE write_MC_state(ierr, message1)
+    implicit none
+    ! output
+    integer(i4b), intent(out)  :: ierr            ! error code
+    character(*), intent(out)  :: message1        ! error message
+    ! local variables
+    type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
+    integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
+
+    ierr=0; message1='write_MC_state/'
+
+    associate(nSeg     => size(RCHFLX_local),                         &
+              nEns     => meta_stateDims(ixStateDims%ens)%dimLength,  &
+              nMesh    => meta_stateDims(ixStateDims%fdmesh)%dimLength)     ! maximum waves allowed in a reach
+
+    allocate(state%var(nVarsMC), stat=ierr, errmsg=cmessage)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+
+    do iVar=1,nVarsMC
+      select case(iVar)
+       case(ixMC%qsub)
+        allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nEns), stat=ierr)
+       case(ixMC%vol)
+       case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for MC routing state '//trim(meta_mc(iVar)%varName); return; endif
+    end do
+
+    ! --Convert data structures to arrays
+    do iens=1,nEns
+      do iSeg=1,nSeg
+        do iVar=1,nVarsMC
+          select case(iVar)
+            case(ixMC%qsub); state%var(iVar)%array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA_local(iSeg)%molecule%Q(1:nMesh)
+            case(ixMC%vol)
+            case default; ierr=20; message1=trim(message1)//'unable to identify MC routing state variable index'; return
+          end select
+        enddo ! variable loop
+      enddo ! seg loop
+    enddo ! ensemble loop
+
+    ! Writing netCDF
+    do iVar=1,nVarsMC
+      select case(iVar)
+       case(ixMC%qsub)
+         call write_pnetcdf(pioFileDescState, trim(meta_mc(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_mesh_double, ierr, cmessage)
+       case(ixMC%vol)
+       case default; ierr=20; message1=trim(message1)//'unable to identify MC variable index for nc writing'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    end do
+
+    end associate
+
+  END SUBROUTINE write_MC_state
+
+  SUBROUTINE write_DW_state(ierr, message1)
+    implicit none
+    ! output
+    integer(i4b), intent(out)  :: ierr            ! error code
+    character(*), intent(out)  :: message1        ! error message
+    ! local variables
+    type(states)               :: state           ! temporal state data structures -currently 2 river routing scheme + basin IRF routing
+    integer(i4b)               :: iVar,iens,iSeg  ! index loops for variables, ensembles and segments respectively
+
+    ierr=0; message1='write_DW_state/'
+
+    associate(nSeg     => size(RCHFLX_local),                         &
+              nEns     => meta_stateDims(ixStateDims%ens)%dimLength,  &
+              nMesh    => meta_stateDims(ixStateDims%fdmesh)%dimLength)     ! maximum waves allowed in a reach
+
+    allocate(state%var(nVarsDW), stat=ierr, errmsg=cmessage)
+    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+
+    do iVar=1,nVarsDW
+      select case(iVar)
+        case(ixDW%qsub); allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nEns), stat=ierr)
+        case(ixDW%vol)
+       case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//'problem allocating space for DW routing state '//trim(meta_dw(iVar)%varName); return; endif
+    end do
+
+    ! --Convert data structures to arrays
+    do iens=1,nEns
+      do iSeg=1,nSeg
+        do iVar=1,nVarsDW
+          select case(iVar)
+            case(ixDW%qsub); state%var(iVar)%array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA_local(iSeg)%molecule%Q(1:nMesh)
+            case(ixDW%vol)
+            case default; ierr=20; message1=trim(message1)//'unable to identify DW routing state variable index'; return
+          end select
+        enddo ! variable loop
+      enddo ! seg loop
+    enddo ! ensemble loop
+
+    ! Writing netCDF
+    do iVar=1,nVarsDW
+      select case(iVar)
+       case(ixDW%qsub)
+         call write_pnetcdf(pioFileDescState, trim(meta_dw(iVar)%varName), state%var(iVar)%array_3d_dp, iodesc_mesh_double, ierr, cmessage)
+       case(ixDW%vol)
+       case default; ierr=20; message1=trim(message1)//'unable to identify DW variable index for nc writing'; return
+      end select
+      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
+    end do
+
+    end associate
+
+  END SUBROUTINE write_DW_state
+
 
  END SUBROUTINE write_state_nc
 


### PR DESCRIPTION
- Added two new routing modules (and minor changes in kwe_route.f90 due to restart data structure change).
- Modify restart derive data (STRSTA) for MC (muskingum-cunge), DW (diffusive wave) and KW (kinematic wave).
- Enabled two new routine options including output and restart I/O. 

relevant pull requests #241 #232 #233