### PR TITLE
Added accumRunoff as a part of routing scheme options with routOpt=0

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -227,10 +227,10 @@ end type subdomain
  end type irfRCH
 
  ! ---------- computational molecule ---------------------------------
- type, public :: cMolecule 
-   integer(i4b)           :: KW_ROUTE 
-   integer(i4b)           :: MC_ROUTE 
-   integer(i4b)           :: DW_ROUTE 
+ type, public :: cMolecule
+   integer(i4b)           :: KW_ROUTE
+   integer(i4b)           :: MC_ROUTE
+   integer(i4b)           :: DW_ROUTE
  end type cMolecule
 
  type, public :: SUBRCH
@@ -273,7 +273,6 @@ end type subdomain
   real(dp)                             :: BASIN_QR(0:1)     ! routed runoff volume from the local basin (m3/s)
   real(dp)                             :: BASIN_QR_IRF(0:1) ! routed runoff volume from all the upstream basin (m3/s)
   type(fluxes), allocatable            :: ROUTE(:)          ! reach fluxes and states for each routing method
-  real(dp)                             :: UPSTREAM_QI       ! sum of upstream streamflow (m3/s)
   real(dp)                             :: TAKE              ! average take
  ENDTYPE STRFLX
 

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -1,7 +1,7 @@
 MODULE globalData
   ! This module includes global data structures
 
-  USE public_var, ONLY : integerMissing
+  USE public_var
 
   ! data types
   USE nrtype
@@ -113,6 +113,8 @@ MODULE globalData
   ! routing methods
   integer(i4b)                   , public :: nRoutes              ! number of active routing methods
   integer(i4b)    , allocatable  , public :: routeMethods(:)      ! active routing method id
+  logical(lgt)                   , public :: onRoute(0:nRouteMethods-1) ! logical to indicate active routing method(s)
+  integer(i4b)                   , public :: idxSUM                     ! index of SUM method
   integer(i4b)                   , public :: idxIRF               ! index of IRF method
   integer(i4b)                   , public :: idxKWT               ! index of KWT method
   integer(i4b)                   , public :: idxKW                ! index of KW method

--- a/route/build/src/nr_utility.f90
+++ b/route/build/src/nr_utility.f90
@@ -24,13 +24,20 @@ interface unique
   module procedure unique_i8b
 end interface
 
+INTERFACE char2int
+  module procedure :: char2int_1d
+  module procedure :: char2int_2d
+END INTERFACE
+
 private
 public::arth
 public::indexx
 public::findIndex
+public::match_index
 public::indexTrue
 public::unique
 public::get_digits
+public::char2int
 
 CONTAINS
 
@@ -268,87 +275,84 @@ CONTAINS
  END SUBROUTINE swap_i8b
 
  ! ************************************************************************************************
- ! * findIndex: find the first index within a vector
+ ! findIndex: find the first index within a vector
  ! ************************************************************************************************
  function findIndex(vector,desiredValue,missingValue)
- ! finds the first index within a vector
- !  -- if the index does not exist, returns zero
- ! NOTE: workaround for (not-yet-implemented) f2008 intrinsic findloc
- implicit none
- ! argument variables
- integer(i4b),intent(in)            :: vector(:)    ! vector to search
- integer(i4b),intent(in)            :: desiredValue ! desired value in the vector
- integer(i4b),intent(in),optional   :: missingValue ! desired missing value if desiredValue is not found
- integer(i4b)                       :: findIndex    ! first index of the desired value in the vector
- ! local variables
- integer(i4b),dimension(1)          :: vecIndex     ! first index of the desired value in the vector (vec of length=1)
+   ! NOTE: if the index does not exist, returns zero
+   !        workaround for (not-yet-implemented) f2008 intrinsic findloc
+   implicit none
+   ! argument variables
+   integer(i4b),intent(in)            :: vector(:)    ! vector to search
+   integer(i4b),intent(in)            :: desiredValue ! desired value in the vector
+   integer(i4b),intent(in),optional   :: missingValue ! desired missing value if desiredValue is not found
+   integer(i4b)                       :: findIndex    ! first index of the desired value in the vector
+   ! local variables
+   integer(i4b),dimension(1)          :: vecIndex     ! first index of the desired value in the vector (vec of length=1)
 
