### PR TITLE
Fix rpointer file IO

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -577,6 +577,7 @@ CONTAINS
     nio = getavu()
     locfn = './'// trim(rpntfil)//trim(inst_suffix)
     call opnfil (locfn, nio, 'f')
+    read (nio,*)
     read (nio,'(a256)') pnamer
     call relavu (nio)
 

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -99,6 +99,8 @@ MODULE globalData
   integer(i4b),                    public :: ixPrint(1:2)=integerMissing ! index of desired reach to be on-screen print
   integer(i4b),                    public :: nEns=1                      ! number of ensemble
   type(cMolecule),                 public :: nMolecule                   ! number of computational molecule (used for KW, MC, DW)
+  character(300),                  public :: hfileout=charMissing        ! name of the history output file
+  character(300),                  public :: rfileout=charMissing        ! name of the restart output file
 
   ! ---------- MPI/OMP/PIO variables ----------------------------------------------------------------
 
@@ -125,10 +127,10 @@ MODULE globalData
   ! spatial constant ....
   real(dp),                        public :: fshape                     ! shape parameter in time delay histogram (=gamma distribution) [-]
   real(dp),                        public :: tscale                     ! scaling factor for the time delay histogram [sec]
-  real(dp),                        public :: velo                       ! velocity [m/s] for Saint-Venant equation   added by NM
-  real(dp),                        public :: diff                       ! diffusivity [m2/s] for Saint-Venant equation   added by NM
-  real(dp),                        public :: mann_n                     ! manning's roughness coefficient [unitless]  added by NM
-  real(dp),                        public :: wscale                     ! scaling factor for river width [-] added by NM
+  real(dp),                        public :: velo                       ! velocity [m/s] for Saint-Venant equation
+  real(dp),                        public :: diff                       ! diffusivity [m2/s] for Saint-Venant equation
+  real(dp),                        public :: mann_n                     ! manning's roughness coefficient [unitless]
+  real(dp),                        public :: wscale                     ! scaling factor for river width [-]
 
   ! ---------- general structure information --------------------------------------------------------
 


### PR DESCRIPTION
This change correctly write last history and restart file paths in rpointer file (this is continue run).

Note: "continue run" means the simulation resumes at the next time step of the end of the previous simulation, using restart file written at the end of the previous simulation.  The output is written in existing history file (not creating new history file)

[x ] The results from the run with this commit does not change the simulation results
[x ] This commit is backward compatibility.