### PR TITLE
Fixed the restart error when single core is used.

### DIFF
--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -676,17 +676,21 @@ CONTAINS
       RCHFLX_main(iens, iSeg) = RCHFLX(iens, jSeg)
       RCHSTA_main(iens, iSeg) = RCHSTA(iens, jSeg)
     end do
-    do iSeg = 1,size(global_ix_comm)
-      jSeg = global_ix_comm(iSeg)
-      RCHFLX_main(iens, iSeg+nRch_mainstem) = RCHFLX(iens, jSeg)
-      RCHSTA_main(iens, iSeg+nRch_mainstem) = RCHSTA(iens, jSeg)
-    end do
+    if (multiProcs) then
+      do iSeg = 1,size(global_ix_comm)
+        jSeg = global_ix_comm(iSeg)
+        RCHFLX_main(iens, iSeg+nRch_mainstem) = RCHFLX(iens, jSeg)
+        RCHSTA_main(iens, iSeg+nRch_mainstem) = RCHSTA(iens, jSeg)
+      end do
+    end if
   else
     flux_global(:)  = realMissing
     if (onRoute(impulseResponseFunc)) then
       vol_global(:,:) = realMissing
     end if
   endif
+
+  if (.not. multiProcs) return
 
   ! Distribute global flux/state (RCHFLX & RCHSTA) to tributary (RCHFLX_trib & RCHSTA_trib)
   ! flux communication (only basin delayed runoff flux)


### PR DESCRIPTION
Bug: when a single core is used,  state data scattering failed after restart file is read (because `global_ix_comm` is initialized only when multi-core is used).

When a single core is used, some of lines (mpi scattering, and array initialization on distributed cores) do not need to be executed.

Fix #280