### PR TITLE
Changes in restart and history file frequency specification

### DIFF
--- a/route/build/src/model_setup.f90
+++ b/route/build/src/model_setup.f90
@@ -462,7 +462,7 @@ CONTAINS
  ! "Monthly" option: use 2000-01 as template calendar yr/month
  ! "Daily" option:   use 2000-01-01 as template calendar yr/month/day
  select case(lower(trim(restart_write)))
-   case('annual')
+   case('yearly')
      call dummyCal%set_datetime(2000, restart_month, 1, 0, 0, 0.0_dp)
      nDays = dummyCal%ndays_month(calendar, ierr, cmessage)
      if(ierr/=0) then; message=trim(message)//trim(cmessage); return; endif
@@ -484,7 +484,7 @@ CONTAINS
       dropCal = restCal%add_sec(-dt, calendar, ierr, cmessage)
       if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [restCal->dropCal]'; return; endif
       restart_month = dropCal%month(); restart_day = dropCal%day(); restart_hour = dropCal%hour()
-    case('annual','monthly','daily')
+    case('yearly','monthly','daily')
       call restCal%set_datetime(2000, restart_month, restart_day, restart_hour, 0, 0._dp)
       dropCal = restCal%add_sec(-dt, calendar, ierr, cmessage)
       if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [ dropCal for periodical restart]'; return; endif
@@ -492,7 +492,7 @@ CONTAINS
     case('never')
       call dropCal%set_datetime(integerMissing, integerMissing, integerMissing, integerMissing, integerMissing, realMissing)
     case default
-      ierr=20; message=trim(message)//'Current accepted <restart_write> options: L[l]ast, N[n]ever, S[s]pecified, A[a]nnual, M[m]onthly, D[d]aily'; return
+      ierr=20; message=trim(message)//'Current accepted <restart_write> options: last, never, specified, yearly, monthly, daily'; return
   end select
 
  END SUBROUTINE init_time

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -140,11 +140,11 @@ CONTAINS
    case('<case_name>');            case_name            = trim(cData)              ! name of simulation. used as head of model output and restart file
    case('<sim_start>');            simStart    = trim(cData)                       ! date string defining the start of the simulation
    case('<sim_end>');              simEnd      = trim(cData)                       ! date string defining the end of the simulation
-   case('<route_opt>');            routOpt     = trim(cData)                           ! routing scheme options  0-> accumRunoff, 1->IRF, 2->KWT, 3-> KW, 4->MC, 5->DW
+   case('<route_opt>');            routOpt     = trim(cData)                       ! routing scheme options  0-> accumRunoff, 1->IRF, 2->KWT, 3-> KW, 4->MC, 5->DW
    case('<doesBasinRoute>');       read(cData,*,iostat=io_error) doesBasinRoute    ! basin routing options   0-> no, 1->IRF, otherwise error
-   case('<newFileFrequency>');     newFileFrequency     = trim(cData)              ! frequency for new output files (day, month, annual, single)
+   case('<newFileFrequency>');     newFileFrequency     = trim(cData)              ! frequency for new output options (case-insensitive): daily, monthly, yearly, or single
    ! RESTART
-   case('<restart_write>');        restart_write        = trim(cData)              ! restart write option: N[n]ever, L[l]ast, S[s]pecified, Monthly, Daily
+   case('<restart_write>');        restart_write        = trim(cData)              ! restart write option (case-insensitive): never, last, specified, yearly, monthly, or daily
    case('<restart_date>');         restart_date         = trim(cData)              ! specified restart date, yyyy-mm-dd (hh:mm:ss) for Specified option
    case('<restart_month>');        read(cData,*,iostat=io_error) restart_month     ! restart periodic month
    case('<restart_day>');          read(cData,*,iostat=io_error) restart_day       ! restart periodic day

--- a/route/build/src/write_restart.f90
+++ b/route/build/src/write_restart.f90
@@ -105,7 +105,7 @@ CONTAINS
    select case(lower(trim(restart_write)))
      case('specified','last')
        restartAlarm = (dropCal==modTime(1))
-     case('annual')
+     case('yearly')
        restartAlarm = (dropCal%is_equal_mon(modTime(1)) .and. dropCal%is_equal_day(modTime(1)) .and. dropCal%is_equal_time(modTime(1)))
      case('monthly')
        restartAlarm = (dropCal%is_equal_day(modTime(1)) .and. dropCal%is_equal_time(modTime(1)))