- ! check if the value exisits
- if(any(vector==desiredValue))then
-
-  ! get the index: merge provides a vector with 1s where mask is true and 0s otherwise, so maxloc(merge) is the first index of value=1
-  vecIndex=maxloc( merge(1, 0, vector==desiredValue) )
-
- else
-  if(present(missingValue))then
-   vecIndex=missingValue
-  else
-   vecIndex=0
-  endif
- endif
-
- findIndex=vecIndex(1)
-
+   ! check if the value exisits
+   if(any(vector==desiredValue))then
+     ! get the index: merge provides a vector with 1s where mask is true and 0s otherwise, so maxloc(merge) is the first index of value=1
+     vecIndex=maxloc( merge(1, 0, vector==desiredValue) )
+   else
+     if(present(missingValue))then
+       vecIndex=missingValue
+     else
+       vecIndex=0
+     endif
+   endif
+   findIndex=vecIndex(1)
  end function findIndex
 
+ ! *************************************************************************************************
+ ! Return indices of True in TF array
+ ! *************************************************************************************************
  subroutine indexTrue(TF,pos)
-  ! Return indices of True in TF array
-  implicit none
-  ! argument variables
-  logical(lgt),intent(in)                :: TF(:)           ! Logical vector (True or False)
-  integer(i4b), allocatable, intent(out) :: pos(:)          ! position of "true" conditions
-  ! Local variables
-  integer(i4b)                           :: npos            ! number of "true" conditions
-  integer(i4b)                           :: idx(size(TF))   ! vector of all positions
+   implicit none
+   ! argument variables
+   logical(lgt),intent(in)                :: TF(:)           ! Logical vector (True or False)
+   integer(i4b), allocatable, intent(out) :: pos(:)          ! position of "true" conditions
+   ! Local variables
+   integer(i4b)                           :: npos            ! number of "true" conditions
+   integer(i4b)                           :: idx(size(TF))   ! vector of all positions
 
-  idx = arth(1,1,size(TF))           ! Enumerate all positions
-  npos  = count(TF)                  ! Count the elements of TF that are .True.
-  allocate(pos(npos))
-  pos = pack(idx,TF)                 ! With Pack function, verify position of true conditions
-
+   idx = arth(1,1,size(TF))           ! Enumerate all positions
+   npos  = count(TF)                  ! Count the elements of TF that are .True.
+   allocate(pos(npos))
+   pos = pack(idx,TF)                 ! With Pack function, verify position of true conditions
  end subroutine indexTrue
 
+ ! *************************************************************************************************
+ ! Find unique elements and indices given array
+ ! *************************************************************************************************
  SUBROUTINE unique_i4b(array, unq, idx)
-  implicit none
-  ! argument variables
-  integer(i4b),            intent(in)  :: array(:)             ! integer array including duplicated elements
-  integer(i4b),allocatable,intent(out) :: unq(:)               ! integer array including unique elements
-  integer(i4b),allocatable,intent(out) :: idx(:)               ! integer array including unique element index
-  ! local variables
-  integer(i4b)                         :: ranked(size(array))  !
-  integer(i4b)                         :: unq_tmp(size(array)) !
-  logical(lgt)                         :: flg_tmp(size(array)) !
-  integer(i4b)                         :: ix                   ! loop index, counter
-  integer(i4b)                         :: last_unique          ! last unique element
+   implicit none
+   ! argument variables
+   integer(i4b),            intent(in)  :: array(:)             ! integer array including duplicated elements
+   integer(i4b),allocatable,intent(out) :: unq(:)               ! integer array including unique elements
+   integer(i4b),allocatable,intent(out) :: idx(:)               ! integer array including unique element index
+   ! local variables
+   integer(i4b)                         :: ranked(size(array))  !
+   integer(i4b)                         :: unq_tmp(size(array)) !
+   logical(lgt)                         :: flg_tmp(size(array)) !
+   integer(i4b)                         :: ix                   ! loop index, counter
+   integer(i4b)                         :: last_unique          ! last unique element
 
