### PR TITLE
Running with multiple routing schemes

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -290,53 +290,73 @@ implicit none
  END TYPE FPOINT
 
  ! Collection of flow points within a given reach
- TYPE, public :: LKWRCH
+ TYPE, public :: kwtRCH
   type(FPOINT),allocatable             :: KWAVE(:)
- END TYPE LKWRCH
+ END TYPE kwtRCH
 
- ! ---------- computational node kw, dw, and mc ---------------------------------
+ ! ---------- irf states (future flow series ) ---------------------------------
+ ! Future flow series
+ type, public :: irfRCH
+  real(dp), allocatable                :: qfuture(:)    ! runoff volume in future time steps for IRF routing (m3/s)
+ end type irfRCH
+
+ ! ---------- computational node for kw, dw, and mc -----------------------------
+ type, public :: cMolecule
+   integer(i4b)           :: KW_ROUTE
+   integer(i4b)           :: MC_ROUTE
+   integer(i4b)           :: DW_ROUTE
+ end type cMolecule
+
  type, public :: SUBRCH
    real(dp), allocatable  :: Q(:)        ! Discharge at sub-reaches at current step (m3/s)
    real(dp), allocatable  :: A(:)        ! Flow area at sub-reach at current step (m2)
    real(dp), allocatable  :: H(:)        ! Flow height at sub-reach at current step (m)
  end type SUBRCH
 
- ! ---------- irf states (future flow series ) ---------------------------------
- ! Future flow series
- type, public :: IRFRCH
-  real(dp), allocatable                :: qfuture(:)    ! runoff volume in future time steps for IRF routing (m3/s)
- END TYPE IRFRCH
+ type, public :: kwRch
+   type(SUBRCH)    :: molecule
+ end type kwRCH
+
+ type, public :: mcRch
+   type(SUBRCH)    :: molecule
+ end type mcRCH
+
+  type, public :: dwRch
+   type(SUBRCH)    :: molecule
+ end type dwRCH
 
  type, public :: STRSTA
-  type(IRFRCH)       :: IRF_ROUTE
-  type(LKWRCH)       :: LKW_ROUTE
-  type(SUBRCH)       :: molecule
+  type(irfRCH)       :: IRF_ROUTE
+  type(kwtRCH)       :: LKW_ROUTE
+  type(kwRCH)        :: KW_ROUTE
+  type(mcRCH)        :: MC_ROUTE
+  type(dwRCH)        :: DW_ROUTE
  end type STRSTA
 
 
  ! ---------- reach fluxes --------------------------------------------------------------------
+ type, public :: fluxes
+   real(dp)        :: REACH_Q
+   real(dp)        :: REACH_VOL(0:1)
+ end type fluxes
 
  ! fluxes and states in each reach
- TYPE, public :: strflx
+ type, public :: strflx
   real(dp), allocatable                :: QFUTURE(:)             ! runoff volume in future time steps (m3/s)
   real(dp), allocatable                :: QFUTURE_IRF(:)         ! runoff volume in future time steps for IRF routing (m3/s)
   real(dp), allocatable                :: QPASTUP_IRF(:,:)       ! runoff volume in the past time steps for lake upstream (m3/s)
   real(dp), allocatable                :: DEMANDPAST_IRF(:,:)    ! demand volume for lake (m3/s)
   real(dp)                             :: BASIN_QI               ! instantaneous runoff volume from the local basin (m3/s)
   real(dp)                             :: BASIN_QR(0:1)          ! routed runoff volume from the local basin (m3/s)
-  real(dp)                             :: REACH_Q                ! time-step average streamflow (m3/s)
-  real(dp)                             :: REACH_Q_IRF            ! time-step average streamflow (m3/s) from IRF routing
   real(dp)                             :: UPSTREAM_QI            ! sum of upstream streamflow (m3/s)
-  real(dp)                             :: REACH_VOL(0:1)         ! volume of water at previous and current time step [m3]
+  type(fluxes), allocatable            :: ROUTE(:)               ! reach fluxes and states for each routing method
   real(dp)                             :: REACH_ELE              ! elevation of the water at the current time step [m]
   real(dp)                             :: REACH_WM_FLUX          ! water management fluxes to and from each reach
   real(dp)                             :: REACH_WM_FLUX_actual   ! water management fluxes to and from each reach
   real(dp)                             :: REACH_WM_VOL           ! target volume from the second water management file (m3)
-  real(dp)                             :: TAKE                   ! average take
-  logical(lgt)                         :: isRoute                ! .true. if the reach is routed
   real(dp)                             :: basinEvapo             ! remapped river network catchment Evaporation (size: number of nHRU)
   real(dp)                             :: basinPrecip            ! remapped river network catchment Precipitation (size: number of nHRU)
- END TYPE strflx
+ end type strflx
 
  ! ---------- lake data types -----------------------------------------------------------------
 

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -6,11 +6,13 @@ USE dataTypes,   ONLY: STRFLX            ! fluxes in each reach
 USE dataTypes,   ONLY: STRSTA            ! state in each reach
 USE dataTypes,   ONLY: RCHTOPO           ! Network topology
 USE dataTypes,   ONLY: RCHPRP            ! Reach parameter
+USE dataTypes,   ONLY: dwRCH             ! dw specific state data structure
 USE dataTypes,   ONLY: subbasin_omp      ! mainstem+tributary data strucuture
 ! global data
 USE public_var,  ONLY: iulog             ! i/o logical unit number
 USE public_var,  ONLY: realMissing       ! missing value for real number
 USE public_var,  ONLY: integerMissing    ! missing value for integer number
+USE globalData, ONLY: idxDW
 ! subroutines: general
 USE perf_mod,    ONLY: t_startf,t_stopf   ! timing start/stop
 USE model_utils, ONLY: handle_err
@@ -181,7 +183,7 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%REACH_Q
+     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
    end do
  endif
 