@@ -114,7 +114,7 @@ CONTAINS
      case('never')
        restartAlarm = .false.
      case default
-       ierr=20; message=trim(message)//'Current accepted <restart_write> options: L[l]ast, N[n]ever, S[s]pecified, Annual, Monthly, or Daily '; return
+       ierr=20; message=trim(message)//'Accepted <restart_write> options (case insensitive): last, never, specified, yearly, monthly, or daily '; return
    end select
 
  END SUBROUTINE restart_alarm

--- a/route/build/src/write_simoutput.f90
+++ b/route/build/src/write_simoutput.f90
@@ -139,6 +139,7 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE prep_output(ierr, message)    ! out:   error control
 
+ USE ascii_util_module,   ONLY: lower
  ! saved public variables (usually parameters, or values not modified)
  USE public_var,          only : output_dir        ! output directory
  USE public_var,          only : case_name         ! simulation name ==> output filename head
@@ -168,12 +169,12 @@ CONTAINS
  write(iulog,'(a,I4,4(x,I4))') new_line('a'), modTime(1)%year(), modTime(1)%month(), modTime(1)%day(), modTime(1)%hour(), modTime(1)%minute()
 
  ! check need for the new file
- select case(trim(newFileFrequency))
+ select case(lower(trim(newFileFrequency)))
    case('single'); defNewOutputFile=(modTime(0)%year() ==integerMissing)
-   case('annual'); defNewOutputFile=(modTime(1)%year() /=modTime(0)%year())
-   case('month');  defNewOutputFile=(modTime(1)%month()/=modTime(0)%month())
-   case('day');    defNewOutputFile=(modTime(1)%day()  /=modTime(0)%day())
-   case default; ierr=20; message=trim(message)//'unable to identify the option to define new output files'; return
+   case('yearly'); defNewOutputFile=(modTime(1)%year() /=modTime(0)%year())
+   case('monthly');  defNewOutputFile=(modTime(1)%month()/=modTime(0)%month())
+   case('daily');    defNewOutputFile=(modTime(1)%day()  /=modTime(0)%day())
+   case default; ierr=20; message=trim(message)//'Accepted <newFileFrequency> options (case-insensitive): single yearly, monthly, or daily '; return
  end select
 
  ! define new file

--- a/route/settings/SAMPLE.control
+++ b/route/settings/SAMPLE.control
@@ -21,10 +21,10 @@
 <case_name>             CASE_NAME                  ! name of simulation 
 <sim_start>             yyyy-mm-dd hh:mm:ss        ! time of simulation start (00:00:00 if hh:mm:ss is not included) 
 <sim_end>               yyyy-mm-dd hh:mm:ss        ! time of simulation end (00:00:00 if hh:mm:ss is not included) 
-<route_opt>             0                          ! option for routing schemes 0-> both, 1->IRF, 2->KWT otherwise error 
-<doesBasinRoute>        1                          ! basin routing options   0-> no, 1->IRF, otherwise error
-<doesAccumRunoff>       1                          ! option to delayed runoff accumulation over all the upstream reaches. 0->no, 1->yes
-<restart_write>         Never                      ! restart write options. options: N[n]ever, L[l]ast, S[s]pecified 
+<route_opt>             0                          ! river routing options: 0-> accumRunoff, 1->IRF, 2->KWT, 3-> KW, 4->MC, 5->DW 
+<doesBasinRoute>        1                          ! basin routing options: 0-> no, 1->IRF, otherwise error
+<newFileFrequency>      yearly                     ! frequency for new output options (case-insensitive): daily, monthly, yearly, or single
+<restart_write>         never                      ! restart write option (case-insensitive): never, last, specified, yearly, monthly, or daily 
 <restart_date>          yyyy-mm-dd hh:mm:ss        ! restart date.  activated only if <restart_write> is "specified" 
 <fname_state_in>        INPUT_RESTART_NC           ! input restart netCDF name. remove for run without any particular initial channel states
 ! ****************************************************************************************************************************


### PR DESCRIPTION
- case insensitive.
- use `yearly` instead of `annual`
- use `daily` instead of `day` for history file
