### PR TITLE
exporting volume (volr) to land model and handling negative qgwl

### DIFF
--- a/route/build/cpl/RtmVar.F90
+++ b/route/build/cpl/RtmVar.F90
@@ -49,9 +49,7 @@ MODULE RtmVar
   logical,           public            :: do_rof         = .true.                   !
   logical,           public            :: do_flood       = .false.                  !
   character(len=CL), public            :: nrevsn_rtm     = ' '                      ! restart data file name for branch run
-  character(len=32), public            :: qgwl_runoff_option ='threshold'           ! method for handling qgwl runoff
-  character(len=32), public            :: bypass_routing_option = 'direct_in_place' ! bypass routing model method
-  real(r8),          public            :: river_depth_minimum = 1.e-4               ! gridcell average minimum river depth [m]
+  real(r8),          public            :: river_depth_minimum = 1.e-1               ! minimum river depth for water take [mm]
   integer,           public            :: coupling_period                           ! coupling period
   integer,           public            :: rtmhist_ndens  = 1                        ! namelist: output density of netcdf history files
   integer,           public            :: rtmhist_mfilt  = 30                       ! namelist: number of time samples per tape

--- a/route/build/cpl/RtmVar.F90
+++ b/route/build/cpl/RtmVar.F90
@@ -46,14 +46,17 @@ MODULE RtmVar
   character(len=16), public            :: inst_suffix
 
   ! rof control variables
-  logical,           public            :: do_rof         = .true.          !
-  logical,           public            :: do_flood       = .false.         !
-  character(len=CL), public            :: nrevsn_rtm     = ' '             ! restart data file name for branch run
-  integer,           public            :: coupling_period                  ! coupling period
-  integer,           public            :: rtmhist_ndens  = 1               ! namelist: output density of netcdf history files
-  integer,           public            :: rtmhist_mfilt  = 30              ! namelist: number of time samples per tape
-  integer,           public            :: rtmhist_nhtfrq = 0               ! namelist: history write freq(0=monthly)
-  logical,           public            :: ice_runoff     = .false.         ! true => runoff is split into liquid and ice,
+  logical,           public            :: do_rof         = .true.                   !
+  logical,           public            :: do_flood       = .false.                  !
+  character(len=CL), public            :: nrevsn_rtm     = ' '                      ! restart data file name for branch run
+  character(len=32), public            :: qgwl_runoff_option ='threshold'           ! method for handling qgwl runoff
+  character(len=32), public            :: bypass_routing_option = 'direct_in_place' ! bypass routing model method
+  real(r8),          public            :: river_depth_minimum = 1.e-4               ! gridcell average minimum river depth [m]
+  integer,           public            :: coupling_period                           ! coupling period
+  integer,           public            :: rtmhist_ndens  = 1                        ! namelist: output density of netcdf history files
+  integer,           public            :: rtmhist_mfilt  = 30                       ! namelist: number of time samples per tape
+  integer,           public            :: rtmhist_nhtfrq = 0                        ! namelist: history write freq(0=monthly)
+  logical,           public            :: ice_runoff     = .false.                  ! true => runoff is split into liquid and ice,
   character(len=256),public            :: cfile_name     = 'mizuRoute.control'
   character(len=256),public            :: para_xxxx      = 'mizuRoute_in'
 

--- a/route/build/cpl/RunoffMod.F90
+++ b/route/build/cpl/RunoffMod.F90
@@ -28,6 +28,8 @@ MODULE RunoffMod
     real(r8), pointer :: qirrig(:)        ! coupler importing irrigation [m3/s]
     real(r8), pointer :: qirrig_actual(:) ! minimum of irrigation and available main channel storage
 
+    real(r8), pointer :: direct(:,:)      ! coupler return direct flow to ocean [m3/s]
+
     real(r8), pointer :: discharge(:,:)   ! coupler exporting river discharge [m3/s]
     real(r8), pointer :: volr(:)          ! coupler exporting river storage (m3)
     real(r8), pointer :: flood(:)         ! coupler exporting flood water sent back to clm [m3/s]
@@ -54,6 +56,7 @@ CONTAINS
              rtmCTL%qirrig(begr:endr),            &
              rtmCTL%qirrig_actual(begr:endr),     &
              rtmCTL%discharge(begr:endr,nt_rof),  &
+             rtmCTL%direct(begr:endr,nt_rof),     &
              rtmCTL%volr(begr:endr),              &
              rtmCTL%flood(begr:endr),             &
              stat=ierr)

--- a/route/build/cpl/nuopc/rof_import_export.F90
+++ b/route/build/cpl/nuopc/rof_import_export.F90
@@ -311,8 +311,8 @@ contains
        !flood(n)   = -rtmCTL%flood(n) / (rtmCTL%area(n)*0.001_r8)
        !flood(n)   = -rtmCTL%flood(n)
        flood(n)   = 0.0_r8
