### PR TITLE
Add number of MPI tasks to restart file to ensure they are the same when reading

### DIFF
--- a/cime_config/testdefs/testmods_dirs/mizuroute/default/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/mizuroute/default/user_nl_clm
@@ -1,3 +1,4 @@
 ! Have some history output from CLM
 hist_nhtfrq = -24
-hist_mfilt = 5
+hist_ndens = 1
+hist_mfilt = 1

--- a/route/build/src/read_restart.f90
+++ b/route/build/src/read_restart.f90
@@ -31,6 +31,7 @@ CONTAINS
  USE globalData, ONLY: RCHFLX                    ! reach flux data structure for the entire domain
  USE globalData, ONLY: RCHSTA                    ! reach state data structure for the entire domain
  USE globalData, ONLY: ixRch_order
+ USE globalData, ONLY: nNodes                    ! number of MPI tasks
 
  implicit none
  ! input variables
@@ -47,6 +48,7 @@ CONTAINS
  integer(i4b)                  :: ntbound              ! dimenion sizes
  integer(i4b)                  :: ixDim_common(3)      ! custom dimension ID array
  integer(i4b)                  :: jDim                 ! index loops for dimension
+ integer(i4b)                  :: nNodes_in            ! number of MPI tasks for restart file
  character(len=strLen)         :: cmessage             ! error message of downwind routine
 
  ierr=0; message='read_state_nc/'
@@ -71,6 +73,15 @@ CONTAINS
  if(ierr/=0)then; message=trim(message)//'problem allocating [RCHFLX, RCHSTA]'; return; endif
 
  ! Read variables
+ call get_nc(fname,'nNodes',nNodes_in, 1, ierr, cmessage)
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ if ( nNodes /= nNodes_in )then
+    write(cmessage,'(i4)') nNodes_in
+    message=trim(message)//'Number of MPI tasks on restart file is different from number using now' // &
+            ', they must be the same, nNodes_in='//trim(cmessage)
+    return
+ end if
+
  ! time bound
  call get_nc(fname,'time_bound',TB(:), 1, 2, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/read_restart.f90
+++ b/route/build/src/read_restart.f90
@@ -77,6 +77,7 @@ CONTAINS
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  if ( nNodes /= nNodes_in )then
     write(cmessage,'(i4)') nNodes_in
+    ierr = 100
     message=trim(message)//'Number of MPI tasks on restart file is different from number using now' // &
             ', they must be the same, nNodes_in='//trim(cmessage)
     return

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -315,6 +315,9 @@ CONTAINS
  ! ----------------------------------
  ! Define variable
  ! ----------------------------------
+ call def_var(pioFileDescState, 'nNodes', ncd_int, ierr, cmessage, vdesc='Number of MPI tasks',  vunit='-' )
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
  call def_var(pioFileDescState, 'reachID', ncd_int, ierr, cmessage, pioDimId=[dim_seg], vdesc='reach ID',  vunit='-' )
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
@@ -777,6 +780,7 @@ CONTAINS
  USE globalData, ONLY: rch_per_proc        ! number of reaches assigned to each proc (size = num of procs+1)
  USE globalData, ONLY: nRch_mainstem       ! number of mainstem reaches
  USE globalData, ONLY: reachID             ! reach ID in network
+ USE globalData, ONLY: nNodes              ! number of MPI tasks
  USE globalData, ONLY: nRch                ! number of reaches in network
  USE globalData, ONLY: TSEC                ! beginning/ending of simulation time step [sec]
  USE globalData, ONLY: timeVar             ! time variables (unit given by runoff data)
@@ -844,6 +848,9 @@ CONTAINS
  ! -- Write out to netCDF
 
  call openFile(pioSystem, pioFileDescState, trim(fname),pio_typename, ncd_write, ierr, cmessage)
+ if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ call write_scalar_netcdf(pioFileDescState, 'nNodes', nNodes, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  call write_netcdf(pioFileDescState, 'reachID', reachID, [1], [nRch], ierr, cmessage)


### PR DESCRIPTION
Add the number of MPI tasks to the restart file to ensure they are the same when starting up from a restart. This addresses #228.