-  flg_tmp = .false.
-  call indexx(array, ranked)
+   flg_tmp = .false.
+   call indexx(array, ranked)
 
-  unq_tmp(ranked(1)) = array(ranked(1))
-  flg_tmp(ranked(1)) = .true.
-  last_unique = array(ranked(1))
-  do ix = 2,size(ranked)
-    if (last_unique==array(ranked(ix))) cycle
-    flg_tmp(ranked(ix)) = .true.
-    unq_tmp(ranked(ix)) = array(ranked(ix))
-    last_unique = array(ranked(ix))
-  end do
+   unq_tmp(ranked(1)) = array(ranked(1))
+   flg_tmp(ranked(1)) = .true.
+   last_unique = array(ranked(1))
+   do ix = 2,size(ranked)
+     if (last_unique==array(ranked(ix))) cycle
+     flg_tmp(ranked(ix)) = .true.
+     unq_tmp(ranked(ix)) = array(ranked(ix))
+     last_unique = array(ranked(ix))
+   end do
 
-  allocate(unq(count(flg_tmp)),idx(count(flg_tmp)))
-
-  idx = pack(arth(1,1,size(array)), flg_tmp)
-  unq = unq_tmp(idx)
-
+   allocate(unq(count(flg_tmp)),idx(count(flg_tmp)))
+   idx = pack(arth(1,1,size(array)), flg_tmp)
+   unq = unq_tmp(idx)
  END SUBROUTINE unique_i4b
  ! ------------------------------------------------------------------------------------------------
  SUBROUTINE unique_i8b(array, unq, idx)
@@ -384,6 +388,9 @@ CONTAINS
 
  END SUBROUTINE unique_i8b
 
+ ! *************************************************************************************************
+ ! * convert integer to digit array
+ ! *************************************************************************************************
  FUNCTION get_digits(num) result(digs)
    implicit none
    ! argument variables
@@ -404,5 +411,121 @@ CONTAINS
      end do
    end if
  END FUNCTION get_digits
