### PR TITLE
initial implementation for continuous_run 

### DIFF
--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -82,7 +82,7 @@ MODULE globalData
 
   ! ---------- Misc. data -------------------------------------------------------------------------
   logical(lgt),                    public :: isStandalone=.true.         ! flag to indicate model is running in standalone mode (True), otherwise coupled mode
-  logical(lgt),                    public :: isFileOpen                  ! flag to indicate output netcdf is open
+  logical(lgt),                    public :: isHistFileOpen=.false.      ! flag to indicate history output netcdf is open
   integer(i4b),                    public :: ixPrint(1:2)=integerMissing ! index of desired reach to be on-screen print
   integer(i4b),                    public :: nEns=1                      ! number of ensemble
   integer(i4b),                    public :: nMolecule                   ! number of computational molecule (used for KW, MC, DW)

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -263,12 +263,13 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE update_time(finished, ierr, message)
 
-  USE public_var, ONLY: dt            ! time step [sec]
-  USE public_var, ONLY: calendar      ! model calendar
-  USE globalData, ONLY: TSEC          ! beginning/ending of simulation time step [sec]
-  USE globalData, ONLY: iTime         ! time index at simulation time step
-  USE globalData, ONLY: endDatetime   ! model ending datetime
+  USE public_var, ONLY: dt                ! time step [sec]
+  USE public_var, ONLY: calendar          ! model calendar
+  USE globalData, ONLY: TSEC              ! beginning/ending of simulation time step [sec]
+  USE globalData, ONLY: iTime             ! time index at simulation time step
+  USE globalData, ONLY: endDatetime       ! model ending datetime
   USE globalData, ONLY: simDatetime       ! current model datetime
+  USE globalData, ONLY: isHistFileOpen    ! history file open/close status
   ! external routine
   USE write_simoutput_pio, ONLY: close_output_nc
 
@@ -283,7 +284,7 @@ CONTAINS
    ierr=0; message='update_time/'
 
    if (simDatetime(1)==endDatetime) then
-     call close_output_nc()
+     call close_output_nc(isHistFileOpen)
      finished=.true.;return
    endif
 

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -87,6 +87,7 @@ module public_var
   character(len=strLen),public    :: restart_dir          = charMissing     ! directory for restart output (netCDF)
   ! RUN CONTROL
   character(len=strLen),public    :: case_name            = ''              ! name of simulation
+  logical(lgt),public             :: continue_run         = .true.          ! T-> append output in existing history files. F-> write output in new history file
   character(len=strLen),public    :: simStart             = ''              ! date string defining the start of the simulation
   character(len=strLen),public    :: simEnd               = ''              ! date string defining the end of the simulation
   character(len=strLen),public    :: newFileFrequency     = 'annual'        ! frequency for new output files (day, month, annual, single)

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -109,6 +109,7 @@ CONTAINS
    case('<case_name>');            case_name   = trim(cData)                           ! name of simulation. used as head of model output and restart file
    case('<sim_start>');            simStart    = trim(cData)                           ! date string defining the start of the simulation
    case('<sim_end>');              simEnd      = trim(cData)                           ! date string defining the end of the simulation
+   case('<continue_run>');         read(cData,*,iostat=io_error) continue_run          ! logical; T-> append output in existing history files. F-> write output in new history file
    case('<newFileFrequency>');     newFileFrequency = trim(cData)                      ! frequency for new output files (day, month, annual, single)
    case('<route_opt>');            read(cData,*,iostat=io_error) routOpt               ! routing scheme options  0-> IRF+KWT (to be removed), 1->IRF, 2->KWT, 3-> KW, 4->MC, 5->DW
    case('<doesBasinRoute>');       read(cData,*,iostat=io_error) doesBasinRoute        ! basin routing options   0-> no, 1->IRF, otherwise error

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -184,8 +184,8 @@ CONTAINS
   call write_state_nc(fnameRestart, ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-  open (1, file = trim(restart_dir)//trim(rpntfil), status='replace', action='write')
-  write(1,'(a)') trim(fnameRestart)
+  open(1, file = trim(restart_dir)//trim(rpntfil), status='unknown', action='write', position='append')
+  write(1,'(a)', advance='no') trim(fnameRestart)
   close(1)
 
  END SUBROUTINE restart_output
@@ -802,6 +802,7 @@ CONTAINS
  type(STRFLX), allocatable       :: RCHFLX_local(:)   ! reordered reach flux data structure
  type(RCHTOPO),allocatable       :: NETOPO_local(:)   ! reordered topology data structure
  type(STRSTA), allocatable       :: RCHSTA_local(:)   ! reordered statedata structure
+ logical(lgt)                    :: restartOpen       ! logical to indicate restart file is open
  character(len=strLen)           :: t_unit            ! unit of time
  character(len=strLen)           :: cmessage          ! error message of downwind routine
 
@@ -849,7 +850,7 @@ CONTAINS
 
  ! -- Write out to netCDF
 
- call openFile(pioSystem, pioFileDescState, trim(fname),pio_typename, ncd_write, ierr, cmessage)
+ call openFile(pioSystem, pioFileDescState, trim(fname),pio_typename, ncd_write, restartOpen, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  call write_scalar_netcdf(pioFileDescState, 'nNodes', nNodes, ierr, cmessage)
@@ -898,7 +899,7 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
 
- call closeFile(pioFileDescState)
+ call closeFile(pioFileDescState, restartOpen)
 
  CONTAINS
 


### PR DESCRIPTION
Allow **_continuous run_** in stand-alone run by adding `<continuous_run> T` in control file. 

Definition of **_continuous run_** 

- stop and restart with restart file and append existing history file.

- if the previous run stops at the end of file frequency, restart run creates new history file. 

- **_continuous_run_** uses rpointer.rof text file containing the last history file and restart file names. 

For example, the first run from 1980-01-01 with monthly new file frequency, which write in <case>.mizuroute.h.1980-01-01-00000.nc, stops on 1980-01-31. Then **_continuous_run_** uses the restart file for 1980-02-01 to initialize the river state, and create new history file, <case>.mizuroute.h.1980-02-01-00000.nc.

If the first run from 1980-01-01 with monthly new file frequency stops on 1980-01-15, then **_continuous_run_** uses the restart file for 1980-01-16 to initialize the river state, and append the output in <case>.mizuroute.h.1980-01-01-00000.nc.