-       volr(n)    =  rtmCTL%volr(n)  ! volume in [m]
-       volrmch(n) =  rtmCTL%volr(n)  ! volume in [m]
+       volr(n)    =  rtmCTL%volr(n)  ! volume per HRU area in [m]
+       volrmch(n) =  rtmCTL%volr(n)  ! volume per HRU area in [m]
     end do
 
     call state_setexport(exportState, 'Forr_rofl', begr, endr, input=rofl, rc=rc)

--- a/route/build/cpl/nuopc/rof_import_export.F90
+++ b/route/build/cpl/nuopc/rof_import_export.F90
@@ -311,10 +311,8 @@ contains
        !flood(n)   = -rtmCTL%flood(n) / (rtmCTL%area(n)*0.001_r8)
        !flood(n)   = -rtmCTL%flood(n)
        flood(n)   = 0.0_r8
-       !volr(n)    =  rtmCTL%volr(n)  / rtmCTL%area(n)
-       !volr(n)    =  rtmCTL%volr(n)
-       volr(n)    =  0.0_r8
-       volrmch(n) =  0.0_r8
+       volr(n)    =  rtmCTL%volr(n)  ! volume in [m]
+       volrmch(n) =  rtmCTL%volr(n)  ! volume in [m]
     end do
 
     call state_setexport(exportState, 'Forr_rofl', begr, endr, input=rofl, rc=rc)

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -1,4 +1,4 @@
-module public_var
+MODULE public_var
   ! This module include variables that can be accessed from any other modules and values not altered
   ! except that variables read from control file are populated.
 
@@ -169,4 +169,8 @@ module public_var
   integer(i4b)         ,public    :: maxPfafLen           = 32              ! maximum digit of pfafstetter code (default 32).
   character(len=1)     ,public    :: pfafMissing          = '0'             ! missing pfafcode (e.g., reach without any upstream area)
 
-end module public_var
+  ! CESM Coupling variables
+  character(len=32)    ,public    :: bypass_routing_option = 'direct_in_place' ! bypass routing model method
+  character(len=32)    ,public    :: qgwl_runoff_option    = 'threshold'       ! method for handling qgwl runoff
+
+END MODULE public_var

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -170,7 +170,7 @@ MODULE public_var
   character(len=1)     ,public    :: pfafMissing          = '0'             ! missing pfafcode (e.g., reach without any upstream area)
 
   ! CESM Coupling variables
-  character(len=32)    ,public    :: bypass_routing_option = 'direct_in_place' ! bypass routing model method
-  character(len=32)    ,public    :: qgwl_runoff_option    = 'threshold'       ! method for handling qgwl runoff
+  character(len=32)    ,public    :: bypass_routing_option = 'direct_in_place' ! bypass routing model method: direct_in_place or direct_to_outlet
+  character(len=32)    ,public    :: qgwl_runoff_option    = 'threshold'       ! method for handling qgwl runoff: all, negative, or threshold
 
 END MODULE public_var

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -299,6 +299,10 @@ CONTAINS
    ! pfafstetter code
    case('<varname_pfafCode>'     ); meta_PFAF   (ixPFAF%code           )%varName =trim(cData)  ! pfafstetter code
 
+   ! CESM coupling variables (not used for stand-alone)
+   case('<qgwl_runoff_option>'   ); qgwl_runoff_option    = trim(cData)  ! handling negative qgwl runoff: all, negative, threshold
+   case('<bypass_routing_option>'); bypass_routing_option = trim(cData)  ! routing bypass option: direct_in_place, direct_to_outlet, none
+
    ! if not in list then keep going
    case default
     message=trim(message)//'unexpected text in control file provided: '//trim(cName)&

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -64,5 +64,10 @@
 <DWroutedRunoff>        T                          ! diffusive wave routed discharge at reach [L3/T]
 <volume>                F                          ! volume at the end of time step at reach [L3] - currently only IRF
 ! ****************************************************************************************************************************
+! cesm-coupler: qgwl runoff handling option
+! ---------------------------
+<qgwl_runoff_option>    threshold                  ! all, negative, or threshold (default)
+<bypass_routing_option> direct_in_place            ! direct_in_place, direct_to_outlet (default), or none:  direct_to_outlet== means send to the river mouth
+! ****************************************************************************************************************************
 ! ****************************************************************************************************************************
 ! ****************************************************************************************************************************


### PR DESCRIPTION
- turn on volume export
- handling negative qgwl.  Three options: putting 1) all, 2) negative, or 3) > threshold qgwl to `rtmCTL%direct` array 

resolve #164 