### PR TITLE
Temporary implementation of the array to export from rof to lnd 

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -473,7 +473,7 @@ CONTAINS
           ix = NETOPO_main(iRch)%HRUIX(iHru)
           rtmCTL%volr(ix)        = 0._r8
           rtmCTL%flood(ix)       = 0._r8
-          rtmCTL%discharge(ix,1) = RCHFLX_trib(iens,main)%ROUTE(idxIRF)%REACH_Q
+          rtmCTL%discharge(ix,1) = RCHFLX_main(iens,iRch)%ROUTE(idxIRF)%REACH_Q
         end do
       end do
     end if

--- a/route/build/src/domain_decomposition.f90
+++ b/route/build/src/domain_decomposition.f90
@@ -21,8 +21,8 @@ implicit none
 logical(lgt) :: domain_debug = .false. ! print out reach info with node assignment for debugging purpose
 
 ! common parameters within this module
-integer(i4b), parameter   :: maxDomainOMP=150000       ! maximum omp domains
-integer(i4b), parameter   :: maxDomainMPI=150000      ! maximum mpi domains
+integer(i4b), parameter   :: maxDomainOMP=700000       ! maximum omp domains
+integer(i4b), parameter   :: maxDomainMPI=500000      ! maximum mpi domains
 integer(i4b), parameter   :: tributary=1
 integer(i4b), parameter   :: mainstem=2
 integer(i4b), parameter   :: endorheic=3


### PR DESCRIPTION
**Background**
mizuRoute has two kinds of model spatial elements—HRU (polygon) and river reach (line).  In the CTSM coupled mode, the coupler can pass various CLM variables as HRU average to mizuRoute, not directly to river reaches. In mizuRoute, HRU average variables are passed to the associated river reach(es) for the processes happening in the reaches.  One example is that the coupler passes CLM total runoff to mizuRoute as HRU average runoff, and then mizuRoute overland-routes the HRU average runoff to river reaches, then routes the runoff along the reach. 

**Potential problem and fix**
In the case where mizuRoute needs to pass some variables (computed by mizuRoute) to CLM through the coupler, the coupler expects the variables are at HRU element not reach element.  Therefore, mizuRoute needs to re-distribute reach variables to the HRUs so that the coupler can pass the variables to CLM. If HRU and reach is one-to-one relationship and HRU ID and ID of the associated reach are the same (this is the most of river network), essentially there is no need to pass back reach variables to the HRU.  if not or if reach-HRU relationship is one-to-many relationship (i.e., many HRUs are associated with one reach), _mizuRoute has to re-distribute reach variables (computed by mizuRoute) to the associated HRUs_.  

This pull-request is to provide some template for this.