@@ -190,28 +192,28 @@ CONTAINS
    if (nUps>0) then
      do iUps = 1,nUps
        iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-       write(iulog,'(A,X,I12,X,G15.4)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%REACH_Q
+       write(iulog,'(A,X,I12,X,G15.4)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
      enddo
    end if
    write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iEns,segIndex)%BASIN_QR(1)=',RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
  endif
 
  ! solve diffusive wave equation
- call diffusive_wave(RPARAM_in(segIndex),         &    ! input: parameter at segIndex reach
-                     T0,T1,                       &    ! input: start and end of the time step
-                     q_upstream,                  &    ! input: total discharge at top of the reach being processed
-                     isHW,                        &    ! input: is this headwater basin?
-                     RCHSTA_out(iens,segIndex),   &    ! inout:
-                     RCHFLX_out(iens,segIndex),   &    ! inout: updated fluxes at reach
-                     doCheck,                     &    ! input: reach index to be examined
-                     ierr, cmessage)                    ! output: error control
+ call diffusive_wave(RPARAM_in(segIndex),                     &  ! input: parameter at segIndex reach
+                     T0,T1,                                   &  ! input: start and end of the time step
+                     q_upstream,                              &  ! input: total discharge at top of the reach being processed
+                     isHW,                                    &  ! input: is this headwater basin?
+                     RCHSTA_out(iens,segIndex)%DW_ROUTE,      &  ! inout:
+                     RCHFLX_out(iens,segIndex),               &  ! inout: updated fluxes at reach
+                     doCheck,                                 &  ! input: reach index to be examined
+                     ierr, cmessage)                             ! output: error control
  if(ierr/=0)then
     write(message, '(A,X,I12,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage)
     return
  endif
 
  if(doCheck)then
-  write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%REACH_Q
+   write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_Q
  endif
 
  END SUBROUTINE dfw_rch
@@ -255,16 +257,14 @@ CONTAINS
  ! ----------------------------------------------------------------------------------------
  USE globalData, ONLY : nMolecule   ! number of internal nodes for finite difference (including upstream and downstream boundaries)
  IMPLICIT NONE
- ! Input
+ ! Argument variables
  type(RCHPRP), intent(in)        :: rch_param      ! River reach parameter
  real(dp),     intent(in)        :: T0,T1          ! start and end of the time step (seconds)
  real(dp),     intent(in)        :: q_upstream     ! total discharge at top of the reach being processed
  logical(lgt), intent(in)        :: isHW           ! is this headwater basin?
- logical(lgt), intent(in)        :: doCheck        ! reach index to be examined
- ! Input/Output
- type(STRSTA), intent(inout)     :: rstate         ! curent reach states
+ type(dwRch),  intent(inout)     :: rstate         ! curent reach states
  type(STRFLX), intent(inout)     :: rflux          ! current Reach fluxes
- ! Output
+ logical(lgt), intent(in)        :: doCheck        ! reach index to be examined
  integer(i4b), intent(out)       :: ierr           ! error code
  character(*), intent(out)       :: message        ! error message
  ! Local variables
@@ -308,21 +308,21 @@ CONTAINS
  wck = 1.0  ! weight in advection term
  wdk = 1.0  ! weight in diffusion term 0.0-> fully explicit, 0.5-> Crank-Nicolson, 1.0 -> fully implicit
 
- Nx = nMolecule - 1  ! Nx: number of internal reach segments
+ Nx = nMolecule%DW_ROUTE - 1  ! Nx: number of internal reach segments
 
  if (.not. isHW) then
 
-   allocate(Qprev(nMolecule), stat=ierr, errmsg=cmessage)
+   allocate(Qprev(nMolecule%DW_ROUTE), stat=ierr, errmsg=cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-   allocate(b(nMolecule), stat=ierr, errmsg=cmessage)
+   allocate(b(nMolecule%DW_ROUTE), stat=ierr, errmsg=cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-   allocate(diagonal(nMolecule,3), stat=ierr, errmsg=cmessage)
+   allocate(diagonal(nMolecule%DW_ROUTE,3), stat=ierr, errmsg=cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    ! initialize previous time step flow
-   Qprev(1:nMolecule) = rstate%molecule%Q     ! flow state at previous time step
+   Qprev(1:nMolecule%DW_ROUTE) = rstate%molecule%Q     ! flow state at previous time step
 
    ! Get the reach parameters
    ! A = (Q/alpha)**(1/beta)
@@ -343,19 +343,19 @@ CONTAINS
      write(iulog,'(A,X,I3,A,X,G12.5)') ' No. sub timestep=',nTsub,' sub time-step [sec]=',dTsub
    end if
 
-   allocate(Qlocal(1:nMolecule, 0:1), stat=ierr, errmsg=cmessage)
+   allocate(Qlocal(1:nMolecule%DW_ROUTE, 0:1), stat=ierr, errmsg=cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-   allocate(Qsolved(1:nMolecule), stat=ierr, errmsg=cmessage)
+   allocate(Qsolved(1:nMolecule%DW_ROUTE), stat=ierr, errmsg=cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    Qlocal(:,0:1) = realMissing
-   Qlocal(1:nMolecule, 0) = Qprev ! previous time step
+   Qlocal(1:nMolecule%DW_ROUTE, 0) = Qprev ! previous time step
    Qlocal(1,1)  = q_upstream     ! infllow at sub-time step in current time step
 
    do it = 1, nTsub
 
-     Qbar = (Qlocal(1,1)+Qlocal(1,0)+Qlocal(nMolecule,0))/3.0 ! 3 point average discharge [m3/s]
+     Qbar = (Qlocal(1,1)+Qlocal(1,0)+Qlocal(nMolecule%DW_ROUTE,0))/3.0 ! 3 point average discharge [m3/s]
      Abar = (abs(Qbar)/alpha)**(1/beta)                            ! flow area [m2] (manning equation)
      Vbar = 0._dp
      if (Abar>0._dp) Vbar = Qbar/Abar                     ! average velocity [m/s]
@@ -369,24 +369,24 @@ CONTAINS
      ! populate tridiagonal elements
      ! diagonal
      diagonal(1,2)             = 1._dp
-     diagonal(2:nMolecule-1,2) = 2._dp + 4*wdk*Cd
+     diagonal(2:nMolecule%DW_ROUTE-1,2) = 2._dp + 4*wdk*Cd
      if (downstreamBC == absorbingBC) then
-       diagonal(nMolecule,2)     = 1._dp + wck*Ca
+       diagonal(nMolecule%DW_ROUTE,2)     = 1._dp + wck*Ca
      else if (downstreamBC == neumannBC) then
-       diagonal(nMolecule,2)     = 1._dp
+       diagonal(nMolecule%DW_ROUTE,2)     = 1._dp
      end if
 
      ! upper
      diagonal(:,1)           = 0._dp
-     diagonal(3:nMolecule,1) = wck*Ca - 2._dp*wdk*Cd
+     diagonal(3:nMolecule%DW_ROUTE,1) = wck*Ca - 2._dp*wdk*Cd
 
      ! lower
      diagonal(:,3)             = 0._dp
-     diagonal(1:nMolecule-2,3) = -wck*Ca - 2._dp*wdk*Cd
+     diagonal(1:nMolecule%DW_ROUTE-2,3) = -wck*Ca - 2._dp*wdk*Cd
      if (downstreamBC == absorbingBC) then
-       diagonal(nMolecule-1,3)   = -wck*Ca
+       diagonal(nMolecule%DW_ROUTE-1,3)   = -wck*Ca
      else if (downstreamBC == neumannBC) then
-       diagonal(nMolecule-1,3)     = -1._dp
+       diagonal(nMolecule%DW_ROUTE-1,3)     = -1._dp
      end if
 
      ! populate left-hand side
@@ -394,21 +394,21 @@ CONTAINS
      b(1)             = Qlocal(1,1)
      ! downstream boundary condition
      if (downstreamBC == absorbingBC) then
-       b(nMolecule)     = (1._dp-(1._dp-wck)*Ca)*Qlocal(nMolecule,0) + (1-wck)*Ca*Qlocal(nMolecule-1,0)
+       b(nMolecule%DW_ROUTE) = (1._dp-(1._dp-wck)*Ca)*Qlocal(nMolecule%DW_ROUTE,0) + (1-wck)*Ca*Qlocal(nMolecule%DW_ROUTE-1,0)
      else if (downstreamBC == neumannBC) then
-       b(nMolecule)     = Sbc*dx
+       b(nMolecule%DW_ROUTE)     = Sbc*dx
      end if
      ! internal node points
-     b(2:nMolecule-1) = ((1._dp-wck)*Ca+2._dp*(1._dp-wdk))*Cd*Qlocal(1:nMolecule-2,0)  &
-                      + (2._dp-4._dp*(1._dp-wdk)*Cd)*Qlocal(2:nMolecule-1,0)           &
-                      - ((1._dp-wck)*Ca - (1._dp-wdk)*Cd)*Qlocal(3:nMolecule,0)
+     b(2:nMolecule%DW_ROUTE-1) = ((1._dp-wck)*Ca+2._dp*(1._dp-wdk))*Cd*Qlocal(1:nMolecule%DW_ROUTE-2,0)  &
+                      + (2._dp-4._dp*(1._dp-wdk)*Cd)*Qlocal(2:nMolecule%DW_ROUTE-1,0)           &
+                      - ((1._dp-wck)*Ca - (1._dp-wdk)*Cd)*Qlocal(3:nMolecule%DW_ROUTE,0)
 
      ! solve matrix equation - get updated Qlocal
-     call TDMA(nMolecule, diagonal, b, Qsolved)
+     call TDMA(nMolecule%DW_ROUTE, diagonal, b, Qsolved)
 
      if (doCheck) then
-       write(fmt1,'(A,I5,A)') '(A,1X',nMolecule,'(1X,F15.7))'
-       write(*,fmt1) ' Q sub_reqch=', (Qlocal(ix,1), ix=1,nMolecule)
+       write(fmt1,'(A,I5,A)') '(A,1X',nMolecule%DW_ROUTE,'(1X,F15.7))'
+       write(*,fmt1) ' Q sub_reqch=', (Qlocal(ix,1), ix=1,nMolecule%DW_ROUTE)
      end if
 
      Qlocal(:,1) = Qsolved
@@ -416,35 +416,35 @@ CONTAINS
    end do
 
    ! store final outflow in data structure
-   rflux%REACH_Q = Qlocal(nMolecule,1) + rflux%BASIN_QR(1)
+   rflux%ROUTE(idxDW)%REACH_Q = Qlocal(nMolecule%DW_ROUTE,1) + rflux%BASIN_QR(1)
 
    if (doCheck) then
-     write(iulog,*) 'rflux%REACH_Q= ', rflux%REACH_Q
-     write(iulog,*) 'Qprev(1:nMolecule)= ', Qprev(1:nMolecule)
+     write(iulog,*) 'rflux%REACH_Q= ', rflux%ROUTE(idxDW)%REACH_Q
+     write(iulog,*) 'Qprev(1:nMolecule)= ', Qprev(1:nMolecule%DW_ROUTE)
      write(iulog,*) 'Qbar, Abar, Vbar, ck, dk= ',Qbar, Abar, Vbar, ck, dk
      write(iulog,*) 'Cd, Ca= ', Cd, Ca
      write(iulog,*) 'diagonal(:,1)= ', diagonal(:,1)
      write(iulog,*) 'diagonal(:,2)= ', diagonal(:,2)
      write(iulog,*) 'diagonal(:,3)= ', diagonal(:,3)
-     write(iulog,*) 'b= ', b(1:nMolecule)
+     write(iulog,*) 'b= ', b(1:nMolecule%DW_ROUTE)
    end if
 
    ! compute volume
-   rflux%REACH_VOL(0) = rflux%REACH_VOL(1)
-   rflux%REACH_VOL(1) = rflux%REACH_VOL(0) + (Qlocal(1,1) - Qlocal(nMolecule,1))*dT
+   rflux%ROUTE(idxDW)%REACH_VOL(0) = rflux%ROUTE(idxDW)%REACH_VOL(1)
+   rflux%ROUTE(idxDW)%REACH_VOL(1) = rflux%ROUTE(idxDW)%REACH_VOL(0) + (Qlocal(1,1) - Qlocal(nMolecule%DW_ROUTE,1))*dT
 
    ! update state
    rstate%molecule%Q = Qlocal(:,1)
 
  else ! if head-water
 
-   rflux%REACH_Q = rflux%BASIN_QR(1)
+   rflux%ROUTE(idxDW)%REACH_Q = rflux%BASIN_QR(1)
 
-   rflux%REACH_VOL(0) = 0._dp
-   rflux%REACH_VOL(1) = 0._dp
+   rflux%ROUTE(idxDW)%REACH_VOL(0) = 0._dp
+   rflux%ROUTE(idxDW)%REACH_VOL(1) = 0._dp
 
-   rstate%molecule%Q(1:nMolecule) = 0._dp
-   rstate%molecule%Q(nMolecule) = rflux%REACH_Q
+   rstate%molecule%Q(1:nMolecule%DW_ROUTE) = 0._dp
+   rstate%molecule%Q(nMolecule%DW_ROUTE)   = rflux%ROUTE(idxDW)%REACH_Q
 
    if (doCheck) then
      write(iulog,'(A)')            ' This is headwater '
@@ -453,7 +453,7 @@ CONTAINS
  endif
 
  if (doCheck) then
-   write(iulog,'(A,X,G12.5)') ' Qout(t) =', rflux%REACH_Q
+   write(iulog,'(A,X,G12.5)') ' Qout(t) =', rflux%ROUTE(idxDW)%REACH_Q
  endif
 
  END SUBROUTINE diffusive_wave

--- a/route/build/src/domain_decomposition.f90
+++ b/route/build/src/domain_decomposition.f90
@@ -21,7 +21,7 @@ implicit none
 logical(lgt) :: domain_debug = .false. ! print out reach info with node assignment for debugging purpose
 
 ! common parameters within this module
-integer(i4b), parameter   :: maxDomainOMP=50000       ! maximum omp domains
+integer(i4b), parameter   :: maxDomainOMP=150000       ! maximum omp domains
 integer(i4b), parameter   :: maxDomainMPI=150000      ! maximum mpi domains
 integer(i4b), parameter   :: tributary=1
 integer(i4b), parameter   :: mainstem=2

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -2,9 +2,9 @@ MODULE globalData
 
   USE pio
 
-  USE public_var, ONLY: integerMissing
+  USE public_var
 
-  USE nrtype  ! numeric type
+  USE nrtype
 
   USE dataTypes, ONLY: struct_info   ! metadata type - data structure
   USE dataTypes, ONLY: dim_info      ! metadata type - variable dimensions
@@ -29,6 +29,8 @@ MODULE globalData
 
   USE dataTypes, ONLY: subbasin_omp  ! data structure - omp domain decomposition
   USE dataTypes, ONLY: subbasin_mpi  ! data structure - mpi domain decomposition
+
+  USE dataTypes, ONLY : cMolecule    ! data structure - computational molecule number
 
   USE datetime_data, ONLY: datetime  ! datetime data class
 
@@ -64,6 +66,16 @@ MODULE globalData
   integer(i4b),     allocatable,   public :: basinID(:)           ! HRU id in the whole river network
   integer(i4b),     allocatable,   public :: reachID(:)           ! reach id in the whole river network
 
+  ! ---------- routing methods  -------------------------------------------------------------------------
+  integer(i4b)                   , public :: nRoutes                ! number of active routing methods
+  integer(i4b)    , allocatable  , public :: routeMethods(:)        ! active routing method id
+  logical(lgt)                   , public :: onRoute(nRouteMethods) ! logical to indicate active routing method(s)
+  integer(i4b)                   , public :: idxIRF                 ! index of IRF method
+  integer(i4b)                   , public :: idxKWT                 ! index of KWT method
+  integer(i4b)                   , public :: idxKW                  ! index of KW method
+  integer(i4b)                   , public :: idxMC                  ! index of MC method
+  integer(i4b)                   , public :: idxDW                  ! index of DW method
+
   ! ---------- Date/Time data  -------------------------------------------------------------------------
 
   integer(i4b),                    public :: iTime                ! time index at simulation time step
@@ -85,7 +97,7 @@ MODULE globalData
   logical(lgt),                    public :: isHistFileOpen=.false.      ! flag to indicate history output netcdf is open
   integer(i4b),                    public :: ixPrint(1:2)=integerMissing ! index of desired reach to be on-screen print
   integer(i4b),                    public :: nEns=1                      ! number of ensemble
-  integer(i4b),                    public :: nMolecule                   ! number of computational molecule (used for KW, MC, DW)
+  type(cMolecule),                 public :: nMolecule                   ! number of computational molecule (used for KW, MC, DW)
 
   ! ---------- MPI/OMP/PIO variables ----------------------------------------------------------------
 
@@ -152,21 +164,21 @@ MODULE globalData
   type(RCHTOPO),      allocatable, public :: NETOPO_main(:)         ! River Network topology for mainstems
 
   ! time delay histogram
-  REAL(dp),           allocatable, public :: FRAC_FUTURE(:)         ! fraction of runoff in future time steps
+  real(dp),           allocatable, public :: FRAC_FUTURE(:)         ! fraction of runoff in future time steps
 
   ! routing data structures
-  TYPE(STRSTA),       allocatable, public :: RCHSTA(:,:)            ! restart variables (ensembles, space [reaches]) for the entire river network
-  TYPE(STRFLX),       allocatable, public :: RCHFLX(:,:)            ! Reach fluxes (ensembles, space [reaches]) for entire river network
-  TYPE(STRSTA),       allocatable, public :: RCHSTA_trib(:,:)       ! restart variables (ensembles, space [reaches]) for tributary
-  TYPE(STRFLX),       allocatable, public :: RCHFLX_trib(:,:)       ! Reach fluxes (ensembles, space [reaches]) for tributaries
-  TYPE(STRSTA),       allocatable, public :: RCHSTA_main(:,:)       ! restart variables (ensembles, space [reaches]) for mainstem
-  TYPE(STRFLX),       allocatable, public :: RCHFLX_main(:,:)       ! Reach fluxes (ensembles, space [reaches]) for mainstem
+  type(STRSTA),       allocatable, public :: RCHSTA(:,:)            ! restart variables (ensembles, space [reaches]) for the entire river network
+  type(STRFLX),       allocatable, public :: RCHFLX(:,:)            ! Reach fluxes (ensembles, space [reaches]) for entire river network
+  type(STRSTA),       allocatable, public :: RCHSTA_trib(:,:)       ! restart variables (ensembles, space [reaches]) for tributary
+  type(STRFLX),       allocatable, public :: RCHFLX_trib(:,:)       ! Reach fluxes (ensembles, space [reaches]) for tributaries
+  type(STRSTA),       allocatable, public :: RCHSTA_main(:,:)       ! restart variables (ensembles, space [reaches]) for mainstem
+  type(STRFLX),       allocatable, public :: RCHFLX_main(:,:)       ! Reach fluxes (ensembles, space [reaches]) for mainstem
 
   ! lakes data structures
-  TYPE(LAKPRP),       allocatable, public :: LPARAM(:)              ! Lake parameters
-  TYPE(LAKTOPO),      allocatable, public :: LKTOPO(:)              ! Lake topology
-  TYPE(LKFLX),        allocatable, public :: LAKFLX(:,:)            ! Lake fluxes
-  TYPE(LKFLX),        allocatable, public :: LAKFLX_local(:,:)      ! Lake fluxes for decomposed domains
+  type(LAKPRP),       allocatable, public :: LPARAM(:)              ! Lake parameters
+  type(LAKTOPO),      allocatable, public :: LKTOPO(:)              ! Lake topology
+  type(LKFLX),        allocatable, public :: LAKFLX(:,:)            ! Lake fluxes
+  type(LKFLX),        allocatable, public :: LAKFLX_local(:,:)      ! Lake fluxes for decomposed domains
 
   ! mapping structures
   type(remap),                     public :: remap_data             ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -8,11 +8,13 @@ USE dataTypes,   ONLY: STRFLX            ! fluxes in each reach
 USE dataTypes,   ONLY: STRSTA            ! state in each reach
 USE dataTypes,   ONLY: RCHTOPO           ! Network topology
 USE dataTypes,   ONLY: RCHPRP            ! Reach parameter
+USE dataTypes,   ONLY: mcRCH             ! MC specific state data structure
 USE dataTypes,   ONLY: subbasin_omp      ! mainstem+tributary data strucuture
 ! global data
 USE public_var,  ONLY: iulog             ! i/o logical unit number
 USE public_var,  ONLY: realMissing       ! missing value for real number
 USE public_var,  ONLY: integerMissing    ! missing value for integer number
+USE globalData,  ONLY: idxMC             ! index of IRF method
 ! subroutines: general
 USE perf_mod,    ONLY: t_startf,t_stopf   ! timing start/stop
 USE model_utils, ONLY: handle_err
@@ -183,7 +185,7 @@ contains
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%REACH_Q
+     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
    end do
  endif
 
@@ -192,28 +194,27 @@ contains
    if (nUps>0) then
      do iUps = 1,nUps
        iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-       write(iulog,'(A,X,I6,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%REACH_Q
+       write(iulog,'(A,X,I6,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
      enddo
    end if
    write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iEns,segIndex)%BASIN_QR(1)=',RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
  endif
 
  ! solve muskingum-cunge alogorithm
- call muskingum_cunge(RPARAM_in(segIndex),         &    ! input: parameter at segIndex reach
-                      T0,T1,                       &    ! input: start and end of the time step
-                      q_upstream,                  &    ! input: total discharge at top of the reach being processed
-                      isHW,                        &    ! input: is this headwater basin?
-                      RCHSTA_out(iens,segIndex),   &    ! inout:
-                      RCHFLX_out(iens,segIndex),   &    ! inout: updated fluxes at reach
-                      doCheck,                     &    ! input: reach index to be examined
-                      ierr, cmessage)                    ! output: error control
+ call muskingum_cunge(RPARAM_in(segIndex),                & ! input: parameter at segIndex reach
+                      T0,T1,                              & ! input: start and end of the time step
+                      q_upstream,                         & ! input: total discharge at top of the reach being processed
+                      isHW,                               & ! input: is this headwater basin?
+                      RCHSTA_out(iens,segIndex)%MC_ROUTE, & ! inout:
+                      RCHFLX_out(iens,segIndex),          & ! inout: updated fluxes at reach
+                      doCheck,                            & ! input: reach index to be examined
+                      ierr, cmessage)                       ! output: error control
  if(ierr/=0)then
-    write(message, '(A,X,I10,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage)
-    return
+   write(message, '(A,X,I10,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage); return
  endif
 
  if(doCheck)then
-  write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%REACH_Q
+   write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_Q
  endif
 
  END SUBROUTINE mc_rch
@@ -244,17 +245,15 @@ contains
  ! (time:0:1, loc:0:1) 0-previous time step/inlet, 1-current time step/outlet.
  ! Q or A(1,2,3,4): 1: (t=0,x=0), 2: (t=0,x=1), 3: (t=1,x=0), 4: (t=1,x=1)
 
- IMPLICIT NONE
- ! Input
+ implicit none
+ ! argument variables
  type(RCHPRP), intent(in)                 :: rch_param    ! River reach parameter
  real(dp),     intent(in)                 :: T0,T1        ! start and end of the time step (seconds)
  real(dp),     intent(in)                 :: q_upstream   ! total discharge at top of the reach being processed
  logical(lgt), intent(in)                 :: isHW         ! is this headwater basin?
- logical(lgt), intent(in)                 :: doCheck      ! reach index to be examined
- ! Input/Output
- type(STRSTA), intent(inout)              :: rstate       ! curent reach states
+ type(mcRCH),  intent(inout)              :: rstate       ! curent reach states
  type(STRFLX), intent(inout)              :: rflux        ! current Reach fluxes
- ! Output
+ logical(lgt), intent(in)                 :: doCheck      ! reach index to be examined
  integer(i4b), intent(out)                :: ierr         ! error code
  character(*), intent(out)                :: message      ! error message
  ! LOCAL VAIRABLES
@@ -372,12 +371,12 @@ contains
  endif
 
  ! compute volume
- rflux%REACH_VOL(0) = rflux%REACH_VOL(1)
- rflux%REACH_VOL(1) = rflux%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dT
- rflux%REACH_VOL(1) = max(rflux%REACH_VOL(1), 0._dp)
+ rflux%ROUTE(idxMC)%REACH_VOL(0) = rflux%ROUTE(idxMC)%REACH_VOL(1)
+ rflux%ROUTE(idxMC)%REACH_VOL(1) = rflux%ROUTE(idxMC)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dT
+ rflux%ROUTE(idxMC)%REACH_VOL(1) = max(rflux%ROUTE(idxMC)%REACH_VOL(1), 0._dp)
 
  ! add catchment flow
- rflux%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)
+ rflux%ROUTE(idxMC)%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)
 
  if (doCheck) then
    write(iulog,'(A,X,G12.5)') ' Qout(t)=',Q(1,1)

--- a/route/build/src/nr_utility.f90
+++ b/route/build/src/nr_utility.f90
@@ -2,18 +2,16 @@ MODULE nr_utility_module
 
 USE nrtype
 
-! contains functions that should really be part of the fortran standard, but are not
 implicit none
 
 INTERFACE arth
- MODULE PROCEDURE arth_r, arth_d, arth_i
+  module procedure arth_r, arth_d, arth_i
 END INTERFACE
 
 INTERFACE sizeo
-  MODULE PROCEDURE sizeo_i4b, sizeo_dp, sizeo_sp
+  module procedure sizeo_i4b, sizeo_dp, sizeo_sp
 END INTERFACE
 
-! (everything private unless otherwise specifed)
 private
 public::arth
 public::indexx
@@ -21,6 +19,7 @@ public::findIndex
 public::indexTrue
 public::unique
 public::sizeo
+public::get_digits
 
 CONTAINS
 
@@ -158,92 +157,84 @@ CONTAINS
  END SUBROUTINE swap
 
  ! ************************************************************************************************
- ! * findIndex: find the first index within a vector
+ ! findIndex: find the first index within a vector
  ! ************************************************************************************************
  function findIndex(vector,desiredValue,missingValue)
- ! finds the first index within a vector
- !  -- if the index does not exist, returns zero
- ! NOTE: workaround for (not-yet-implemented) f2008 intrinsic findloc
- implicit none
- ! dummy variables
- integer(i4b),intent(in)            :: vector(:)    ! vector to search
- integer(i4b),intent(in)            :: desiredValue ! desired value in the vector
- integer(i4b),intent(in),optional   :: missingValue ! desired missing value if desiredValue is not found
- integer(i4b)                       :: findIndex    ! first index of the desired value in the vector
- ! local variables
- integer(i4b),dimension(1)          :: vecIndex     ! first index of the desired value in the vector (vec of length=1)
+   ! NOTE: if the index does not exist, returns zero
+   !        workaround for (not-yet-implemented) f2008 intrinsic findloc
+   implicit none
+   ! argument variables
+   integer(i4b),intent(in)            :: vector(:)    ! vector to search
+   integer(i4b),intent(in)            :: desiredValue ! desired value in the vector
+   integer(i4b),intent(in),optional   :: missingValue ! desired missing value if desiredValue is not found
+   integer(i4b)                       :: findIndex    ! first index of the desired value in the vector
+   ! local variables
+   integer(i4b),dimension(1)          :: vecIndex     ! first index of the desired value in the vector (vec of length=1)
 
- ! check if the value exisits
- if(any(vector==desiredValue))then
-
-  ! get the index: merge provides a vector with 1s where mask is true and 0s otherwise, so maxloc(merge) is the first index of value=1
-  ! NOTE: workaround for (not-yet-implemented) f2008 intrinsic findloc
-  vecIndex=maxloc( merge(1, 0, vector==desiredValue) )
-
- ! value does not exist
- else
-  if(present(missingValue))then
-   vecIndex=missingValue
-  else
-   vecIndex=0
-  endif
- endif
-
- ! return function value (extract into a scalar)
- findIndex=vecIndex(1)
-
+   ! check if the value exisits
+   if(any(vector==desiredValue))then
+     ! get the index: merge provides a vector with 1s where mask is true and 0s otherwise, so maxloc(merge) is the first index of value=1
+     vecIndex=maxloc( merge(1, 0, vector==desiredValue) )
+   else
+     if(present(missingValue))then
+       vecIndex=missingValue
+     else
+       vecIndex=0
+     endif
+   endif
+   findIndex=vecIndex(1)
  end function findIndex
 
+ ! *************************************************************************************************
+ ! Return indices of True in TF array
+ ! *************************************************************************************************
  subroutine indexTrue(TF,pos)
-  ! Return indices of True in TF array
-  implicit none
-  ! Inlet variables
-  logical(lgt),intent(in)                :: TF(:)           ! Logical vector (True or False)
-  ! Outlet variables
-  integer(i4b), allocatable, intent(out) :: pos(:)          ! position of "true" conditions
-  ! Local variable
-  integer(i4b)                           :: npos            ! number of "true" conditions
-  integer(i4b)                           :: idx(size(TF))   ! vector of all positions
+   implicit none
+   ! argument variables
+   logical(lgt),intent(in)                :: TF(:)           ! Logical vector (True or False)
+   integer(i4b), allocatable, intent(out) :: pos(:)          ! position of "true" conditions
+   ! Local variable
+   integer(i4b)                           :: npos            ! number of "true" conditions
+   integer(i4b)                           :: idx(size(TF))   ! vector of all positions
 
-  idx = arth(1,1,size(TF))           ! Enumerate all positions
-  npos  = count(TF)                  ! Count the elements of TF that are .True.
-  allocate(pos(npos))
-  pos = pack(idx,TF)                 ! With Pack function, verify position of true conditions
-
+   idx = arth(1,1,size(TF))           ! Enumerate all positions
+   npos  = count(TF)                  ! Count the elements of TF that are .True.
+   allocate(pos(npos))
+   pos = pack(idx,TF)                 ! With Pack function, verify position of true conditions
  end subroutine indexTrue
 
+ ! *************************************************************************************************
+ ! Find unique elements and indices given array
+ ! *************************************************************************************************
  SUBROUTINE unique(array, unq, idx)
-  implicit none
-  ! Input variables
-  integer(i4b),            intent(in)  :: array(:)             ! integer array including duplicated elements
-  ! outpu variables
-  integer(i4b),allocatable,intent(out) :: unq(:)               ! integer array including unique elements
-  integer(i4b),allocatable,intent(out) :: idx(:)               ! integer array including unique element index
-  ! local
-  integer(i4b)                         :: ranked(size(array))  !
-  integer(i4b)                         :: unq_tmp(size(array)) !
-  logical(lgt)                         :: flg_tmp(size(array)) !
-  integer(i4b)                         :: ix                   ! loop index, counter
-  integer(i4b)                         :: last_unique          ! last unique element
+   implicit none
+   ! argument variables
+   integer(i4b),            intent(in)  :: array(:)             ! integer array including duplicated elements
+   integer(i4b),allocatable,intent(out) :: unq(:)               ! integer array including unique elements
+   integer(i4b),allocatable,intent(out) :: idx(:)               ! integer array including unique element index
+   ! local
+   integer(i4b)                         :: ranked(size(array))  !
+   integer(i4b)                         :: unq_tmp(size(array)) !
+   logical(lgt)                         :: flg_tmp(size(array)) !
+   integer(i4b)                         :: ix                   ! loop index, counter
+   integer(i4b)                         :: last_unique          ! last unique element
 
-  flg_tmp = .false.
-  call indexx(array, ranked)
+   flg_tmp = .false.
+   call indexx(array, ranked)
 
-  unq_tmp(ranked(1)) = array(ranked(1))
-  flg_tmp(ranked(1)) = .true.
-  last_unique = array(ranked(1))
-  do ix = 2,size(ranked)
-    if (last_unique==array(ranked(ix))) cycle
-    flg_tmp(ranked(ix)) = .true.
-    unq_tmp(ranked(ix)) = array(ranked(ix))
-    last_unique = array(ranked(ix))
-  end do
+   unq_tmp(ranked(1)) = array(ranked(1))
+   flg_tmp(ranked(1)) = .true.
+   last_unique = array(ranked(1))
+   do ix = 2,size(ranked)
+     if (last_unique==array(ranked(ix))) cycle
+     flg_tmp(ranked(ix)) = .true.
+     unq_tmp(ranked(ix)) = array(ranked(ix))
+     last_unique = array(ranked(ix))
+   end do
 
-  allocate(unq(count(flg_tmp)),idx(count(flg_tmp)))
-
-  idx = pack(arth(1,1,size(array)), flg_tmp)
-  unq = unq_tmp(idx)
-
+   allocate(unq(count(flg_tmp)),idx(count(flg_tmp)))
+   idx = pack(arth(1,1,size(array)), flg_tmp)
+   unq = unq_tmp(idx)
  END SUBROUTINE unique
 
  ! *************************************************************************************************
@@ -281,5 +272,29 @@ CONTAINS
      asize = size(var)
    end if
  END FUNCTION sizeo_sp
+
+ ! *************************************************************************************************
+ ! * convert integer to digit array
+ ! *************************************************************************************************
+ FUNCTION get_digits(num) result(digs)
+   implicit none
+   ! argument variables
+   integer(i4b), intent(in)  :: num
+   ! local variables
+   integer(i4b), allocatable :: digs(:)
+   integer(i4b)              :: num_digits, ix, rem
+   if (num==0) then
+     allocate(digs(1))
+     digs=0
+   else
+     num_digits = floor(log10(real(num))+1)
+     allocate(digs(num_digits))
+     rem = num
+     do ix = 1, num_digits
+        digs(num_digits-ix+1) = rem - (rem/10)*10  ! Take advantage of integer division
+        rem = rem/10
+     end do
+   end if
+ END FUNCTION get_digits
 
 END MODULE nr_utility_module

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -95,7 +95,9 @@ contains
  meta_stateDims(ixStateDims%tbound  ) = dim_info('tbound',  integerMissing, 2)               ! time bound (alway 2 - start and end)
  meta_stateDims(ixStateDims%ens     ) = dim_info('ens',     integerMissing, integerMissing)  ! runoff ensemble
  meta_stateDims(ixStateDims%wave    ) = dim_info('wave',    integerMissing, MAXQPAR)         ! reach waves vector (max. number is defined as MAXQPAR)
- meta_stateDims(ixStateDims%fdmesh  ) = dim_info('fdmesh',  integerMissing, integerMissing)  ! finite difference computing molecule numbers
+ meta_stateDims(ixStateDims%mol_kw  ) = dim_info('mol_kw',  integerMissing, integerMissing)  ! kw finite difference computing nodes
+ meta_stateDims(ixStateDims%mol_mc  ) = dim_info('mol_mc',  integerMissing, integerMissing)  ! mc finite difference computing nodes
+ meta_stateDims(ixStateDims%mol_dw  ) = dim_info('mol_dw',  integerMissing, integerMissing)  ! dw finite difference computing nodes
  meta_stateDims(ixStateDims%tdh_irf ) = dim_info('tdh_irf', integerMissing, integerMissing)  ! future time steps for irf routing
  meta_stateDims(ixStateDims%tdh     ) = dim_info('tdh',     integerMissing, integerMissing)  ! future time steps for bsasin irf routing
 
@@ -232,20 +234,20 @@ contains
  call meta_kwt(ixKWT%routed   )%init('routed'   , 'routing flag'                                  , '-'   , pio_int,    [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
 
  ! Kinematic Wave
- call meta_kw(ixKW%qsub)%init('q_sub',  'flow at computational moelcule', 'm3/s', pio_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens], .true.)
- call meta_kw(ixKW%vol )%init('volume', 'volume in reach/lake',           'm3',   pio_double, [ixStateDims%seg,ixStateDims%ens] , .true.)
+ call meta_kw(ixKW%qsub)%init('q_sub_kw' , 'flow at computational moelcule', 'm3/s', pio_double, [ixStateDims%seg,ixStateDims%mol_kw,ixStateDims%ens], .true.)
+ call meta_kw(ixKW%vol )%init('volume_kw', 'volume in reach/lake',           'm3',   pio_double, [ixStateDims%seg,ixStateDims%ens] , .true.)
 
  ! Diffusive Wave
- call meta_dw(ixDW%qsub)%init('q_sub',  'flow at computational moelcule', 'm3/s', pio_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens], .true.)
- call meta_dw(ixDW%vol )%init('volume', 'volume in reach/lake',           'm3',   pio_double, [ixStateDims%seg,ixStateDims%ens] , .true.)
+ call meta_dw(ixDW%qsub)%init('q_sub_dw' , 'flow at computational moelcule', 'm3/s', pio_double, [ixStateDims%seg,ixStateDims%mol_dw,ixStateDims%ens], .true.)
+ call meta_dw(ixDW%vol )%init('volume_dw', 'volume in reach/lake',           'm3',   pio_double, [ixStateDims%seg,ixStateDims%ens] , .true.)
 
  ! Muskingum-cunge
- call meta_mc(ixMC%qsub)%init('q_sub',  'flow at computational molecule', 'm3/s', pio_double, [ixStateDims%seg,ixStateDims%fdmesh,ixStateDims%ens], .true.)
- call meta_mc(ixMC%vol )%init('volume', 'volume in reach/lake',           'm3',   pio_double, [ixStateDims%seg,ixStateDims%ens] , .true.)
+ call meta_mc(ixMC%qsub)%init('q_sub_mc' , 'flow at computational molecule', 'm3/s', pio_double, [ixStateDims%seg,ixStateDims%mol_mc,ixStateDims%ens], .true.)
+ call meta_mc(ixMC%vol )%init('volume_mc', 'volume in reach/lake',           'm3',   pio_double, [ixStateDims%seg,ixStateDims%ens] , .true.)
 
  ! Impulse Response Function
  call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series',   'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%tdh_irf,ixStateDims%ens] , .true.)
- call meta_irf(ixIRF%vol    )%init('volume'     , 'volume in reach/lake', 'm3'   ,pio_double, [ixStateDims%seg,ixStateDims%tbound, ixStateDims%ens] , .true.)
+ call meta_irf(ixIRF%vol    )%init('volume_irf' , 'volume in reach/lake', 'm3'   ,pio_double, [ixStateDims%seg,ixStateDims%tbound, ixStateDims%ens] , .true.)
 
  ! Basin Impulse Response Function
  call meta_irf_bas(ixIRFbas%qfuture)%init('qfuture', 'future flow series', 'm3/s' ,pio_double, [ixStateDims%seg,ixStateDims%tdh,ixStateDims%ens], .true.)

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -70,7 +70,7 @@ module public_var
   integer(i4b), parameter,public  :: readFromFile=0         ! read given variable from a file
 
   ! routing methods
-  integer(i4b), parameter,public  :: allRoutingMethods=0     ! all routing methods
+  integer(i4b), parameter,public  :: nRouteMethods=5         ! number of routing methods available
   integer(i4b), parameter,public  :: impulseResponseFunc=1   ! impulse response function
   integer(i4b), parameter,public  :: kinematicWaveTracking=2 ! Lagrangian kinematic wave
   integer(i4b), parameter,public  :: kinematicWave=3         ! kinematic wave

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -2,64 +2,64 @@ MODULE read_control_module
 
 USE nrtype
 USE public_var
-USE globalData, ONLY: pid, nNodes, masterproc             ! procs id and number of procs
 
 implicit none
-! privacy
+
 private
 public::read_control
 
 CONTAINS
 
  ! =======================================================================================================
- ! * new subroutine: read the control file
+ ! * public subroutine: read the control file
  ! =======================================================================================================
- ! read the control file
  SUBROUTINE read_control(ctl_fname, err, message)
 
- USE nrtype                                  ! variable types, etc.
  ! global vars
- USE globalData, ONLY: time_conv,length_conv  ! conversion factors
-
+ USE globalData, ONLY: time_conv,length_conv   ! conversion factors
+ USE globalData, ONLY: masterproc              ! procs id and number of procs
  ! metadata structures
- USE globalData, ONLY: meta_HRU             ! HRU properties
- USE globalData, ONLY: meta_HRU2SEG         ! HRU-to-segment mapping
- USE globalData, ONLY: meta_SEG             ! stream segment properties
- USE globalData, ONLY: meta_NTOPO           ! network topology
- USE globalData, ONLY: meta_PFAF            ! pfafstetter code
- USE globalData, ONLY: meta_rflx            ! river flux variables
-
+ USE globalData, ONLY: meta_HRU                ! HRU properties
+ USE globalData, ONLY: meta_HRU2SEG            ! HRU-to-segment mapping
+ USE globalData, ONLY: meta_SEG                ! stream segment properties
+ USE globalData, ONLY: meta_NTOPO              ! network topology
+ USE globalData, ONLY: meta_PFAF               ! pfafstetter code
+ USE globalData, ONLY: meta_rflx               ! river flux variables
+ USE globalData, ONLY: nRoutes                 ! number of active routing methods
+ USE globalData, ONLY: routeMethods            ! active routing method index and id
+ USE globalData, ONLY: onRoute                 ! logical to indicate actiive routing method(s)
+ USE globalData, ONLY: idxIRF, idxKWT, &
+                       idxKW, idxMC, idxDW
  ! named variables in each structure
- USE var_lookup, ONLY: ixHRU                ! index of variables for data structure
- USE var_lookup, ONLY: ixHRU2SEG            ! index of variables for data structure
- USE var_lookup, ONLY: ixSEG                ! index of variables for data structure
- USE var_lookup, ONLY: ixNTOPO              ! index of variables for data structure
- USE var_lookup, ONLY: ixPFAF               ! index of variables for data structure
- USE var_lookup, ONLY: ixRFLX               ! index of variables for data structure
-
+ USE var_lookup, ONLY: ixHRU                   ! index of variables for data structure
+ USE var_lookup, ONLY: ixHRU2SEG               ! index of variables for data structure
+ USE var_lookup, ONLY: ixSEG                   ! index of variables for data structure
+ USE var_lookup, ONLY: ixNTOPO                 ! index of variables for data structure
+ USE var_lookup, ONLY: ixPFAF                  ! index of variables for data structure
+ USE var_lookup, ONLY: ixRFLX, nVarsRFLX       ! index of variables for data structure
  ! external subroutines
- USE ascii_util_module, ONLY:file_open        ! open file (performs a few checks as well)
- USE ascii_util_module, ONLY:get_vlines       ! get a list of character strings from non-comment lines
+ USE ascii_util_module, ONLY: file_open        ! open file (performs a few checks as well)
+ USE ascii_util_module, ONLY: get_vlines       ! get a list of character strings from non-comment lines
+ USE nr_utility_module, ONLY: get_digits       ! convert integer number to a array containing individual digits
 
  implicit none
- ! input
- character(*), intent(in)          :: ctl_fname      ! name of the control file
- ! output: error control
- integer(i4b),intent(out)          :: err            ! error code
- character(*),intent(out)          :: message        ! error message
- ! ------------------------------------------------------------------------------------------------------
+ ! argument variables
+ character(*), intent(in)          :: ctl_fname               ! name of the control file
+ integer(i4b),intent(out)          :: err                     ! error code
+ character(*),intent(out)          :: message                 ! error message
  ! Local variables
- character(len=strLen),allocatable :: cLines(:)      ! vector of character strings
- character(len=strLen)             :: cName,cData    ! name and data from cLines(iLine)
- character(len=strLen)             :: cLength,cTime  ! length and time units
- integer(i4b)                      :: ipos           ! index of character string
- integer(i4b)                      :: ibeg_name      ! start index of variable name in string cLines(iLine)
- integer(i4b)                      :: iend_name      ! end index of variable name in string cLines(iLine)
- integer(i4b)                      :: iend_data      ! end index of data in string cLines(iLine)
- integer(i4b)                      :: iLine          ! index of line in cLines
- integer(i4b)                      :: iunit          ! file unit
- integer(i4b)                      :: io_error       ! error in I/O
- character(len=strLen)             :: cmessage       ! error message from subroutine
+ character(len=strLen),allocatable :: cLines(:)               ! vector of character strings
+ character(len=strLen)             :: cName,cData             ! name and data from cLines(iLine)
+ character(len=strLen)             :: cLength,cTime           ! length and time units
+ integer(i4b)                      :: ipos                    ! index of character string
+ integer(i4b)                      :: ibeg_name               ! start index of variable name in string cLines(iLine)
+ integer(i4b)                      :: iend_name               ! end index of variable name in string cLines(iLine)
+ integer(i4b)                      :: iend_data               ! end index of data in string cLines(iLine)
+ integer(i4b)                      :: iLine                   ! index of line in cLines
+ integer(i4b)                      :: iunit                   ! file unit
+ integer(i4b)                      :: io_error                ! error in I/O
+ integer(i4b)                      :: iRoute                  ! loop index
+ character(len=strLen)             :: cmessage                ! error message from subroutine
 
  err=0; message='read_control/'
 
@@ -297,16 +297,14 @@ CONTAINS
 
    ! if not in list then keep going
    case default
-    message=trim(message)//'unexpected text in control file -- provided '//trim(cName)&
+    message=trim(message)//'unexpected text in control file provided: '//trim(cName)&
                          //' (note strings in control file must match the variable names in public_var.f90)'
     err=20; return
-
   end select
 
   ! check I/O error
   if(io_error/=0)then
-   message=trim(message)//'problem with internal read of '//trim(cName)
-   err=20; return
+    message=trim(message)//'problem with internal read of '//trim(cName); err=20; return
   endif
 
  end do  ! looping through lines in the control file
@@ -348,8 +346,8 @@ CONTAINS
  ! find the position of the "/" character
  ipos = index(trim(units_qsim),'/')
  if(ipos==0)then
-  message=trim(message)//'expect the character "/" exists in the units string [units='//trim(units_qsim)//']'
-  err=80; return
+   message=trim(message)//'expect the character "/" exists in the units string [units='//trim(units_qsim)//']'
+   err=80; return
  endif
 
  ! get the length and time units
@@ -358,49 +356,58 @@ CONTAINS
 
  ! get the conversion factor for length
  select case(trim(cLength))
-  case('m');  length_conv = 1._dp
-  case('mm'); length_conv = 1._dp/1000._dp
-  case default
-   message=trim(message)//'expect the length units of runoff to be "m" or "mm" [units='//trim(cLength)//']'
-   err=81; return
+   case('m');  length_conv = 1._dp
+   case('mm'); length_conv = 1._dp/1000._dp
+   case default
+     message=trim(message)//'expect the length units of runoff to be "m" or "mm" [units='//trim(cLength)//']'
+     err=81; return
  end select
 
  ! get the conversion factor for time
  select case(trim(cTime))
-  case('d','day');          time_conv = 1._dp/secprday
-  case('h','hr','hour');    time_conv = 1._dp/secprhour
-  case('s','sec','second'); time_conv = 1._dp
-  case default
-   message=trim(message)//'expect the time units of to be "day"("d"), "hour"("h") or "second"("s") [time units = '//trim(cTime)//']'
-   err=81; return
+   case('d','day');          time_conv = 1._dp/secprday
+   case('h','hr','hour');    time_conv = 1._dp/secprhour
+   case('s','sec','second'); time_conv = 1._dp
+   case default
+     message=trim(message)//'expect the time units of to be "day"("d"), "hour"("h") or "second"("s") [time units = '//trim(cTime)//']'
+     err=81; return
  end select
 
  ! ---------- output options --------------------------------------------------------------------------------------------
+ ! Assign index for each active routing method
  ! Make sure to turn off write option for routines not used
- ! Routing options
- if (routOpt==allRoutingMethods) then
-    meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = (.true. .and. meta_rflx(ixRFLX%KWTroutedRunoff)%varFile)
-    meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = (.true. .and. meta_rflx(ixRFLX%IRFroutedRunoff)%varFile)
-    meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.
-    meta_rflx(ixRFLX%KWroutedRunoff)%varFile = .false.
-    meta_rflx(ixRFLX%DWroutedRunoff)%varFile = .false.
- else
- ! ----- end: this (allRoutingMethods) is to be removed
- if (routOpt/=kinematicWaveTracking) meta_rflx(ixRFLX%KWTroutedRunoff)%varFile = .false.
- if (routOpt/=impulseResponseFunc) meta_rflx(ixRFLX%IRFroutedRunoff)%varFile = .false.
- if (routOpt/=muskingumCunge) meta_rflx(ixRFLX%MCroutedRunoff)%varFile = .false.
- if (routOpt/=kinematicWave) meta_rflx(ixRFLX%KWroutedRunoff)%varFile = .false.
- if (routOpt/=diffusiveWave) meta_rflx(ixRFLX%DWroutedRunoff)%varFile = .false.
- endif
+ if (routOpt==0)then; message=trim(message)//'routOpt=0 is terminated. 12 is equivalent to 0 now'; err=10; return; endif
+ routeMethods = get_digits(routOpt)
+ nRoutes = size(routeMethods)
+ onRoute = .false.
+ do iRoute = 1, nRoutes
+   select case(routeMethods(iRoute))
+     case(kinematicWaveTracking); idxKWT = iRoute; onRoute(kinematicWaveTracking)=.true.
+     case(impulseResponseFunc);   idxIRF = iRoute; onRoute(impulseResponseFunc)=.true.
+     case(muskingumCunge);        idxMC  = iRoute; onRoute(muskingumCunge)=.true.
+     case(kinematicWave);         idxKW  = iRoute; onRoute(kinematicWave)=.true.
+     case(diffusiveWave);         idxDW  = iRoute; onRoute(diffusiveWave)=.true.
+     case default
+       message=trim(message)//'routOpt may include invalid digits; expect digits 1-5 in routOpt'; err=81; return
+   end select
+ end do
+
+ do iRoute = 1, nRouteMethods
+   select case(iRoute)
+     case(kinematicWaveTracking); if (.not. onRoute(iRoute)) meta_rflx(ixRFLX%KWTroutedRunoff)%varFile=.false.
+     case(impulseResponseFunc);   if (.not. onRoute(iRoute)) meta_rflx(ixRFLX%IRFroutedRunoff)%varFile=.false.
+     case(muskingumCunge);        if (.not. onRoute(iRoute)) meta_rflx(ixRFLX%MCroutedRunoff)%varFile=.false.
+     case(kinematicWave);         if (.not. onRoute(iRoute)) meta_rflx(ixRFLX%KWroutedRunoff)%varFile=.false.
+     case(diffusiveWave);         if (.not. onRoute(iRoute)) meta_rflx(ixRFLX%DWroutedRunoff)%varFile=.false.
+     case default; message=trim(message)//'expect digits from 1 and 5'; err=81; return
+   end select
+ end do
 
  ! runoff accumulation option
- if (doesAccumRunoff==0) then
-   meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile = .false.
- endif
+ if (doesAccumRunoff==0) meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile = .false.
+
  ! basin runoff routing option
- if (doesBasinRoute==0) then
-   meta_rflx(ixRFLX%instRunoff)%varFile = .false.
- endif
+ if (doesBasinRoute==0) meta_rflx(ixRFLX%instRunoff)%varFile = .false.
 
  END SUBROUTINE read_control
 

--- a/route/build/src/standalone/read_runoff.f90
+++ b/route/build/src/standalone/read_runoff.f90
@@ -16,58 +16,52 @@ private
 public::read_runoff_metadata
 public::read_runoff_data
 
-contains
+CONTAINS
 
  ! *****
  ! public subroutine: get runoff  metadata...
  ! ******************************************
- subroutine read_runoff_metadata(&
-                                 ! input
-                                 fname            , & ! filename including directory
-                                 var_name         , & ! varibale name
-                                 var_time_name    , & ! name of varibale time
-                                 dim_time_name    , & ! name of dimension time
-                                 var_hru_name     , & ! name of varibale HRUs
-                                 dim_hru_name     , & ! name of dimension HRUs
-                                 dim_ylat_name    , & ! name of dimension lat in case of a 2D input varibale
-                                 dim_xlon_name    , & ! name of dimension lon in case of a 2D input varibale
-                                 ! output
-                                 nSpace           , & ! nSpace of the input in runoff or wm strcuture
-                                 nTime            , & ! nTime of the input in runoff or wm strcuture
-                                 sim              , & ! 1D simulation
-                                 sim2D            , & ! 2D simulation
-                                 ID_array         , & ! ID of seg or hru in data
-                                 timeUnits        , & ! time units
-                                 calendar         , & ! calendar
-                                 ! error control
-                                 ierr, message)     ! output: error control
+ SUBROUTINE read_runoff_metadata(fname            , & ! input: filename including directory
+                                 var_name         , & ! input: varibale name
+                                 var_time_name    , & ! input: name of varibale time
+                                 dim_time_name    , & ! input: name of dimension time
+                                 var_hru_name     , & ! input: name of varibale HRUs
+                                 dim_hru_name     , & ! input: name of dimension HRUs
+                                 dim_ylat_name    , & ! input: name of dimension lat in case of a 2D input varibale
+                                 dim_xlon_name    , & ! input: name of dimension lon in case of a 2D input varibale
+                                 nSpace           , & ! output: nSpace of the input in runoff or wm strcuture
+                                 nTime            , & ! output: nTime of the input in runoff or wm strcuture
+                                 sim              , & ! output: 1D simulation
+                                 sim2D            , & ! output: 2D simulation
+                                 ID_array         , & ! output: ID of seg or hru in data
+                                 timeUnits        , & ! output: time units
+                                 calendar         , & ! output: calendar
+                                 ierr, message)       ! output: error control
  implicit none
- ! input variables
- character(*), intent(in)        :: fname           ! filename
- character(*), intent(in)        :: var_name        ! name of the varibale for simulated runoff or abstraction/injection
- character(*), intent(in)        :: var_time_name   ! name of the varibale time
- character(*), intent(in)        :: dim_time_name   ! name of dimension for time
- character(*), intent(in)        :: var_hru_name    ! name of the varibale hru
- character(*), intent(in)        :: dim_hru_name    ! name of dimension for hydrological HRUs
- character(*), intent(in)        :: dim_ylat_name   ! name of dimension along lat
- character(*), intent(in)        :: dim_xlon_name   ! name of dimension along lon
- ! output variables
- integer(i4b),                intent(out)   :: nSpace(1:2)     ! nSpace of the input in runoff or wm strcuture
- integer(i4b),                intent(out)   :: nTime           ! nTime of the input in runoff or wm strcuture
- real(dp),      allocatable,  intent(out)   :: sim(:)          ! 1D simulation
- real(dp),      allocatable,  intent(out)   :: sim2D(:,:)      ! 2D simulation
- integer(i4b),  allocatable,  intent(out)   :: ID_array(:)     ! ID of seg or hru in data
- character(*),                intent(out)   :: timeUnits       ! time units
- character(*),                intent(out)   :: calendar        ! calendar
- ! error control
- integer(i4b), intent(out)       :: ierr            ! error code
- character(*), intent(out)       :: message         ! error message
+ ! argument variables
+ character(*),              intent(in)    :: fname           ! filename
+ character(*),              intent(in)    :: var_name        ! name of the varibale for simulated runoff or abstraction/injection
+ character(*),              intent(in)    :: var_time_name   ! name of the varibale time
+ character(*),              intent(in)    :: dim_time_name   ! name of dimension for time
+ character(*),              intent(in)    :: var_hru_name    ! name of the varibale hru
+ character(*),              intent(in)    :: dim_hru_name    ! name of dimension for hydrological HRUs
+ character(*),              intent(in)    :: dim_ylat_name   ! name of dimension along lat
+ character(*),              intent(in)    :: dim_xlon_name   ! name of dimension along lon
+ integer(i4b),              intent(out)   :: nSpace(1:2)     ! nSpace of the input in runoff or wm strcuture
+ integer(i4b),              intent(out)   :: nTime           ! nTime of the input in runoff or wm strcuture
+ real(dp),     allocatable, intent(out)   :: sim(:)          ! 1D simulation
+ real(dp),     allocatable, intent(out)   :: sim2D(:,:)      ! 2D simulation
+ integer(i4b), allocatable, intent(out)   :: ID_array(:)     ! ID of seg or hru in data
+ character(*),              intent(out)   :: timeUnits       ! time units
+ character(*),              intent(out)   :: calendar        ! calendar
+ integer(i4b),              intent(out)   :: ierr            ! error code
+ character(*),              intent(out)   :: message         ! error message
  ! local variables
- integer(i4b)                    :: ncid            ! netcdf id
- integer(i4b)                    :: ivarID          ! variable id
- integer(i4b)                    :: nDims           ! number of dimension in runoff file
- character(len=strLen)           :: cmessage        ! error message from subroutine
- ! initialize error control
+ integer(i4b)                             :: ncid            ! netcdf id
+ integer(i4b)                             :: ivarID          ! variable id
+ integer(i4b)                             :: nDims           ! number of dimension in runoff file
+ character(len=strLen)                    :: cmessage        ! error message from subroutine
+
  ierr=0; message='read_runoff_metadata/'
 
  ! open NetCDF file
@@ -89,11 +83,10 @@ contains
                                         dim_time_name,    & ! dimension of varibale time
                                         var_hru_name,     & ! name of varibale hrus
                                         dim_hru_name,     & ! dimension of varibales hrus
-                                        nSpace        , & ! nSpace of the input in runoff or wm strcuture
-                                        nTime           , & ! nTime of the input in runoff or wm strcuture
-                                        sim             , & ! 1D simulation
-                                        sim2D           , & ! 2D simulation
-                                        ID_array        , & ! ID of seg or hru in data
+                                        nSpace,           & ! nSpace of the input in runoff or wm strcuture
+                                        nTime,            & ! nTime of the input in runoff or wm strcuture
+                                        sim,              & ! 1D simulation
+                                        ID_array,         & ! ID of seg or hru in data
                                         timeUnits,        &
                                         calendar,         &
                                         ierr, cmessage)
@@ -102,11 +95,10 @@ contains
                                         dim_time_name,    & ! dimension of varibale time
                                         dim_ylat_name,    & ! dimesnion of lat
                                         dim_xlon_name,    & ! dimension of lon
-                                        nSpace        , & ! nSpace of the input in runoff or wm strcuture
-                                        nTime           , & ! nTime of the input in runoff or wm strcuture
-                                        sim             , & ! 1D simulation
-                                        sim2D           , & ! 2D simulation
-                                        ID_array        , & ! ID of seg or hru in data
+                                        nSpace,           & ! nSpace of the input in runoff or wm strcuture
+                                        nTime,            & ! nTime of the input in runoff or wm strcuture
+                                        sim2D,            & ! 2D simulation
+                                        ID_array,         & ! ID of seg or hru in data
                                         timeUnits,        &
                                         calendar,         &
                                         ierr, cmessage)
@@ -114,51 +106,41 @@ contains
  end select
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- end subroutine read_runoff_metadata
+ END SUBROUTINE read_runoff_metadata
 
  ! *****
  ! private subroutine: get 2D runoff (hru, time) metadata...
  ! ******************************************
- subroutine read_1D_runoff_metadata(&
-                                   ! input
-                                   fname            , & ! filename
-                                   var_time_name    , & ! name of varibale time
-                                   dim_time_name    , & ! name of dimension time
-                                   var_hru_name     , & ! name of varibale HRUs
-                                   dim_hru_name     , & ! name of dimension HRUs
-                                   ! output
-                                   nSpace           , & ! nSpace of the input in runoff or wm strcuture
-                                   nTime            , & ! nTime of the input in runoff or wm strcuture
-                                   sim              , & ! 1D simulation
-                                   sim2D            , & ! 2D simulation
-                                   ID_array         , & ! ID of seg or hru in data
-                                   timeUnits        , & ! time units
-                                   calendar         , & ! calendar
-                                   ! error control
-                                   ierr, message)     ! output: error control
+ SUBROUTINE read_1D_runoff_metadata(fname           , & ! input: filename
+                                   var_time_name    , & ! input: name of varibale time
+                                   dim_time_name    , & ! input: name of dimension time
+                                   var_hru_name     , & ! input: name of varibale HRUs
+                                   dim_hru_name     , & ! input: name of dimension HRUs
+                                   nSpace           , & ! output: nSpace of the input in runoff or wm strcuture
+                                   nTime            , & ! output: nTime of the input in runoff or wm strcuture
+                                   sim              , & ! output: 1D simulation
+                                   ID_array         , & ! output: ID of seg or hru in data
+                                   timeUnits        , & ! output: time units
+                                   calendar         , & ! output: calendar
+                                   ierr, message)       ! output: error control
  implicit none
- ! input variables
+ ! argument variables
  character(*),               intent(in)          :: fname           ! filename
  character(*),               intent(in)          :: var_time_name   ! name of the varibale time
  character(*),               intent(in)          :: dim_time_name   ! name of dimension for time
  character(*),               intent(in)          :: var_hru_name    ! name of the varibale hru
  character(*),               intent(in)          :: dim_hru_name    ! name of dimension for hydrological HRUs
- ! output variables
  integer(i4b),               intent(out)         :: nSpace(1:2)     ! nSpace of the input in runoff or wm strcuture
  integer(i4b),               intent(out)         :: nTime           ! nTime of the input in runoff or wm strcuture
  real(dp),     allocatable,  intent(out)         :: sim(:)          ! 1D simulation
- real(dp),     allocatable,  intent(out)         :: sim2D(:,:)      ! 2D simulation
  integer(i4b), allocatable,  intent(out)         :: ID_array(:)     ! ID of seg or hru in data
  character(*),               intent(out)         :: timeUnits       ! time units
  character(*),               intent(out)         :: calendar        ! calendar
- ! error control
  integer(i4b),               intent(out)         :: ierr            ! error code
  character(*),               intent(out)         :: message         ! error message
  ! local variables
  character(len=strLen)                           :: cmessage        ! error message from subroutine
 
-
- ! initialize error control
  ierr=0; message='read_1D_runoff_metadata/'
 
  nSpace(2) = integerMissing
@@ -195,51 +177,41 @@ contains
  call get_nc(fname, var_hru_name, ID_array, 1, nSpace(1), ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- end subroutine read_1D_runoff_metadata
+ END SUBROUTINE read_1D_runoff_metadata
 
  ! *****
  ! private subroutine: get 3D runoff (lat, lon, time) metadata...
  ! ******************************************
- subroutine read_2D_runoff_metadata(&
-                                    ! input
-                                    fname            , & ! filename
-                                    var_time_name    , & ! name of varibale time
-                                    dim_time_name    , & ! name of dimension time
-                                    dim_ylat_name    , & ! name of varibale HRUs
-                                    dim_xlon_name    , & ! name of dimension HRUs
-                                    ! output
-                                    nSpace           , & ! nSpace of the input in runoff or wm strcuture
-                                    nTime            , & ! nTime of the input in runoff or wm strcuture
-                                    sim              , & ! 1D simulation
-                                    sim2D            , & ! 2D simulation
-                                    ID_array         , & ! ID of seg or hru in data
-                                    timeUnits        , & ! time units
-                                    calendar         , & ! calendar
-                                    ! error control
-                                    ierr, message)     ! output: error control
+ SUBROUTINE read_2D_runoff_metadata(fname            , & ! input: filename
+                                    var_time_name    , & ! input: name of varibale time
+                                    dim_time_name    , & ! input: name of dimension time
+                                    dim_ylat_name    , & ! input: name of varibale HRUs
+                                    dim_xlon_name    , & ! input: name of dimension HRUs
+                                    nSpace           , & ! output: nSpace of the input in runoff or wm strcuture
+                                    nTime            , & ! output: nTime of the input in runoff or wm strcuture
+                                    sim2D            , & ! output: 2D simulation
+                                    ID_array         , & ! output: ID of seg or hru in data
+                                    timeUnits        , & ! output: time units
+                                    calendar         , & ! output: calendar
+                                    ierr, message)       ! output: error control
  implicit none
- ! input variables
+ ! argument variables
  character(*),                  intent(in)   :: fname           ! filename
  character(*),                  intent(in)   :: var_time_name   ! name of the varibale time
  character(*),                  intent(in)   :: dim_time_name   ! name of dimension for time
  character(*),                  intent(in)   :: dim_ylat_name   ! name of dimension along lat
  character(*),                  intent(in)   :: dim_xlon_name   ! name of dimension along lon
- ! output variables
  integer(i4b),                  intent(out)  :: nSpace(1:2)     ! nSpace of the input in runoff or wm strcuture
  integer(i4b),                  intent(out)  :: nTime           ! nTime of the input in runoff or wm strcuture
- real(dp),     allocatable,     intent(out)  :: sim(:)          ! 1D simulation
  real(dp),     allocatable,     intent(out)  :: sim2D(:,:)      ! 2D simulation
  integer(i4b), allocatable,     intent(out)  :: ID_array(:)     ! ID of seg or hru in data
  character(*),                  intent(out)  :: timeUnits       ! time units
  character(*),                  intent(out)  :: calendar        ! calendar
- ! error control
  integer(i4b),                  intent(out)  :: ierr            ! error code
  character(*),                  intent(out)  :: message         ! error message
  ! local variables
  character(len=strLen)                       :: cmessage        ! error message from subroutine
 
-
- ! initialize error control
  ierr=0; message='read_2D_runoff_metadata/'
 
  ! get number of time steps from the runoff file
@@ -270,13 +242,12 @@ contains
  allocate(sim2d(nSpace(2),nSpace(1)), stat=ierr)
  if(ierr/=0)then; message=trim(message)//'problem allocating sim'; return; endif
 
- end subroutine read_2D_runoff_metadata
-
+ END SUBROUTINE read_2D_runoff_metadata
 
  ! *********************************************************************
  ! public subroutine: read runoff data
  ! *********************************************************************
- subroutine read_runoff_data(fname,            &  ! input: filename
+ SUBROUTINE read_runoff_data(fname,            &  ! input: filename
                              var_name,         &  ! input: varibale name
                              time_index,       &  ! input: time index
                              nSpace,           &  ! input: dimension of data to be read
@@ -284,21 +255,18 @@ contains
                              sim2D,            &  ! input/output: read data 2D sim
                              ierr, message)       ! output: error control
  implicit none
- ! input variables
- character(*), intent(in)                :: fname              ! filename
- character(*), intent(in)                :: var_name           ! variable name
- integer(i4b), intent(in)                :: time_index         ! index of time element
- integer(i4b), intent(in)                :: nSpace(1:2)        ! dimension of data for one time step
- ! input/output variables
- real(dp), allocatable,  intent(inout)   :: sim(:)             ! runoff for one time step for all spatial dimension
- real(dp), allocatable,  intent(inout)   :: sim2D(:,:)         ! runoff for one time step for all spatial dimension
- ! output variables
- integer(i4b), intent(out)               :: ierr               ! error code
- character(*), intent(out)               :: message            ! error message
+ ! argument variables
+ character(*),          intent(in)      :: fname              ! filename
+ character(*),          intent(in)      :: var_name           ! variable name
+ integer(i4b),          intent(in)      :: time_index         ! index of time element
+ integer(i4b),          intent(in)      :: nSpace(1:2)        ! dimension of data for one time step
+ real(dp), allocatable, intent(inout)   :: sim(:)             ! runoff for one time step for all spatial dimension
+ real(dp), allocatable, intent(inout)   :: sim2D(:,:)         ! runoff for one time step for all spatial dimension
+ integer(i4b), intent(out)              :: ierr               ! error code
+ character(*), intent(out)              :: message            ! error message
  ! local variables
- character(len=strLen)                   :: cmessage           ! error message from subroutine
+ character(len=strLen)                  :: cmessage           ! error message from subroutine
 
- ! initialize error control
  ierr=0; message='read_runoff_data/'
 
  if (nSpace(2) == integerMissing) then
@@ -309,36 +277,33 @@ contains
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  endif
 
- end subroutine read_runoff_data
+ END SUBROUTINE read_runoff_data
 
  ! *********************************************************************
  ! private subroutine: read 2D runoff data
  ! *********************************************************************
- subroutine read_1D_runoff(fname,          &  ! input: filename
+ SUBROUTINE read_1D_runoff(fname,          &  ! input: filename
                            var_name,       &  ! input: variable name
                            time_index,     &  ! input: time index
                            nSpace,         &  ! input: size of HRUs
                            sim,            &  ! input/output: runoff data structure
                            ierr, message)     ! output: error control
  implicit none
- ! input variables
- character(*), intent(in)                :: fname              ! filename
- character(*), intent(in)                :: var_name           ! variable name
- integer(i4b), intent(in)                :: time_index         ! index of time element
- integer(i4b), intent(in)                :: nSpace             ! size of spatial dimensions
- ! input/output variables
- real(dp), allocatable,  intent(inout)   :: sim(:)             ! runoff for one time step for all spatial dimension
- ! output variables
- integer(i4b), intent(out)               :: ierr               ! error code
- character(*), intent(out)               :: message            ! error message
+ ! argument variables
+ character(*),          intent(in)      :: fname              ! filename
+ character(*),          intent(in)      :: var_name           ! variable name
+ integer(i4b),          intent(in)      :: time_index         ! index of time element
+ integer(i4b),          intent(in)      :: nSpace             ! size of spatial dimensions
+ real(dp), allocatable, intent(inout)   :: sim(:)             ! runoff for one time step for all spatial dimension
+ integer(i4b),          intent(out)     :: ierr               ! error code
+ character(*),          intent(out)     :: message            ! error message
  ! local variables
- integer(i4b)                            :: iStart(2)
- integer(i4b)                            :: iCount(2)
- logical(lgt)                            :: existFillVal
- real(dp)                                :: dummy(nSpace,1)    ! data read
- character(len=strLen)                   :: cmessage           ! error message from subroutine
+ integer(i4b)                           :: iStart(2)
+ integer(i4b)                           :: iCount(2)
+ logical(lgt)                           :: existFillVal
+ real(dp)                               :: dummy(nSpace,1)    ! data read
+ character(len=strLen)                  :: cmessage           ! error message from subroutine
 
- ! initialize error control
  ierr=0; message='read_1D_runoff/'
 
  ! get the simulated runoff data
@@ -360,12 +325,12 @@ contains
  ! reshape
  sim(1:nSpace) = dummy(1:nSpace,1)
 
- end subroutine read_1D_runoff
+ END SUBROUTINE read_1D_runoff
 
  ! *********************************************************************
  ! private subroutine: read 2D runoff data
  ! *********************************************************************
- subroutine read_2D_runoff(fname,            &  ! input: filename
+ SUBROUTINE read_2D_runoff(fname,            &  ! input: filename
                            var_name,         &  ! input: variable name
                            time_index,       &  ! input: time index
                            nSpace,           &  ! input: size of HRUs
@@ -373,24 +338,20 @@ contains
                            ierr, message)       ! output: error control
  implicit none
  ! input variables
- character(*), intent(in)                :: fname            ! filename
- character(*), intent(in)                :: var_name         ! variable name
- integer(i4b), intent(in)                :: time_index       ! index of time element
- integer(i4b), intent(in)                :: nSpace(1:2)      ! size of spatial dimensions
- ! input/output variables
- real(dp), allocatable,  intent(inout)   :: sim2D(:,:)       ! runoff for one time step for all spatial dimension
- ! output variables
- integer(i4b), intent(out)               :: ierr             ! error code
- character(*), intent(out)               :: message          ! error message
+ character(*),          intent(in)      :: fname            ! filename
+ character(*),          intent(in)      :: var_name         ! variable name
+ integer(i4b),          intent(in)      :: time_index       ! index of time element
+ integer(i4b),          intent(in)      :: nSpace(1:2)      ! size of spatial dimensions
+ real(dp), allocatable, intent(inout)   :: sim2D(:,:)       ! runoff for one time step for all spatial dimension
+ integer(i4b),          intent(out)     :: ierr             ! error code
+ character(*),          intent(out)     :: message          ! error message
  ! local variables
- logical(lgt)                            :: existFillVal
- integer(i4b)                            :: iStart(3)
- integer(i4b)                            :: iCount(3)
- real(dp)                                :: dummy(nSpace(2),nSpace(1),1) ! data read
- character(len=strLen)                   :: cmessage                     ! error message from subroutine
+ logical(lgt)                           :: existFillVal
+ integer(i4b)                           :: iStart(3)
+ integer(i4b)                           :: iCount(3)
+ real(dp)                               :: dummy(nSpace(2),nSpace(1),1) ! data read
+ character(len=strLen)                  :: cmessage                     ! error message from subroutine
 
-
- ! initialize error control
  ierr=0; message='read_2D_runoff/'
 
  ! get the simulated runoff data
@@ -412,6 +373,6 @@ contains
  ! reshape
  sim2d(1:nSpace(2),1:nSpace(1)) = dummy(1:nSpace(2),1:nSpace(1),1)
 
- end subroutine read_2D_runoff
+ END SUBROUTINE read_2D_runoff
 
 END MODULE read_runoff

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -38,7 +38,9 @@ MODULE var_lookup
   integer(i4b)     :: tbound       = integerMissing   ! 2 elelment time bound vector
   integer(i4b)     :: ens          = integerMissing   ! runoff ensemble
   integer(i4b)     :: wave         = integerMissing   ! waves in a channel
-  integer(i4b)     :: fdmesh       = integerMissing   ! finite difference computational molecule
+  integer(i4b)     :: mol_kw       = integerMissing   ! kw finite difference computational molecule
+  integer(i4b)     :: mol_mc       = integerMissing   ! mc finite difference computational molecule
+  integer(i4b)     :: mol_dw       = integerMissing   ! kw finite difference computational molecule
   integer(i4b)     :: tdh_irf      = integerMissing   ! irf routed future channel flow in a segment
   integer(i4b)     :: tdh          = integerMissing   ! uh routed future overland flow
  endtype iLook_stateDims
@@ -242,7 +244,7 @@ MODULE var_lookup
  ! ***********************************************************************************************************
  type(iLook_struct)   ,public,parameter :: ixStruct    = iLook_struct   (1,2,3,4,5)
  type(iLook_dims)     ,public,parameter :: ixDims      = iLook_dims     (1,2,3,4,5,6,7)
- type(iLook_stateDims),public,parameter :: ixStateDims = iLook_stateDims(1,2,3,4,5,6,7,8)
+ type(iLook_stateDims),public,parameter :: ixStateDims = iLook_stateDims(1,2,3,4,5,6,7,8,9,10)
  type(iLook_qDims)    ,public,parameter :: ixqDims     = iLook_qDims    (1,2,3,4)
  type(iLook_HRU)      ,public,parameter :: ixHRU       = iLook_HRU      (1)
  type(iLook_HRU2SEG)  ,public,parameter :: ixHRU2SEG   = iLook_HRU2SEG  (1,2,3,4)


### PR DESCRIPTION
Goal: To enable reach routing with multiple methods at the same run. User can select multiple routing methods.

Important note: routOpt = 0 runs IRF and KWT previously. With the changes made in this pull-request, the run will be terminated right after reading control file if you set routOpt to 0.  To run IRF and KWT the same time, set routOpt to 12.

[x ] the results from the run with this commit reproduce the current develop