### PR TITLE
history and restart file name control

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -18,7 +18,7 @@ MODULE RtmMod
   USE public_var,     ONLY : dt                         ! routing time step
   USE public_var    , ONLY : iulog
   USE public_var    , ONLY : rpntfil
-  USE globalData    , ONLY : isStandalone
+  USE globalData    , ONLY : runMode
   USE globalData    , ONLY : iam        => pid
   USE globalData    , ONLY : npes       => nNodes
   USE globalData    , ONLY : mpicom_rof => mpicom_route
@@ -128,7 +128,7 @@ CONTAINS
     !-------------------------------------------------------
     ! Overwrite PIO parameter from CIME
     !-------------------------------------------------------
-    isStandalone = .false.
+    runMode='cesm-coupling'
 
     select case(shr_pio_getioformat(inst_name))
       case(PIO_64BIT_OFFSET); pio_netcdf_format = '64bit_offset'

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -81,7 +81,7 @@ MODULE globalData
   type(infileinfo), allocatable,   public :: infileinfo_data_wm(:) ! input water management (abstaction/injection) file information
 
   ! ---------- Misc. data -------------------------------------------------------------------------
-  logical(lgt),                    public :: isStandalone=.true.         ! flag to indicate model is running in standalone mode (True), otherwise coupled mode
+  character(len=strLen),           public :: runMode='standalone'        ! run options: standalone or cesm-coupling
   logical(lgt),                    public :: isHistFileOpen=.false.      ! flag to indicate history output netcdf is open
   integer(i4b),                    public :: ixPrint(1:2)=integerMissing ! index of desired reach to be on-screen print
   integer(i4b),                    public :: nEns=1                      ! number of ensemble


### PR DESCRIPTION
If running stand-alone, history and restart file name does not include "mizuroute"
If running with cesm coupling mode, history and restart file names need to include "mizuroute" for cesm archiving capability 

No need for control variable from a user.