+
+ ! *************************************************************************************************
+ ! character-to-integer routines/functions
+ ! *************************************************************************************************
+ SUBROUTINE char2int_1d(char_array, int_array, invalid_value)
+   ! Convert character array to one digit integer array
+   ! if character array is '-9999' or '0', int_array(:) = [invalid_value,...,invalid_value]
+   implicit none
+   ! argument variables
+   character(*),              intent(in)   :: char_array
+   integer(i4b), allocatable, intent(out)  :: int_array(:)
+   integer(i4b), optional,    intent(in)   :: invalid_value
+   ! local variables
+   character(len=strLen)                   :: string
+   integer(i4b)                            :: str_len
+   integer(i4b)                            :: iChr
+   integer(i4b)                            :: invalValue
+
+   if (present(invalid_value)) then
+     invalValue = invalid_value
+   else
+     invalValue = -1
+   endif
+
+   allocate(int_array(len(char_array)))
+   int_array = invalValue
+
+   string = adjustl(char_array)
+   str_len = len(trim(string))
+
+   if (trim(string)=='-9999' .or. trim(string)=='0') then
+     int_array(1) = invalValue
+   else
+     do iChr =1,str_len
+       read(string(iChr:iChr),'(I1)') int_array(iChr)
+     end do
+   endif
+ END SUBROUTINE char2int_1d
+
+ SUBROUTINE char2int_2d(char_array, int_array, invalid_value)
+   ! convert character array to one digit integer array
+   ! if character array is '-9999' or '0', int_array(:) = [invalid_value,...,invalid_value]
+   implicit none
+   ! Argument variables
+   character(*),              intent(in)   :: char_array(:)
+   integer(i4b), allocatable, intent(out)  :: int_array(:,:)
+   integer(i4b), optional,    intent(in)   :: invalid_value
+   ! local variables
+   character(len=strLen)                   :: string
+   integer(i4b)                            :: str_len
+   integer(i4b)                            :: iSize
+   integer(i4b)                            :: iChr
+   integer(i4b)                            :: invalValue
+
+  if (present(invalid_value)) then
+    invalValue = invalid_value
+  else
+    invalValue = -1
+  endif
+
+   allocate(int_array(size(char_array),len(char_array)))
+   int_array = invalValue
+
+   do iSize = 1, size(char_array)
+     str_len = len(trim(adjustl(char_array(iSize))))
+     string = adjustl(char_array(iSize))
+     if (trim(string) == '-9999' .or. trim(string) == '0') then
+       int_array(iSize, 1) = invalValue
+     else
+       do iChr =1,str_len
+         read(string(iChr:iChr),'(I1)') int_array(iSize, iChr)
+       end do
+     end if
+   end do
+ END SUBROUTINE char2int_2d
+
+  ! ************************************************************************************************
+  ! match_index: find array1 indix for each array2 element if array2 includes matching element in array1
+  ! ************************************************************************************************
+  FUNCTION match_index(array1, array2, missingValue) RESULT(index1)
+    implicit none
+    ! Argument variables:
+    integer(i4b), allocatable, intent(in)  :: array1(:)
+    integer(i4b), allocatable, intent(in)  :: array2(:)
+    integer(i4b), optional,    intent(in)  :: missingValue ! desired missing value if desiredValue is not found
+    ! Local variables:
+    integer(i4b), allocatable              :: index1(:)
+    integer(i4b), allocatable              :: rnkArray1(:)
+    integer(i4b), allocatable              :: rnkArray2(:)
+    integer(i4b)                           :: ix, jx, begIx
+
+    allocate(index1(size(array2)), rnkArray1(size(array1)), rnkArray2(size(array2)) )
+
+    if(present(missingValue))then
+      index1=missingValue
+    else
+      index1 = -9999
+    endif
+
+    call indexx(array1, rnkArray1)
+    call indexx(array2, rnkArray2)
+
+    begIx=1
+    do ix=1,size(rnkArray2)
+      do jx=begIx,size(rnkArray1)
+        if (array2(rnkArray2(ix))==array1(rnkArray1(jx))) then
+          index1(rnkArray2(ix)) = rnkArray1(jx)
+          begIx=jx
+          exit
+        else if (array2(rnkArray2(ix))<array1(rnkArray1(jx))) then
+          begIx=jx
+          exit
+        end if
+      end do
+    end do
+  END FUNCTION
 
 END MODULE nr_utility_module

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -61,7 +61,8 @@ module public_var
   integer(i4b), parameter,public  :: readFromFile=0         ! read given variable from a file
 
   ! routing methods
-  integer(i4b), parameter,public  :: nRouteMethods=5         ! number of routing methods available
+  integer(i4b), parameter,public  :: nRouteMethods=6         ! number of routing methods available
+  integer(i4b), parameter,public  :: accumRunoff=0           ! runoff accumulation over all the upstream reaches
   integer(i4b), parameter,public  :: impulseResponseFunc=1   ! impulse response function
   integer(i4b), parameter,public  :: kinematicWaveTracking=2 ! Lagrangian kinematic wave
   integer(i4b), parameter,public  :: kinematicWave=3         ! kinematic wave
@@ -76,9 +77,6 @@ module public_var
   character(len=strLen),public    :: input_dir            = ''              ! directory containing input runoff netCDF
   character(len=strLen),public    :: output_dir           = ''              ! directory for routed flow output (netCDF)
   character(len=strLen),public    :: restart_dir          = charMissing     ! directory for restart output (netCDF)
-  ! SIMULATION TIME
-  character(len=strLen),public    :: simStart             = ''              ! date string defining the start of the simulation
-  character(len=strLen),public    :: simEnd               = ''              ! date string defining the end of the simulation
   ! RIVER NETWORK TOPOLOGY
   character(len=strLen),public    :: fname_ntopOld        = ''              ! old filename containing stream network topology information
   logical(lgt)         ,public    :: ntopAugmentMode      = .false.         ! option for river network augmentation mode. terminate the program after writing augmented ntopo.
