### PR TITLE
miscellaneous changes

### DIFF
--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -317,7 +317,7 @@ CONTAINS
 
     deallocate(array_dp_temp, array_int_temp, stat=ierr, errmsg=cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-    allocate(array_dp_temp(nRch_in), array_int_temp(nHRU_in), stat=ierr, errmsg=cmessage)
+    allocate(array_dp_temp(nHRU_in), array_int_temp(nHRU_in), stat=ierr, errmsg=cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     do ix=1,nVarsHRU2SEG

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -230,6 +230,8 @@ CONTAINS
       hru_per_proc(idx) = hru_per_proc(idx) + sizeo(domains_mpi(ix)%hruIndex)
     end do
 
+    deallocate(domains_mpi)
+
     ! Reorder reachID and basinID for output to match up with order of RCHFLX/RCHSTA reach order and basinRunoff hru order
     reachID(1:nRch_in) = reachID( ixRch_order )
     basinID(1:nHRU_in) = basinID( ixHRU_order )

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -1,28 +1,21 @@
 MODULE model_setup
 
-USE nrtype,    ONLY: i4b,dp,lgt          ! variable types, etc.
-USE nrtype,    ONLY: strLen              ! length of characters
-
-USE public_var, ONLY: iulog              ! i/o logical unit number
-USE public_var, ONLY: debug
-USE public_var, ONLY: integerMissing
-USE public_var, ONLY: realMissing
-USE public_var, ONLY: charMissing
-
-USE init_model_data,  ONLY: init_ntopo_data
-USE init_model_data,  ONLY: init_state_data
-USE init_model_data,  ONLY: get_mpi_omp
-USE init_model_data,  ONLY: update_time
-
-USE nr_utility_module, ONLY : unique  ! get unique element array
-USE nr_utility_module, ONLY : indexx  ! get rank of data value
+USE nrtype,            ONLY: i4b,dp,lgt
+USE nrtype,            ONLY: strLen
+USE public_var,        ONLY: iulog
+USE public_var,        ONLY: debug
+USE public_var,        ONLY: integerMissing
+USE public_var,        ONLY: realMissing
+USE public_var,        ONLY: charMissing
+USE nr_utility_module, ONLY: unique         ! get unique element array
+USE nr_utility_module, ONLY: indexx         ! get rank of data value
 
 implicit none
 
-! privacy -- everything private unless declared explicitly
 private
 public :: init_mpi
 public :: init_data
+
 CONTAINS
 
  ! *********************************************************************
@@ -32,13 +25,11 @@ CONTAINS
 
   ! Initialize MPI and get OMP thread
 
-  ! shared data used
-  USE globalData, ONLY: mpicom_route ! communicator id
-  ! subroutines: populate metadata
-  USE mpi_utils,  ONLY: shr_mpi_init
+  USE globalData,      ONLY: mpicom_route ! communicator id
+  USE init_model_data, ONLY: get_mpi_omp
+  USE mpi_utils,       ONLY: shr_mpi_init
 
   implicit none
-
   ! input:  None
   ! output: None
   ! local variables
@@ -64,6 +55,8 @@ CONTAINS
 
    USE public_var,          ONLY: continue_run        ! T-> append output in existing history files. F-> write output in new history file
    USE mpi_process,         ONLY: pass_global_data    ! mpi globaldata copy to slave proc
+   USE init_model_data,     ONLY: init_ntopo_data
+   USE init_model_data,     ONLY: init_state_data
    USE write_simoutput_pio, ONLY: init_histFile       ! open existing history file to append (only continue_run is true)
 
    implicit none

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -448,9 +448,13 @@ CONTAINS
 
  do jDim =1,nQdims
    if (jDim ==ixQdims%time) then ! time dimension (unlimited)
-    call def_dim(pioFileDesc, trim(meta_qDims(jDim)%dimName), recordDim, meta_qDims(jDim)%dimId)
+     call def_dim(pioFileDesc, trim(meta_qDims(jDim)%dimName), recordDim, meta_qDims(jDim)%dimId)
+   else if (jDim==ixQdims%hru) then
+     if (meta_rflx(ixRFLX%basRunoff)%varFile) then
+       call def_dim(pioFileDesc, trim(meta_qDims(jDim)%dimName), meta_qDims(jDim)%dimLength, meta_qDims(jDim)%dimId)
+     end if
    else
-    call def_dim(pioFileDesc, trim(meta_qDims(jDim)%dimName), meta_qDims(jDim)%dimLength, meta_qDims(jDim)%dimId)
+     call def_dim(pioFileDesc, trim(meta_qDims(jDim)%dimName), meta_qDims(jDim)%dimLength, meta_qDims(jDim)%dimId)
    endif
  end do
 

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -327,8 +327,10 @@ CONTAINS
    call openFile(pioSystem, pioFileDesc, trim(hfileout), pio_typename, ncd_write, isHistFileOpen, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-   call write_netcdf(pioFileDesc, 'basinID', basinID, [1], [nHRU], ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   if (meta_rflx(ixRFLX%basRunoff)%varFile) then
+     call write_netcdf(pioFileDesc, 'basinID', basinID, [1], [nHRU], ierr, cmessage)
+     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   end if
 
    call write_netcdf(pioFileDesc, 'reachID', reachID, [1], [nRch], ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -436,7 +438,8 @@ CONTAINS
                  ixHRU(ix1:ix2),& ! input:
                  iodesc_hru_ro)
 
- if (createNewFile) then
+ if (.not. createNewFile) return
+
  ! --------------------
  ! define file
  ! --------------------
@@ -461,43 +464,41 @@ CONTAINS
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! define hru ID and reach ID variables
- call def_var(pioFileDesc, 'basinID', ncd_int, ierr, cmessage, pioDimId=[meta_qDims(ixQdims%hru)%dimId], vdesc='basin ID', vunit='-')
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ if (meta_rflx(ixRFLX%basRunoff)%varFile) then
+   call def_var(pioFileDesc, 'basinID', ncd_int, ierr, cmessage, pioDimId=[meta_qDims(ixQdims%hru)%dimId], vdesc='basin ID', vunit='-')
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+ end if
 
  call def_var(pioFileDesc, 'reachID', ncd_int, ierr, cmessage, pioDimId=[meta_qDims(ixQdims%seg)%dimId], vdesc='reach ID', vunit='-')
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! define flux variables
  do iVar=1,nVarsRFLX
+   if (.not.meta_rflx(iVar)%varFile) cycle
 
-  if (.not.meta_rflx(iVar)%varFile) cycle
+   ! define dimension ID array
+   nDims = size(meta_rflx(iVar)%varDim)
+   if (allocated(dim_array)) then
+     deallocate(dim_array)
+   endif
+   allocate(dim_array(nDims))
+   do ixDim = 1, nDims
+     dim_array(ixDim) = meta_qDims(meta_rflx(iVar)%varDim(ixDim))%dimId
+   end do
 
-  ! define dimension ID array
-  nDims = size(meta_rflx(iVar)%varDim)
-  if (allocated(dim_array)) then
-    deallocate(dim_array)
-  endif
-  allocate(dim_array(nDims))
-  do ixDim = 1, nDims
-    dim_array(ixDim) = meta_qDims(meta_rflx(iVar)%varDim(ixDim))%dimId
-  end do
-
-  ! define variable
-  call def_var(pioFileDesc,            &                 ! pio file descriptor
-              meta_rflx(iVar)%varName, &                 ! variable name
-              ncd_float,               &                 ! dimension array and type
-              ierr, cmessage,          &                 ! error handling
-              pioDimId=dim_array,      &                 ! dimension id
-              vdesc=meta_rflx(iVar)%varDesc, vunit=meta_rflx(iVar)%varUnit)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
+   ! define variable
+   call def_var(pioFileDesc,             &                 ! pio file descriptor
+                meta_rflx(iVar)%varName, &                 ! variable name
+                ncd_float,               &                 ! dimension array and type
+                ierr, cmessage,          &                 ! error handling
+                pioDimId=dim_array,      &                 ! dimension id
+                vdesc=meta_rflx(iVar)%varDesc, vunit=meta_rflx(iVar)%varUnit)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end do
 
  ! end definitions
  call end_def(pioFileDesc, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
- end if
 
  END SUBROUTINE defineFile
 


### PR DESCRIPTION
1. if saved data structures (defined in globalData.f90) are not used any longer, deallocate them.
 - domains_mpi
 
2. basinID is not written if basRunoff is not written. 
3. one minor bug fix ([3cb78a8](https://github.com/ESCOMP/mizuRoute/pull/272/commits/3cb78a8b7dc0c8aa095e3bfb34325d485f02e18d))