### PR TITLE
one bugfix and one small change to remove warning when compling with ifort 

### DIFF
--- a/route/build/src/pio_utils.f90
+++ b/route/build/src/pio_utils.f90
@@ -478,7 +478,7 @@ contains
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  ierr = pio_put_var(pioFileDesc, pioVarId, scalar)
+  ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
   end subroutine write_int_scalar
@@ -505,7 +505,7 @@ contains
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  ierr = pio_put_var(pioFileDesc, pioVarId, scalar)
+  ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
   end subroutine write_double_scalar
@@ -532,7 +532,7 @@ contains
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  ierr = pio_put_var(pioFileDesc, pioVarId, scalar)
+  ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
   end subroutine write_char_scalar

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -792,7 +792,9 @@ CONTAINS
  ! local variables
  real(dp)                        :: secPerTime        ! number of sec per time-unit. time-unit is from t_unit
  real(dp)                        :: restartTimeVar    ! restart timeVar [time_units]
+ real(dp)                        :: tb_array(2)       ! restart timeVar [time_units]
  integer(i4b)                    :: iens              ! temporal
+ integer(i4b)                    :: nRch_local        ! number of reach in each processors
  type(STRFLX), allocatable       :: RCHFLX_local(:)   ! reordered reach flux data structure
  type(RCHTOPO),allocatable       :: NETOPO_local(:)   ! reordered topology data structure
  type(STRSTA), allocatable       :: RCHSTA_local(:)   ! reordered statedata structure
@@ -804,28 +806,28 @@ CONTAINS
  iens = 1
 
  if (masterproc) then
-  associate(nRch_trib => rch_per_proc(0))
-  allocate(RCHFLX_local(nRch_mainstem+nRch_trib), &
-           NETOPO_local(nRch_mainstem+nRch_trib), &
-           RCHSTA_local(nRch_mainstem+nRch_trib), stat=ierr)
-  if (nRch_mainstem>0) then
-    RCHFLX_local(1:nRch_mainstem) = RCHFLX_main(iens,1:nRch_mainstem)
-    NETOPO_local(1:nRch_mainstem) = NETOPO_main(1:nRch_mainstem)
-    RCHSTA_local(1:nRch_mainstem) = RCHSTA_main(iens,1:nRch_mainstem)
-  end if
-   if (nRch_trib>0) then
-     RCHFLX_local(nRch_mainstem+1:nRch_mainstem+nRch_trib) = RCHFLX_trib(iens,:)
-     NETOPO_local(nRch_mainstem+1:nRch_mainstem+nRch_trib) = NETOPO_trib(:)
-     RCHSTA_local(nRch_mainstem+1:nRch_mainstem+nRch_trib) = RCHSTA_trib(iens,:)
+   nRch_local = nRch_mainstem+rch_per_proc(0)
+   allocate(RCHFLX_local(nRch_local), &
+            NETOPO_local(nRch_local), &
+            RCHSTA_local(nRch_local), stat=ierr, errmsg=cmessage)
+   if (nRch_mainstem>0) then
+     RCHFLX_local(1:nRch_mainstem) = RCHFLX_main(iens,1:nRch_mainstem)
+     NETOPO_local(1:nRch_mainstem) = NETOPO_main(1:nRch_mainstem)
+     RCHSTA_local(1:nRch_mainstem) = RCHSTA_main(iens,1:nRch_mainstem)
+   end if
+   if (rch_per_proc(0)>0) then
+     RCHFLX_local(nRch_mainstem+1:nRch_local) = RCHFLX_trib(iens,:)
+     NETOPO_local(nRch_mainstem+1:nRch_local) = NETOPO_trib(:)
+     RCHSTA_local(nRch_mainstem+1:nRch_local) = RCHSTA_trib(iens,:)
    endif
-   end associate
  else
-  allocate(RCHFLX_local(rch_per_proc(pid)), &
-           NETOPO_local(rch_per_proc(pid)), &
-           RCHSTA_local(rch_per_proc(pid)),stat=ierr)
-  RCHFLX_local = RCHFLX_trib(iens,:)
-  NETOPO_local = NETOPO_trib(:)
-  RCHSTA_local = RCHSTA_trib(iens,:)
+   nRch_local = rch_per_proc(pid)
+   allocate(RCHFLX_local(nRch_local), &
+            NETOPO_local(nRch_local), &
+            RCHSTA_local(nRch_local),stat=ierr, errmsg=cmessage)
+   RCHFLX_local = RCHFLX_trib(iens,:)
+   NETOPO_local = NETOPO_trib(:)
+   RCHSTA_local = RCHSTA_trib(iens,:)
  endif
 
  ! get the time multiplier needed to convert time to units of days
@@ -852,7 +854,8 @@ CONTAINS
  call write_scalar_netcdf(pioFileDescState, 'restart_time', restartTimeVar, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call write_netcdf(pioFileDescState, 'time_bound', [TSEC(0),TSEC(1)], [1], [2], ierr, cmessage)
+ tb_array = [TSEC(0),TSEC(1)]
+ call write_netcdf(pioFileDescState, 'time_bound', tb_array, [1], [2], ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  call write_basinQ_state(ierr, cmessage)


### PR DESCRIPTION
The following error may occurs if ifort with flags: -debug all -warn all -check all

First, when scattering array (main array) in a main processor to distributed processors, main array needs to be defined and allocated in distributed processors, otherwise some of compiler may complain. (d08dab8a7e2d81c7a75a4c76d5e2866f8cd34684)

Explicitly defined array is provided in argument of subroutine. otherwise when compiling ifort with warning all flag (-warn all), waring message is written out on screen: _**forrtl: warning (406): fort: (1): In call to <module_name/subroutine_name>, an array temporary was created for argument #?**_ (0e92da752f09922f9f76e6d4310d9bac30e28ad8)