@@ -109,8 +107,12 @@ module public_var
   character(len=strLen),public    :: vname_j_index        = ''              ! variable for numbers of x (longitude) index if runoff file is grid
   character(len=strLen),public    :: dname_hru_remap      = ''              ! dimension name for river network HRU
   character(len=strLen),public    :: dname_data_remap     = ''              ! dimension name for runoff HRU ID
-  ! ROUTED FLOW OUTPUT
+  ! RUN CONTROL
   character(len=strLen),public    :: case_name            = ''              ! name of simulation. used as head of model output and restart file
+  character(len=strLen),public    :: simStart             = ''              ! date string defining the start of the simulation
+  character(len=strLen),public    :: simEnd               = ''              ! date string defining the end of the simulation
+  character(len=10)    ,public    :: routOpt              = '0'             ! routing scheme options  0: accum runoff, 1:IRF, 2:KWT, 3:KW, 4:MC, 5:DW
+  integer(i4b)         ,public    :: doesBasinRoute       = 1               ! basin routing options   0-> no, 1->IRF, otherwise error
   character(len=strLen),public    :: newFileFrequency     = 'annual'        ! frequency for new output files (day, month, annual, single)
   ! STATES
   character(len=strLen),public    :: restart_write        = 'never'         ! restart write option: N[n]ever-> never write, L[l]ast -> write at last time step, S[s]pecified, Monthly, Daily
@@ -132,10 +134,7 @@ module public_var
   ! MISCELLANEOUS
   logical(lgt)         ,public    :: debug                = .false.         ! print out detaled information
   integer(i4b)         ,public    :: idSegOut             = integerMissing  ! id of outlet stream segment
-  integer(i4b)         ,public    :: routOpt              = integerMissing  ! routing scheme options  0-> both, 1->IRF, 2->KWT, otherwise error
   integer(i4b)         ,public    :: desireId             = integerMissing  ! turn off checks or speficy reach ID if necessary to print on screen
-  integer(i4b)         ,public    :: doesBasinRoute       = 1               ! basin routing options   0-> no, 1->IRF, otherwise error
-  integer(i4b)         ,public    :: doesAccumRunoff      = 1               ! option to delayed runoff accumulation over all the upstream reaches
   character(len=strLen),public    :: netcdf_format        = 'netcdf4'       ! netcdf format for output
   ! PFAFCODE
   integer(i4b)         ,public    :: maxPfafLen           = 32              ! maximum digit of pfafstetter code (default 32).

--- a/route/build/src/write_simoutput.f90
+++ b/route/build/src/write_simoutput.f90
@@ -7,7 +7,7 @@ USE public_var,only: iulog
 USE public_var,only: integerMissing
 USE globalData,only: meta_rflx
 USE globalData,only: simout_nc
-USE globalData,only: idxIRF, idxKWT, idxKW, idxMC, idxDW
+USE globalData,only: idxSUM, idxIRF, idxKWT, idxKW, idxMC, idxDW
 USE io_netcdf, only: ncd_int
 USE io_netcdf, only: ncd_float, ncd_double
 USE io_netcdf, only: ncd_unlimited
@@ -84,9 +84,11 @@ CONTAINS
   endif
 
   if (meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile) then
-   ! write accumulated runoff (m3/s)
-   call write_nc(simout_nc%ncid, 'sumUpstreamRunoff', RCHFLX(iens,:)%UPSTREAM_QI, (/1,jTime/), (/nRch,1/), ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+    do ix=1,nRCH
+      array_temp(ix) = RCHFLX(iens, ix)%ROUTE(idxSUM)%REACH_Q
+    end do
+    call write_nc(simout_nc%ncid, 'sumUpstreamRunoff', array_temp, (/1,jTime/), (/nRch,1/), ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
   if (meta_rflx(ixRFLX%KWTroutedRunoff)%varFile) then


### PR DESCRIPTION
accumRunoff (accumulating upstream runoff) is now part of routing scheme options and routOpt=0 enable this scheme.

Previously `routOpt=0` executes KWT and IRF, but now should set `routOpt=12`.  `routOpt=0` gives you warning for this.

[x ] the results from the run with this commit reproduce the current develop