### PR TITLE
reading water take and observed flow 

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -129,6 +129,8 @@ DATATYPES = \
     time_utils.f90 \
     datetime_data.f90 \
     csv_data.f90 \
+    gageMeta_data.f90 \
+    obs_data.f90 \
     globalData.f90 \
     popMetadat.f90 \
     allocation.f90

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -169,7 +169,6 @@ end type subdomain
   real(DP)                                :: UPSAREA  ! upstream area (zero if headwater basin)
   real(DP)                                :: BASAREA  ! local basin area
   real(DP)                                :: TOTAREA  ! UPSAREA + BASAREA
-  real(DP)                                :: QTAKE    ! target abstraction/injection [m3/s]
   real(DP)                                :: MINFLOW  ! minimum environmental flow
  end type RCHPRP
 

--- a/route/build/src/gageMeta_data.f90
+++ b/route/build/src/gageMeta_data.f90
@@ -1,0 +1,172 @@
+MODULE gageMeta_data
+
+  USE nrtype
+  USE public_var,        ONLY: integerMissing
+  USE csv_data,          ONLY: csv
+  USE nr_utility_module, ONLY: match_index
+
+  implicit none
+
+  public:: gageMeta
+
+  type :: gageMeta
+    private
+    integer(i4b)                   :: nGage
+    character(len=30), allocatable :: gageID(:)
+    integer(i4b),      allocatable :: reachID(:)
+
+    CONTAINS
+
+      procedure, public :: get_reach_index
+      procedure, public :: gage_num => fn_get_gage_num
+      generic,   public :: gage_id  => fn_get_gageID, fn_get_gageID_vec, fn_get_gageID_scalar
+      generic,   public :: reach_id => fn_get_reachID, fn_get_reachID_vec, fn_get_reachID_scalar
+      procedure, private :: fn_get_gageID
+      procedure, private :: fn_get_gageID_vec
+      procedure, private :: fn_get_gageID_scalar
+      procedure, private :: fn_get_reachID
+      procedure, private :: fn_get_reachID_vec
+      procedure, private :: fn_get_reachID_scalar
+
+  end type gageMeta
+
+  private :: fn_get_gage_num
+
+  INTERFACE gageMeta
+    module procedure constructor
+  END INTERFACE gageMeta
+
+  CONTAINS
+
+    ! -----------------------------------------------------
+    ! constructor
+    ! -----------------------------------------------------
+    FUNCTION constructor(gageCsvName, ierr, message) RESULT(instGageMeta)
+
+      implicit none
+      type(gageMeta)                    :: instGageMeta
+      character(*),       intent(in)    :: gageCsvName
+      integer(i4b),       intent(out)   :: ierr              ! error code
+      character(*),       intent(out)   :: message           ! error message
+      ! local variables
+      type(csv)                  :: gage_meta_csv
+      character(len=strLen)      :: cmessage          ! error message from subroutine
+
+      ierr=0; message='gageMeta'
+
+      ! import gauge meta data
+      gage_meta_csv = csv(trim(gageCsvName), ierr, cmessage,  mode='r')
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call gage_meta_csv%csv_read(ierr, cmessage, header_row=1)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call gage_meta_csv%fclose()
+
+      ! populate gauge data
+      call gage_meta_csv%get_data('gage_id', instGageMeta%gageID, ierr)
+      call gage_meta_csv%get_data('reach_id', instGageMeta%reachID, ierr)
+      instGageMeta%nGage = size(instGageMeta%gageID)
+
+    END FUNCTION constructor
+
+    ! -----------------------------------------------------
+    ! FUNCTION: get gage site number
+    ! -----------------------------------------------------
+    FUNCTION fn_get_gage_num(this) result(nGage)
+      implicit none
+      class(gageMeta), intent(in) :: this
+      integer(i4b), allocatable   :: nGage
+      nGage = this%nGage
+    END FUNCTION fn_get_gage_num
+
+    ! -----------------------------------------------------
+    ! FUNCTIONs: get gage ID
+    ! -----------------------------------------------------
+    FUNCTION fn_get_gageID(this) result(gageID)
+      implicit none
+      class(gageMeta), intent(in) :: this
+      character(30), allocatable  :: gageID(:)
+      allocate(gageID(this%nGage))
+      gageID = this%gageID
+    END FUNCTION fn_get_gageID
+
+    FUNCTION fn_get_gageID_vec(this, ix) result(gageID)
+      implicit none
+      class(gageMeta), intent(in) :: this
+      integer(i4b)                :: ix(:)
+      character(30), allocatable  :: gageID(:)
+      allocate(gageID(size(ix)))
+      gageID = this%gageID(ix)
+    END FUNCTION fn_get_gageID_vec
+
+    FUNCTION fn_get_gageID_scalar(this, ix) result(gageID)
+      implicit none
+      class(gageMeta), intent(in) :: this
+      integer(i4b)                :: ix
+      character(30)               :: gageID
+      gageID = this%gageID(ix)
+    END FUNCTION fn_get_gageID_scalar
+
+    ! -----------------------------------------------------
+    ! FUNCTIONs: get reach ID
+    ! -----------------------------------------------------
+    FUNCTION fn_get_reachID(this) result(reachID)
+      implicit none
+      class(gageMeta), intent(in) :: this
+      integer(i4b), allocatable   :: reachID(:)
+      allocate(reachID(this%nGage))
+      reachID = this%reachID
+    END FUNCTION fn_get_reachID
+
+    FUNCTION fn_get_reachID_vec(this, ix) result(reachID)
+      implicit none
+      class(gageMeta), intent(in) :: this
+      integer(i4b)                :: ix(:)
+      integer(i4b), allocatable   :: reachID(:)
+      allocate(reachID(size(ix)))
+      reachID = this%reachID(ix)
+    END FUNCTION fn_get_reachID_vec
+
+    FUNCTION fn_get_reachID_scalar(this, ix) result(reachID)
+      implicit none
+      class(gageMeta), intent(in) :: this
+      integer(i4b)                :: ix
+      integer(i4b)                :: reachID
+      reachID = this%reachID(ix)
+    END FUNCTION fn_get_reachID_scalar
+
+    ! -----------------------------------------------------
+    ! subroutine: index of reach ID array
+    ! -----------------------------------------------------
+    SUBROUTINE get_reach_index(this, reachID_in, reach_index)
+
+      implicit none
+      ! Argument variables
+      class(gageMeta),                 intent(in)  :: this
+      integer(i4b), allocatable,       intent(in)  :: reachID_in(:)
+      integer(i4b), allocatable,       intent(out) :: reach_index(:)     ! index in the same size as reachID_in
+      ! local variables
+      integer(i4b), allocatable                    :: index1(:)
+      integer(i4b)                                 :: nGage
+      logical(lgt), allocatable                    :: mask(:)
+
+      ! array size = number of gauges in each mpi core
+      allocate(index1(this%nGage), mask(this%nGage))
+
+      ! Find index of matching reachID in reachID_in array
+      index1 = match_index(reachID_in, this%reachID, missingValue=integerMissing)
+      mask=(index1/=integerMissing)
+      nGage = count(mask)
+
+      if (nGage>0) then
+        allocate(reach_index(nGage))
+        reach_index = pack(index1, mask)
+      else
+        allocate(reach_index(1))
+        reach_index = integerMissing
+      end if
+
+    END SUBROUTINE get_reach_index
+
+END MODULE gageMeta_data

--- a/route/build/src/get_basin_runoff.f90
+++ b/route/build/src/get_basin_runoff.f90
@@ -1,61 +1,65 @@
-module get_runoff
+MODULE get_runoff
 
 USE nrtype
 
 implicit none
 
 private
-
 public::get_hru_runoff
 
-contains
+CONTAINS
 
  ! *********************************************************************
  ! public subroutine: read runoff data
  ! *********************************************************************
- subroutine get_hru_runoff(ierr, message)     ! output: error control
+ SUBROUTINE get_hru_runoff(ierr, message)
 
  ! populate runoff_data with runoff values at LSM domain and at iTime step
 
-  ! shared data
   USE public_var,  only:input_dir               ! directory containing input data
   USE public_var,  only:fname_qsim              ! simulated runoff netCDF name
   USE public_var,  only:is_remap                ! logical whether or not runnoff needs to be mapped to river network HRU
+  USE public_var,  ONLY: qmodOption             !
+  USE public_var,  ONLY: integerMissing         !
   USE globalData,  only:iTime
   USE globalData,  only:nHRU
   USE globalData,  only:runoff_data             ! data structure to hru runoff data
   USE globalData,  only:remap_data              ! data structure to remap data
-  ! subroutines
+  USE globalData,  ONLY: modTime
+  USE globalData,  ONLY: gage_obs_data
+  USE globalData,  ONLY: rch_qtake_data
+  USE globalData,  ONLY: RCHFLX
   USE read_runoff, only:read_runoff_data        ! read runoff value into runoff_data data strucuture
   USE remapping,   only:remap_runoff            ! mapping HM runoff to river network HRU runoff (HM_HRU /= RN_HRU)
   USE remapping,   only:sort_runoff             ! mapping HM runoff to river network HRU runoff (HM_HRU == RN_HRU)
 
   implicit none
-  ! input variables: none
-  ! output variables
+  ! argument variables
   integer(i4b), intent(out)     :: ierr               ! error code
   character(*), intent(out)     :: message            ! error message
   ! local variables
   character(len=strLen)         :: cmessage           ! error message from subroutine
+  integer(i4b)                  :: iens=1
+  integer(i4b)                  :: ix, jx
+  integer(i4b), allocatable     :: reach_ix(:)
   ! timing
-  integer*8                     :: startTime,endTime,cr ! star and end time stamp, rate
-  real(dp)                      :: elapsedTime          ! elapsed time for the process
+!  integer*8                     :: startTime,endTime,cr ! star and end time stamp, rate
+!  real(dp)                      :: elapsedTime          ! elapsed time for the process
 
-  ! initialize error control
   ierr=0; message='get_hru_runoff/'
-  call system_clock(count_rate=cr)
 
-  call system_clock(startTime)
+!  call system_clock(count_rate=cr)
+
+!  call system_clock(startTime)
   ! get the simulated runoff for the current time step - runoff_data%qsim(:) or %qsim2D(:,:)
   call read_runoff_data(trim(input_dir)//trim(fname_qsim), & ! input: filename
                         iTime,                             & ! input: time index
                         runoff_data,                       & ! inout: runoff data structure
                         ierr, cmessage)                      ! output: error control
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-  call system_clock(endTime)
-  elapsedTime = real(endTime-startTime, kind(dp))/real(cr)
+!  call system_clock(endTime)
+!  elapsedTime = real(endTime-startTime, kind(dp))/real(cr)
 !  write(*,"(A,1PG15.7,A)") '  elapsed-time [runoff_input/read] = ', elapsedTime, ' s'
-
 
   ! initialize runoff_data%basinRunoff
   if ( allocated(runoff_data%basinRunoff) ) then
@@ -65,24 +69,50 @@ contains
   allocate(runoff_data%basinRunoff(nHRU), stat=ierr)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-  call system_clock(startTime)
+!  call system_clock(startTime)
   ! Get river network HRU runoff into runoff_data data structure
   if (is_remap) then ! remap LSM simulated runoff to the HRUs in the river network
-
-   call remap_runoff(runoff_data, remap_data, runoff_data%basinRunoff, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
+    call remap_runoff(runoff_data, remap_data, runoff_data%basinRunoff, ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   else ! runoff is already remapped to river network HRUs
-
-   call sort_runoff(runoff_data, runoff_data%basinRunoff, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
+    call sort_runoff(runoff_data, runoff_data%basinRunoff, ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   end if
-  call system_clock(endTime)
-  elapsedTime = real(endTime-startTime, kind(dp))/real(cr)
+!  call system_clock(endTime)
+!  elapsedTime = real(endTime-startTime, kind(dp))/real(cr)
 !  write(*,"(A,1PG15.7,A)") '  elapsed-time [runoff_input/remap] = ', elapsedTime, ' s'
 
+  ! initialize TAKE for water take or direct insersion
+  RCHFLX(:,:)%TAKE = 0.0_dp
+  select case(qmodOption)
+    case(0)
+    case(1)
+      ! read gage observation [m3/s] at current time
+      jx = gage_obs_data%time_ix(modTime(1))
+      call gage_obs_data%read_obs(ierr, cmessage, index_time=jx)
 
- end subroutine get_hru_runoff
+      ! put qmod at right reach
+      reach_ix = gage_obs_data%link_ix()
+      do ix=1,size(reach_ix)
+        if (reach_ix(ix)==integerMissing) cycle
+        RCHFLX(iens,reach_ix(ix))%TAKE = gage_obs_data%get_obs(tix=1, six=ix)
+      end do
+    case(2)
+      ! read reach water take [m3/s] at current time
+      jx = rch_qtake_data%time_ix(modTime(1))
+      call rch_qtake_data%read_obs(ierr, cmessage, index_time=jx)
 
-end module get_runoff
+      ! put qmod at right reach
+      reach_ix = rch_qtake_data%link_ix()
+
+      do ix=1,size(reach_ix)
+        if (reach_ix(ix)==integerMissing) cycle
+        RCHFLX(iens,reach_ix(ix))%TAKE = rch_qtake_data%get_obs(tix=1, six=ix)
+      end do
+    case default
+      ierr=1; message=trim(message)//"Error: qmodOption invalid"; return
+  end select
+
+ END SUBROUTINE get_hru_runoff
+
+END MODULE get_runoff

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -12,6 +12,11 @@ MODULE globalData
   USE dataTypes,  ONLY : var_info      ! metadata type
   USE objTypes,   ONLY : meta_var      ! metadata type
 
+  ! gage data strucuture
+  USE gageMeta_data, ONLY : gageMeta
+  USE obs_data,      ONLY : gageObs
+  USE obs_data,      ONLY : waterTake
+
   ! parameter structures
   USE dataTypes,  ONLY : RCHPRP        ! Reach parameters (properties)
   USE dataTypes,  ONLY : RCHTOPO       ! Network topology
@@ -33,7 +38,7 @@ MODULE globalData
   USE dataTypes,  ONLY : subbasin_omp  ! mainstem+tributary data structures
 
   ! time data structure
-  USE date_time,  ONLY : datetime      ! time data
+  USE datetime_data, ONLY : datetime   ! time data
 
   ! time data structure
   USE dataTypes,  ONLY : nc            ! netCDF data
@@ -134,6 +139,11 @@ MODULE globalData
   type(datetime)                 , public :: restCal              ! desired restart date/time (yyyy:mm:dd:hh:mm:ss)
   type(datetime)                 , public :: dropCal              ! restart dropoff date/time (yyyy:mm:dd:hh:mm:ss)
   logical(lgt)                   , public :: restartAlarm         ! alarm to triger restart file writing
+
+  ! obs data - gage data, watertake etc.
+  type(gageMeta),                   public :: gage_meta_data      ! gauge metadata
+  type(gageObs),                    public :: gage_obs_data       ! gauge observed data
+  type(waterTake),                  public :: rch_qtake_data      ! water injetion/abstraction data
 
   ! simulation output netcdf
   type(nc)                       , public :: simout_nc

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -6,12 +6,12 @@ USE nrtype
 USE dataTypes,          only : STRFLX         ! fluxes in each reach
 USE dataTypes,          only : RCHTOPO        ! Network topology
 USE dataTypes,          only : RCHPRP         ! Reach parameter
-USE dataTypes,          only : irfRCH         ! irf specific state data structure 
+USE dataTypes,          only : irfRCH         ! irf specific state data structure
 ! global parameters
 USE public_var,         only : realMissing    ! missing value for real number
 USE public_var,         only : integerMissing ! missing value for integer number
 USE globalData,         only : nThreads       ! number of threads used for openMP
-USE globalData,         only : idxIRF          ! index of IRF method 
+USE globalData,         only : idxIRF          ! index of IRF method
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
 
@@ -200,12 +200,12 @@ contains
   endif
 
   ! perform UH convolution
-  call conv_upsbas_qr(NETOPO_in(segIndex)%UH,    &    ! input: reach unit hydrograph
-                      q_upstream,                &    ! input: total discharge at top of the reach being processed
-                      RCHFLX_out(iens,segIndex), &    ! inout: updated fluxes at reach
-                      RPARAM_in(segIndex)%QTAKE, &    ! input: abstraction(-)/injection(+) [m3/s]
-                      RPARAM_in(segIndex)%MINFLOW, &  ! input: minimum environmental flow [m3/s]
-                      ierr, message)                  ! output: error control
+  call conv_upsbas_qr(NETOPO_in(segIndex)%UH,         &  ! input: reach unit hydrograph
+                      q_upstream,                     &  ! input: total discharge at top of the reach being processed
+                      RCHFLX_out(iens,segIndex),      &  ! inout: updated fluxes at reach
+                      RCHFLX_out(iens,segIndex)%TAKE, &  ! input: abstraction(-)/injection(+) [m3/s]
+                      RPARAM_in(segIndex)%MINFLOW,    &  ! input: minimum environmental flow [m3/s]
+                      ierr, message)                     ! output: error control
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   ! check

--- a/route/build/src/kwt_route.f90
+++ b/route/build/src/kwt_route.f90
@@ -8,13 +8,13 @@ USE dataTypes, ONLY: STRFLX            ! fluxes in each reach
 USE dataTypes, ONLY: STRSTA            ! states in each reach
 USE dataTypes, ONLY: RCHTOPO           ! Network topology
 USE dataTypes, ONLY: RCHPRP            ! Reach parameter
-USE dataTypes, ONLY: kwtRCH            ! kwt specific state data structure 
+USE dataTypes, ONLY: kwtRCH            ! kwt specific state data structure
 ! global data
 USE public_var, ONLY: runoffMin         ! minimum runoff
 USE public_var, ONLY: verySmall         ! a very small value
 USE public_var, ONLY: realMissing       ! missing value for real number
 USE public_var, ONLY: integerMissing    ! missing value for integer number
-USE globalData, ONLY: idxKWT            ! index of KWT method 
+USE globalData, ONLY: idxKWT            ! index of KWT method
 ! utilities
 USE nr_utility_module, ONLY: arth       ! Num. Recipies utilities
 
@@ -274,8 +274,6 @@ CONTAINS
      write(*,'(a,x,F15.7)')          ' RPARAM_in%R_WIDTH =', RPARAM_in(JRCH)%R_WIDTH
    end if
 
-   RCHFLX_out(IENS,JRCH)%TAKE=0.0_dp ! initialize take from this reach
-
     ! ----------------------------------------------------------------------------------------
     ! (1) EXTRACT FLOW FROM UPSTREAM REACHES & APPEND TO THE NON-ROUTED FLOW PARTICLES IN JRCH
     ! ----------------------------------------------------------------------------------------
@@ -342,11 +340,11 @@ CONTAINS
     T_START = T0 - (T1 - T0)*ROFFSET
     T_END   = T1 - (T1 - T0)*ROFFSET
 
-    if (RPARAM_in(jrch)%QTAKE < 0._dp) then
+    if (RCHFLX_out(iens, jrch)%TAKE < 0._dp) then
       call extract_from_rch(iens, jrch,                       & ! input: ensemble and reach indices
                             T_START, T_END,                   & ! input: time [sec] of current time step bounds
                             RPARAM_in,                        & ! input: river reach parameters
-                            RPARAM_in(jrch)%QTAKE,            & ! input: target Qtake (minus)
+                            RCHFLX_out(iens, jrch)%TAKE,      & ! input: target Qtake (minus)
                             ixDesire,                         & ! input:
                             Q_JRCH, T_EXIT, TENTRY,           & ! inout: discharge and exit time for particle
                             ierr,cmessage)

--- a/route/build/src/ncio_utils.f90
+++ b/route/build/src/ncio_utils.f90
@@ -27,6 +27,7 @@ INTERFACE get_nc
   module procedure get_ivec
   module procedure get_ivec_long
   module procedure get_dvec
+  module procedure get_charvec
   module procedure get_2d_iarray
   module procedure get_2d_darray
   module procedure get_3d_iarray
@@ -461,6 +462,42 @@ CONTAINS
   ! get the data
   ierr = nf90_get_var(ncid, iVarID, array, start=(/iStart/), count=(/iCount/))
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+ end subroutine
+
+ ! *********************************************************************
+ ! subroutine: read a character vector
+ ! *********************************************************************
+ subroutine get_charvec(ncid,            &  ! input: netcdf id
+                        vname,           &  ! input: variable name
+                        array,           &  ! output: variable data
+                        iStart,          &  ! input: start index
+                        iCount,          &  ! input: length of vector
+                        ierr, message)      ! output: error control
+  implicit none
+  ! input variables
+  integer(i4b), intent(in)        :: ncid        ! NetCDF file ID
+  character(*), intent(in)        :: vname       ! variable name
+  integer(i4b), intent(in)        :: iStart(1:2) ! start index
+  integer(i4b), intent(in)        :: iCount(1:2) ! length of vector to be read in
+  ! output variables
+  character(*), intent(out)       :: array(:)    ! output variable data
+  integer(i4b), intent(out)       :: ierr        ! error code
+  character(*), intent(out)       :: message     ! error message
+  ! local variables
+  integer(i4b)                    :: iVarID      ! NetCDF variable ID
+
+  ierr=0; message='get_charvec/'
+
+  ! get variable ID
+  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+  ! get the data
+  ierr = nf90_get_var(ncid, iVarID, array, start=iStart, count=iCount)
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+  array = adjustl(array)
 
  end subroutine
 

--- a/route/build/src/nr_utility.f90
+++ b/route/build/src/nr_utility.f90
@@ -493,19 +493,17 @@ CONTAINS
   FUNCTION match_index(array1, array2, missingValue) RESULT(index1)
     implicit none
     ! Argument variables:
-    integer(i4b), allocatable, intent(in)  :: array1(:)
-    integer(i4b), allocatable, intent(in)  :: array2(:)
-    integer(i4b), optional,    intent(in)  :: missingValue ! desired missing value if desiredValue is not found
+    integer(i4b), intent(in)           :: array1(:)
+    integer(i4b), intent(in)           :: array2(:)
+    integer(i4b), optional, intent(in) :: missingValue ! desired missing value if desiredValue is not found
     ! Local variables:
-    integer(i4b), allocatable              :: index1(:)
-    integer(i4b), allocatable              :: rnkArray1(:)
-    integer(i4b), allocatable              :: rnkArray2(:)
-    integer(i4b)                           :: ix, jx, begIx
+    integer(i4b)              :: index1(size(array2))
+    integer(i4b)              :: rnkArray1(size(array1))
+    integer(i4b)              :: rnkArray2(size(array2))
+    integer(i4b)              :: ix, jx, begIx
 
-    allocate(index1(size(array2)), rnkArray1(size(array1)), rnkArray2(size(array2)) )
-
-    if(present(missingValue))then
-      index1=missingValue
+    if (present(missingValue)) then
+      index1 = missingValue
     else
       index1 = -9999
     endif
@@ -513,8 +511,8 @@ CONTAINS
     call indexx(array1, rnkArray1)
     call indexx(array2, rnkArray2)
 
-    begIx=1
-    do ix=1,size(rnkArray2)
+    begIx = 1
+    do ix = 1,size(rnkArray2)
       do jx=begIx,size(rnkArray1)
         if (array2(rnkArray2(ix))==array1(rnkArray1(jx))) then
           index1(rnkArray2(ix)) = rnkArray1(jx)

--- a/route/build/src/obs_data.f90
+++ b/route/build/src/obs_data.f90
@@ -730,6 +730,7 @@ MODULE obs_data
       type(datetime), intent(in) :: datetime_in
       integer(i4b)   :: tix
       integer(i4b)   :: ix
+      tix=integerMissing
       do ix = 1, size(datetime_array)
         if (datetime_array(ix) == datetime_in) then
           tix = ix
@@ -744,6 +745,7 @@ MODULE obs_data
       character(*), intent(in) :: site_in
       integer(i4b)   :: six
       integer(i4b)   :: ix
+      six=integerMissing
       do ix = 1, size(site_array)
         if (trim(site_array(ix)) == trim(site_in)) then
           six = ix
@@ -758,6 +760,7 @@ MODULE obs_data
       integer(i4b), intent(in) :: reach_in
       integer(i4b) :: rix
       integer(i4b) :: ix
+      rix=integerMissing
       do ix = 1, size(reach_array)
         if (reach_array(ix) == reach_in) then
           rix = ix

--- a/route/build/src/obs_data.f90
+++ b/route/build/src/obs_data.f90
@@ -1,0 +1,769 @@
+MODULE obs_data
+
+! flow obs data class
+! flow data should be stored in netcdf
+!   dimensions:
+!     time = nTime ;
+!     site = nSite ;
+!     stringLen = nChar ;
+!   variables:
+!     float streamflow(time, site)
+!       units: m3/s
+!     char  site(site, stringLen)
+!     float time(time)
+!       units: m3/s
+!       calendar: regular
+!
+! usage:
+! initialize gage obs data
+!   gage_flow = gageObs(trim(ncname), varname_flow, varname_time, varname_site, dimname_time, dimname_site, ierr, cmessage)
+!
+! initialize reach water take data
+!   qtake = waterTake(trim(ncname), varname_flow, varname_time, varname_reach, dimname_time, dimname_reach, ierr, cmessage)
+!
+
+  USE nrtype
+  USE io_netcdf
+  USE datetime_data, ONLY: datetime
+  USE gageMeta_data, ONLY: gageMeta
+  USE nr_utility_module, ONLY: match_index
+  USE public_var, ONLY: integerMissing
+  USE public_var, ONLY: clen=>strlen_gageSite
+
+  implicit none
+
+  private
+  public:: gageObs
+  public:: waterTake
+
+  type, abstract :: obs
+    private
+    integer(i4b)                   :: ncid = integerMissing ! netCDF ID
+    character(strLen)              :: varName_obs
+    character(strLen)              :: varName_time
+    character(strLen)              :: varName_loc
+    character(strLen)              :: dimName_time
+    character(strLen)              :: dimName_loc
+    integer(i4b)                   :: nLoc
+    type(datetime),  allocatable   :: time(:)               ! datetime in the netcdf
+    real(dp),        allocatable   :: obs(:,:)              ! selected observed data
+    integer(i4b),    allocatable   :: link_index(:)         ! index of target location array (e.g., reachID)
+    logical(lgt)                   :: fileOpen = .false.    ! flag to indicate history output netcdf is open
+
+    CONTAINS
+
+      procedure,  public :: openNC
+      procedure,  public :: isFileOpen
+      procedure,  public :: closeNC
+      procedure,  public :: read_obs
+      procedure,  public :: read_time
+      procedure,  public :: time_ix => fn_get_time_ix
+      procedure,  public :: link_Ix => fn_get_link_ix
+      generic,    public :: get_datetime => fn_get_datetime, fn_get_datetime_vec, fn_get_datetime_scalar
+      generic,    public :: get_obs => fn_get_obs, fn_get_obs_vec, fn_get_obs_tvec, fn_get_obs_svec, fn_get_obs_scalar
+      procedure, private :: fn_get_link_ix
+      procedure, private :: fn_get_time_ix
+      procedure, private :: fn_get_datetime
+      procedure, private :: fn_get_datetime_vec
+      procedure, private :: fn_get_datetime_scalar
+      procedure, private :: fn_get_obs
+      procedure, private :: fn_get_obs_vec
+      procedure, private :: fn_get_obs_tvec
+      procedure, private :: fn_get_obs_svec
+      procedure, private :: fn_get_obs_scalar
+
+  end type obs
+
+  type, extends(obs) :: gageObs
+    character(25),   allocatable   :: site(:)  ! list of gauge site id
+    CONTAINS
+      procedure,  public :: read_site
+      procedure,  public :: comp_link => sub_comp_link_site2reach
+      generic,    public :: gage_id => fn_get_gageID, fn_get_gageID_vec, fn_get_gageID_scalar
+      procedure,  public :: site_ix => fn_get_site_ix
+      procedure, private :: fn_get_gageID
+      procedure, private :: fn_get_gageID_vec
+      procedure, private :: fn_get_gageID_scalar
+  end type gageObs
+
+  type, extends(obs) :: waterTake
+    integer(i4b),   allocatable   :: reach(:)  ! list of all the reach id
+    CONTAINS
+      procedure,  public :: read_reach
+      procedure,  public :: comp_link => sub_comp_link_reach2reach
+      generic,    public :: reach_id => fn_get_reachID, fn_get_reachID_vec, fn_get_reachID_scalar
+      procedure,  public :: reach_ix => fn_get_reach_ix
+      procedure, private :: fn_get_reachID
+      procedure, private :: fn_get_reachID_vec
+      procedure, private :: fn_get_reachID_scalar
+  end type waterTake
+
+  INTERFACE waterTake
+    module procedure waterTake_constructor
+  END INTERFACE waterTake
+
+  INTERFACE gageObs
+    module procedure gageObs_constructor
+  END INTERFACE gageObs
+
+  private:: fn_get_time_ix
+  private:: fn_get_site_ix
+  private:: fn_get_reach_ix
+  private:: sub_comp_link_reach2reach
+  private:: sub_comp_link_site2reach
+
+  public :: get_time_ix
+  public :: get_site_ix
+  public :: get_reach_ix
+
+  CONTAINS
+
+    ! -----------------------------------------------------
+    ! Instantiate gageObs
+    ! -----------------------------------------------------
+    FUNCTION gageObs_constructor(fileName, &
+                                 obsVarName, &
+                                 timeVarName, &
+                                 locVarName, &
+                                 timeDimName, &
+                                 locDimName, &
+                                 ierr, message) RESULT(instObs)
+      implicit none
+      type(gageObs)                        :: instObs
+      character(*),           intent(in)   :: fileName
+      character(*),           intent(in)   :: obsVarName
+      character(*),           intent(in)   :: timeVarName
+      character(*),           intent(in)   :: locVarName
+      character(*),           intent(in)   :: timeDimName
+      character(*),           intent(in)   :: locDimName
+      integer(i4b),           intent(out)  :: ierr             ! error code
+      character(*),           intent(out)  :: message          ! error message
+      ! local variables
+      character(strLen)                    :: cmessage         ! error message of downwind routine
+
+      ierr=0; message='gageObs/'
+
+      instObs%varName_obs  = obsVarName
+      instObs%varName_time = timeVarName
+      instObs%varName_loc  = locVarName
+      instObs%dimName_time = timeDimName
+      instObs%dimName_loc  = locDimName
+
+      call instObs%openNC(fileName, ierr, cmessage) ! open gauge data nc and assing ncid and fileOpen = .true.
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call instObs%read_site(ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call instObs%read_time(ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      instObs%nLoc = size(instObs%site)
+
+    END FUNCTION gageObs_constructor
+
+    ! -----------------------------------------------------
+    ! Instantiate gageObs
+    ! -----------------------------------------------------
+    FUNCTION waterTake_constructor(fileName, &
+                                   obsVarName, &
+                                   timeVarName, &
+                                   locVarName, &
+                                   timeDimName, &
+                                   locDimName, &
+                                   ierr, message) RESULT(instObs)
+      implicit none
+      type(waterTake)                      :: instObs
+      character(*),           intent(in)   :: fileName
+      character(*),           intent(in)   :: obsVarName
+      character(*),           intent(in)   :: timeVarName
+      character(*),           intent(in)   :: locVarName
+      character(*),           intent(in)   :: timeDimName
+      character(*),           intent(in)   :: locDimName
+      integer(i4b),           intent(out)  :: ierr             ! error code
+      character(*),           intent(out)  :: message          ! error message
+      ! local variables
+      character(strLen)                    :: cmessage         ! error message of downwind routine
+
+      ierr=0; message='waterTake/'
+
+      instObs%varName_obs  = obsVarName
+      instObs%varName_time = timeVarName
+      instObs%varName_loc  = locVarName
+      instObs%dimName_time = timeDimName
+      instObs%dimName_loc  = locDimName
+
+      call instObs%openNC(fileName, ierr, cmessage) ! open gauge data nc and assing ncid and fileOpen = .true.
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call instObs%read_reach(ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call instObs%read_time(ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      instObs%nLoc = size(instObs%reach)
+
+    END FUNCTION waterTake_constructor
+
+    ! ---------------------------------
+    ! open netCDF
+    ! ---------------------------------
+    SUBROUTINE openNC(this, fname, ierr, message)
+      implicit none
+      ! Argument variables
+      class(obs),   intent(inout)  :: this
+      character(*),     intent(in)     :: fname
+      integer(i4b),     intent(out)    :: ierr             ! error code
+      character(*),     intent(out)    :: message          ! error message
+      ! local variables
+      character(strLen)                :: cmessage         ! error message of downwind routine
+
+      ierr=0; message='openNC/'
+
+      call open_nc(trim(fname), 'r', this%ncid, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      this%fileOpen = .true.
+
+    END SUBROUTINE openNC
+
+    ! ---------------------------------
+    ! Check if file is open or not
+    ! ---------------------------------
+    logical(lgt) FUNCTION isFileOpen(this)
+      implicit none
+      class(obs), intent(inout) :: this
+
+      isFileOpen = this%fileOpen
+    END FUNCTION
+
+    ! ---------------------------------
+    ! close netCDF
+    ! ---------------------------------
+    SUBROUTINE closeNC(this, ierr, message)
+      implicit none
+      class(obs), intent(inout) :: this
+      integer(i4b),     intent(out)    :: ierr             ! error code
+      character(*),     intent(out)    :: message          ! error message
+      ! local variables
+      character(strLen)                :: cmessage         ! error message of downwind routine
+
+      ierr=0; message='closeNC/'
+
+      if (this%fileOpen) then
+        call close_nc(this%ncid, ierr, cmessage)
+        this%fileOpen = .false.
+      endif
+    END SUBROUTINE closeNC
+
+    ! ---------------------------------
+    ! get site ID
+    ! ---------------------------------
+    SUBROUTINE read_site(this, ierr, message, index_loc)
+
+      implicit none
+      ! Argument variables
+      class(gageObs),          intent(inout) :: this
+      integer(i4b),            intent(out)   :: ierr            ! error code
+      character(*),            intent(out)   :: message         ! error message
+      integer(i4b), optional,  intent(in)    :: index_loc(:)
+      ! local variables
+      integer(i4b)                           :: nSite           ! total number of sites
+      integer(i4b)                           :: nSite_read      ! number of sites read in
+      integer(i4b)                           :: ix
+      character(clen), allocatable           :: array_temp(:)
+      character(strLen)                      :: cmessage        ! error message of downwind routine
+
+      ierr=0; message='read_site/'
+
+      call get_nc_dim_len(this%ncid, this%dimName_loc, nSite, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      if (present(index_loc)) then
+        nSite_read = size(index_loc)
+
+        allocate(array_temp(nSite), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [array_temp]'; return; endif
+
+        allocate(this%site(nSite_read), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [this%site]'; return; endif
+
+        call get_nc(this%ncid, this%varName_loc, array_temp, [1,1], [clen, nSite], ierr, cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+        do ix=1,nSite_read
+          this%site(ix) = array_temp(index_loc(ix))
+        end do
+      else
+        allocate(this%site(nSite), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [this%site]'; return; endif
+
+        call get_nc(this%ncid, this%varName_loc, this%site, [1,1], [clen, nSite], ierr, cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+      end if
+
+    END SUBROUTINE read_site
+
+    ! ---------------------------------
+    ! get reach ID
+    ! ---------------------------------
+    SUBROUTINE read_reach(this, ierr, message, index_loc)
+
+      implicit none
+      ! Argument variables
+      class(waterTake),        intent(inout) :: this
+      integer(i4b),            intent(out)   :: ierr            ! error code
+      character(*),            intent(out)   :: message         ! error message
+      integer(i4b), optional,  intent(in)    :: index_loc(:)
+      ! local variables
+      integer(i4b)                           :: nSite           ! total number of sites
+      integer(i4b)                           :: nSite_read      ! number of sites read in
+      integer(i4b)                           :: ix
+      integer(i4b), allocatable              :: array_temp(:)
+      character(strLen)                      :: cmessage        ! error message of downwind routine
+
+      ierr=0; message='read_reach/'
+
+      call get_nc_dim_len(this%ncid, this%dimName_loc, nSite, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      if (present(index_loc)) then
+        nSite_read = size(index_loc)
+
+        allocate(array_temp(nSite), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [array_temp]'; return; endif
+
+        allocate(this%reach(nSite_read), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [this%reach]'; return; endif
+
+        call get_nc(this%ncid, this%varName_loc, array_temp, 1, nSite, ierr, cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+        do ix=1,nSite_read
+          this%reach(ix) = array_temp(index_loc(ix))
+        end do
+      else
+        allocate(this%reach(nSite), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [this%reach]'; return; endif
+
+        call get_nc(this%ncid, this%varName_loc, this%reach, 1, nSite, ierr, cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+      end if
+
+    END SUBROUTINE read_reach
+
+    ! ---------------------------------
+    ! get time
+    ! ---------------------------------
+    SUBROUTINE read_time(this, ierr, message, index_time)
+
+      implicit none
+      ! Argument variables
+      class(obs),             intent(inout) :: this
+      integer(i4b),           intent(out)   :: ierr            ! error code
+      character(*),           intent(out)   :: message         ! error message
+      integer(i4b), optional, intent(in)    :: index_time(:)
+      ! local variables
+      type(datetime)                        :: datetime_start
+      real(dp), allocatable                 :: timeVar_temp(:)
+      real(dp)                              :: timeVar
+      real(dp)                              :: convTime2Secs
+      integer(i4b)                          :: nTime           ! total number of sites
+      integer(i4b)                          :: nTime_read      ! number of sites read in
+      integer(i4b)                          :: ix
+      character(100)                        :: timestr_start
+      character(30)                         :: gage_calendar
+      character(30)                         :: t_unit
+      character(len=strLen)                 :: cmessage        ! error message of downwind routine
+
+      ierr=0; message='read_time/'
+
+      call get_nc_dim_len(this%ncid, this%dimName_time, nTime, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call get_var_attr(this%ncid, this%varName_time, 'units', timestr_start, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call get_var_attr(this%ncid, this%varName_time, 'calendar', gage_calendar, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call datetime_start%str2datetime(timestr_start, ierr, cmessage)
+
+      t_unit = trim(timestr_start(1:index(timestr_start,' ')))
+      select case( trim(t_unit) )
+        case('seconds','second','sec','s'); convTime2Secs=1._dp
+        case('minutes','minute','min','m'); convTime2Secs=24._dp
+        case('hours'  ,'hour'  ,'hr' ,'h'); convTime2Secs=1440._dp
+        case('days'   ,'day'   ,'d');       convTime2Secs=86400._dp
+        case default
+          ierr=20; message=trim(message)//'<t_unit>= '//trim(t_unit)//': <t_unit> must be seconds, minutes, hours or days.'; return
+       end select
+
+      if (present(index_time)) then
+        nTime_read = size(index_time)
+
+        allocate(timeVar_temp(nTime), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [timeVar_temp]'; return; endif
+
+        allocate(this%time(nTime_read), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [this%time]'; return; endif
+
+        call get_nc(this%ncid, this%varName_time, timeVar_temp, 1, nTime, ierr, cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+        do ix=1,nTime_read
+          timeVar = timeVar_temp(index_time(ix))*convTime2Secs
+          this%time(ix) = datetime_start%add_sec(timeVar, gage_calendar, ierr, cmessage)
+        end do
+      else
+        allocate(timeVar_temp(nTime), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [this%time]'; return; endif
+
+        allocate(this%time(nTime), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [this%time]'; return; endif
+
+        call get_nc(this%ncid, this%varName_time, timeVar_temp, 1, nTime, ierr, cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+        ! construct datetime data
+        do ix=1,nTime
+          timeVar = timeVar_temp(ix)*convTime2Secs
+          this%time(ix) = datetime_start%add_sec(timeVar, gage_calendar, ierr, cmessage)
+        end do
+
+      end if
+
+    END SUBROUTINE read_time
+
+    ! ---------------------------------
+    ! get obs data
+    ! ---------------------------------
+    SUBROUTINE read_obs(this, ierr, message, index_loc, index_time)
+
+      implicit none
+      ! Argument variables
+      class(obs),              intent(inout) :: this
+      integer(i4b),            intent(out)   :: ierr             ! error code
+      character(*),            intent(out)   :: message          ! error message
+      integer(i4b), optional,  intent(in)    :: index_loc
+      integer(i4b), optional,  intent(in)    :: index_time
+      ! local variables
+      real(dp),    allocatable               :: array_temp(:,:)
+      integer(i4b)                           :: nLoc_read        ! number of sites read
+      integer(i4b)                           :: nTime_read       ! number of time read
+      integer(i4b)                           :: nTime            ! number of time
+      integer(i4b)                           :: nLoc             ! number of site
+      integer(i4b)                           :: ix_loc, ix_time  ! starting reading index
+      integer(i4b)                           :: ix,jx
+      character(len=strLen)                  :: cmessage         ! error message of downwind routine
+
+      ierr=0; message='read_obs/'
+
+      if (present(index_loc)) then
+        nLoc_read = 1
+        ix_loc = index_loc
+      else
+        call get_nc_dim_len(this%ncid, this%dimName_loc, nLoc, ierr, cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+        nLoc_read = nLoc
+        ix_loc = 1
+      end if
+      if (present(index_time)) then
+        nTime_read = 1
+        ix_time = index_time
+      else
+        call get_nc_dim_len(this%ncid, this%dimName_time, nTime, ierr, cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+        nTime_read = nTime
+        ix_time = 1
+      end if
+
+      ! read full obs data
+      allocate(array_temp(nLoc_read, nTime_read), stat=ierr, errmsg=cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [array_temp]'; return; endif
+
+      call get_nc(this%ncid, this%varName_obs, array_temp, [ix_loc, ix_time], [nLoc_read, nTime_read], ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      if (allocated(this%obs)) then
+        deallocate(this%obs)
+      end if
+      allocate(this%obs(nTime_read, nLoc_read), stat=ierr, errmsg=cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [this%obs]'; return; endif
+      do ix=1,nLoc_read
+        do jx=1,nTime_read
+          this%obs(jx, ix) = array_temp(ix, jx)
+        end do
+      end do
+
+    END SUBROUTINE read_obs
+
+    ! -----------------------------------------------------
+    ! Wrapper FUNCTIONs: get array index
+    ! -----------------------------------------------------
+    FUNCTION fn_get_time_ix(this, datetime_in) result(ix)
+      implicit none
+      class(obs), intent(in)     :: this
+      type(datetime), intent(in) :: datetime_in
+      integer(i4b)               :: ix
+      ix = get_time_ix(this%time, datetime_in)
+    END FUNCTION fn_get_time_ix
+
+    FUNCTION fn_get_site_ix(this, site_in) result(ix)
+      implicit none
+      class(gageObs), intent(in) :: this
+      character(*), intent(in)   :: site_in
+      integer(i4b)               :: ix
+      ix = get_site_ix(this%site, site_in)
+    END FUNCTION fn_get_site_ix
+
+    FUNCTION fn_get_reach_ix(this, reach_in) result(ix)
+      implicit none
+      class(waterTake), intent(in) :: this
+      integer(i4b), intent(in)    :: reach_in
+      integer(i4b)                :: ix
+      ix = get_reach_ix(this%reach, reach_in)
+    END FUNCTION fn_get_reach_ix
+
+    ! -----------------------------------------------------
+    ! FUNCTIONs: get gage ID
+    ! -----------------------------------------------------
+    pure FUNCTION fn_get_link_ix(this) result(ix)
+      implicit none
+      class(obs), intent(in) :: this
+      integer(i4b), allocatable  :: ix(:)
+      allocate(ix(size(this%link_index)))
+      ix = this%link_index
+    END FUNCTION fn_get_link_ix
+
+    ! -----------------------------------------------------
+    ! FUNCTIONs: get gage ID
+    ! -----------------------------------------------------
+    pure FUNCTION fn_get_gageID(this) result(gageID)
+      implicit none
+      class(gageObs), intent(in) :: this
+      character(clen), allocatable  :: gageID(:)
+      allocate(gageID(size(this%site)))
+      gageID = this%site
+    END FUNCTION fn_get_gageID
+
+    pure FUNCTION fn_get_gageID_vec(this, ix) result(gageID)
+      implicit none
+      class(gageObs), intent(in) :: this
+      integer(i4b), intent(in)   :: ix(:)
+      character(clen), allocatable  :: gageID(:)
+      allocate(gageID(size(ix)))
+      gageID = this%site(ix)
+    END FUNCTION fn_get_gageID_vec
+
+    pure FUNCTION fn_get_gageID_scalar(this, ix) result(gageID)
+      implicit none
+      class(gageObs), intent(in) :: this
+      integer(i4b), intent(in)   :: ix
+      character(clen)            :: gageID
+      gageID = this%site(ix)
+    END FUNCTION fn_get_gageID_scalar
+
+    ! -----------------------------------------------------
+    ! FUNCTIONs: get reach ID
+    ! -----------------------------------------------------
+    pure FUNCTION fn_get_reachID(this) result(reachID)
+      implicit none
+      class(waterTake), intent(in) :: this
+      integer(i4b), allocatable    :: reachID(:)
+      allocate(reachID(size(this%reach)))
+      reachID = this%reach
+    END FUNCTION fn_get_reachID
+
+    pure FUNCTION fn_get_reachID_vec(this, ix) result(reachID)
+      implicit none
+      class(waterTake), intent(in) :: this
+      integer(i4b), intent(in)     :: ix(:)
+      integer(i4b), allocatable    :: reachID(:)
+      allocate(reachID(size(ix)))
+      reachID = this%reach(ix)
+    END FUNCTION fn_get_reachID_vec
+
+    pure FUNCTION fn_get_reachID_scalar(this, ix) result(reachID)
+      implicit none
+      class(waterTake), intent(in) :: this
+      integer(i4b), intent(in)     :: ix
+      integer(i4b)                 :: reachID
+      reachID = this%reach(ix)
+    END FUNCTION fn_get_reachID_scalar
+
+    ! -----------------------------------------------------
+    ! FUNCTIONs: get time
+    ! -----------------------------------------------------
+    FUNCTION fn_get_datetime(this) result(out_datetime)
+      implicit none
+      class(obs),  intent(in)     :: this
+      type(datetime), allocatable :: out_datetime(:)
+      integer(i4b)                :: ix
+      allocate(out_datetime(size(this%time)))
+      do ix=1,size(this%time)
+        out_datetime(ix) = this%time(ix)
+      end do
+    END FUNCTION fn_get_datetime
+
+    FUNCTION fn_get_datetime_vec(this, ix) result(out_datetime)
+      implicit none
+      class(obs),   intent(in)    :: this
+      integer(i4b), intent(in)    :: ix(:)
+      type(datetime), allocatable :: out_datetime(:)
+      integer(i4b)                :: jx
+      allocate(out_datetime(size(ix)))
+      do jx=1,size(ix)
+        out_datetime(jx) = this%time(ix(jx))
+      end do
+    END FUNCTION fn_get_datetime_vec
+
+    FUNCTION fn_get_datetime_scalar(this, ix) result(out_datetime)
+      implicit none
+      class(obs),   intent(in) :: this
+      integer(i4b), intent(in) :: ix
+      type(datetime)           :: out_datetime
+      out_datetime = this%time(ix)
+    END FUNCTION fn_get_datetime_scalar
+
+    ! -----------------------------------------------------
+    ! FUNCTIONs: get flow data
+    ! -----------------------------------------------------
+    pure FUNCTION fn_get_obs(this) result(flow)
+      implicit none
+      class(obs), intent(in) :: this
+      real(dp),allocatable   :: flow(:,:)
+      allocate(flow(size(this%obs,1), size(this%obs,2)))
+      flow = this%obs
+    END FUNCTION fn_get_obs
+
+    pure FUNCTION fn_get_obs_vec(this, tix, six) result(flow)
+      implicit none
+      class(obs),   intent(in) :: this
+      integer(i4b), intent(in) :: tix(:)
+      integer(i4b), intent(in) :: six(:)
+      real(dp),allocatable     :: flow(:,:)
+      allocate(flow(size(tix),size(six)))
+      flow = this%obs(tix, six)
+    END FUNCTION fn_get_obs_vec
+
+    pure FUNCTION fn_get_obs_tvec(this, tix, six) result(flow)
+      implicit none
+      class(obs),   intent(in) :: this
+      integer(i4b), intent(in) :: tix(:)
+      integer(i4b), intent(in) :: six
+      real(dp),allocatable     :: flow(:)
+      allocate(flow(size(tix)))
+      flow = this%obs(tix, six)
+    END FUNCTION fn_get_obs_tvec
+
+    pure FUNCTION fn_get_obs_svec(this, tix, six) result(flow)
+      implicit none
+      class(obs),   intent(in) :: this
+      integer(i4b), intent(in) :: tix
+      integer(i4b), intent(in) :: six(:)
+      real(dp),allocatable     :: flow(:)
+      allocate(flow(size(six)))
+      flow = this%obs(tix, six)
+    END FUNCTION fn_get_obs_svec
+
+    pure FUNCTION fn_get_obs_scalar(this, tix, six) result(flow)
+      implicit none
+      class(obs),   intent(in) :: this
+      integer(i4b), intent(in) :: tix
+      integer(i4b), intent(in) :: six
+      real(dp)                 :: flow
+      flow = this%obs(tix,six)
+    END FUNCTION fn_get_obs_scalar
+
+    ! -----------------------------------------------------
+    ! subroutine: index of reach ID array given reach iD
+    ! -----------------------------------------------------
+    SUBROUTINE sub_comp_link_reach2reach(this, reachID_in)
+      implicit none
+      ! Argument variables
+      class(waterTake),       intent(inout)  :: this
+      integer(i4b),           intent(in)     :: reachID_in(:)
+
+      allocate(this%link_index(this%nLoc))
+
+      ! Find index of matching reachID in reachID_in array
+      this%link_index = match_index(reachID_in, this%reach, missingValue=integerMissing)
+    END SUBROUTINE sub_comp_link_reach2reach
+
+    ! -----------------------------------------------------
+    ! subroutine: index of reach ID array given site iD
+    ! -----------------------------------------------------
+    SUBROUTINE sub_comp_link_site2reach(this, reachID_in, gageMeta_in)
+      implicit none
+      ! Argument variables
+      class(gageObs),         intent(inout)  :: this
+      integer(i4b),           intent(in)     :: reachID_in(:)
+      type(gageMeta),         intent(in)     :: gageMeta_in
+      ! local variables
+      integer(i4b), allocatable              :: reachID_gage(:)
+      integer(i4b)                           :: ix, jx
+
+      allocate(this%link_index(this%nLoc), reachID_gage(this%nLoc))
+
+      ! assuming nLoc and nGage are small
+      do ix = 1, this%nLoc
+        do jx = 1, gageMeta_in%gage_num()
+          if (trim(this%site(ix)) == trim(gageMeta_in%gage_id(jx))) then
+            reachID_gage(ix) = gageMeta_in%reach_id(jx)
+            exit
+          end if
+        end do
+      end do
+
+      ! Find index of matching reachID in reachID_in array
+      this%link_index = match_index(reachID_in, reachID_gage, missingValue=integerMissing)
+    END SUBROUTINE sub_comp_link_site2reach
+
+    ! -----------------------------------------------------
+    ! private functions/subroutines
+    ! -----------------------------------------------------
+    FUNCTION get_time_ix(datetime_array, datetime_in) result(tix)
+      implicit none
+      type(datetime), intent(in) :: datetime_array(:)
+      type(datetime), intent(in) :: datetime_in
+      integer(i4b)   :: tix
+      integer(i4b)   :: ix
+      do ix = 1, size(datetime_array)
+        if (datetime_array(ix) == datetime_in) then
+          tix = ix
+          exit
+        end if
+      end do
+    END FUNCTION get_time_ix
+
+    FUNCTION get_site_ix(site_array, site_in) result(six)
+      implicit none
+      character(*), intent(in) :: site_array(:)
+      character(*), intent(in) :: site_in
+      integer(i4b)   :: six
+      integer(i4b)   :: ix
+      do ix = 1, size(site_array)
+        if (trim(site_array(ix)) == trim(site_in)) then
+          six = ix
+          exit
+        end if
+      end do
+    END FUNCTION get_site_ix
+
+    FUNCTION get_reach_ix(reach_array, reach_in) result(rix)
+      implicit none
+      integer(i4b), intent(in) :: reach_array(:)
+      integer(i4b), intent(in) :: reach_in
+      integer(i4b) :: rix
+      integer(i4b) :: ix
+      do ix = 1, size(reach_array)
+        if (reach_array(ix) == reach_in) then
+          rix = ix
+          exit
+        end if
+      end do
+    END FUNCTION get_reach_ix
+
+END MODULE obs_data

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -131,7 +131,6 @@ contains
  meta_SEG    (ixSEG%totalArea        ) = var_info('totalArea'      , 'area above the bottom of the reach -- bas + ups'   ,'m2'    ,ixDims%seg   , .false.)
  meta_SEG    (ixSEG%basUnderLake     ) = var_info('basUnderLake'   , 'Area of basin under lake'                          ,'m2'    ,ixDims%seg   , .false.)
  meta_SEG    (ixSEG%rchUnderLake     ) = var_info('rchUnderLake'   , 'Length of reach under lake'                        ,'m'     ,ixDims%seg   , .false.)
- meta_SEG    (ixSEG%Qtake            ) = var_info('Qtake'          , 'target abstraction(-)/injection(+)'                ,'m3 s-1',ixDims%seg   , .false.)
  meta_SEG    (ixSEG%minFlow          ) = var_info('minFlow'        , 'minimum environmental flow'                        ,'m s-1' ,ixDims%seg   , .false.)
 
  ! NTOPO                                         varName        varDesc                                                varUnit, varType, varFile

--- a/route/build/src/process_ntopo.f90
+++ b/route/build/src/process_ntopo.f90
@@ -12,7 +12,6 @@ USE globalData, ONLY: onRoute               ! logical to indicate which routing 
 USE public_var, only : idSegOut           ! ID for stream segment at the bottom of the subset
 
 ! options
-USE public_var, only : qtakeOption            ! option to compute network topology
 USE public_var, only : topoNetworkOption      ! option to compute network topology
 USE public_var, only : computeReachList       ! option to compute reach list
 USE public_var, only : hydGeometryOption      ! option to obtain routing parameters
@@ -237,12 +236,6 @@ contains
    structSEG(iSeg)%var(ixSEG%minFlow)%dat(1) = 1.e-15_dp  ! Minimum environmental flow
  end do
 
- if(.not.qtakeOption)then
-  do iSeg=1,nSeg
-   structSEG(iSeg)%var(ixSEG%Qtake)%dat(1) = 0._dp  ! no abstraction/injection
-  end do
- end if
-
  ! compute hydraulic geometry (width and Manning's "n")
  if(hydGeometryOption==compute)then
 
@@ -456,9 +449,6 @@ end subroutine augment_ntopo
    RPARAM_in(iSeg)%BASAREA = structSEG(iSeg)%var(ixSEG%basArea)%dat(1)
    RPARAM_in(iSeg)%UPSAREA = structSEG(iSeg)%var(ixSEG%upsArea)%dat(1)
    RPARAM_in(iSeg)%TOTAREA = structSEG(iSeg)%var(ixSEG%totalArea)%dat(1)
-
-   ! Abstraction/Injection coefficient
-   RPARAM_in(iSeg)%QTAKE   = structSEG(iSeg)%var(ixSEG%Qtake)%dat(1)
 
    ! MINFLOW -- minimum environmental flow
    RPARAM_in(iSeg)%MINFLOW = structSEG(iSeg)%var(ixSEG%minFlow)%dat(1)

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -2,8 +2,7 @@ module public_var
   ! This module include variables that can be accessed from any other modules and values not altered
   ! except that variables read from control file are populated.
 
-  use nrtype, only: i4b,dp,lgt
-  use nrtype, only: strLen  ! string length
+  USE nrtype
   implicit none
 
   save
@@ -39,6 +38,7 @@ module public_var
   ! constants for general use
   real(dp),    parameter,public   :: MinPosVal=1.e-10_dp    ! minimum value for positive value
   integer(i4b),parameter,public   :: integerMissing=-9999   ! missing value for integers
+  real(sp),    parameter,public   :: floatMissing=-9999._sp ! missing value for real32 numbers
   real(dp),    parameter,public   :: realMissing=-9999._dp  ! missing value for real numbers
   character(5),parameter,public   :: charMissing='empty'    ! missing value for character
 
@@ -124,8 +124,25 @@ module public_var
   character(len=strLen),public    :: fname_state_in       = charMissing     ! name of state file
   ! SPATIAL CONSTANT PARAMETERS
   character(len=strLen),public    :: param_nml            = ''              ! name of the namelist file
+  ! GAUGE DATA
+  character(len=strLen),public    :: gageMetaFile         = charMissing     ! name of the gauge metadata csv
+  logical(lgt),public             :: outputAtGage         = .false.         ! logical; T-> history file output at only gauge points
+  character(len=strLen),public    :: fname_gageObs        = ''              ! gauge data netcdf name
+  character(len=strLen),public    :: vname_gageFlow       = ''              ! variable name for gauge flow data
+  character(len=strLen),public    :: vname_gageSite       = ''              ! variable name for site name data
+  character(len=strLen),public    :: vname_gageTime       = ''              ! variable name for time data
+  character(len=strLen),public    :: dname_gageSite       = ''              ! dimension name for gauge site
+  character(len=strLen),public    :: dname_gageTime       = ''              ! dimension name for time
+  integer(i4b)         ,public    :: strlen_gageSite      = 30              ! maximum character length for site name
+  ! WATER TAKE DATA
+  character(len=strLen),public    :: fname_waterTake      = ''              ! gauge data netcdf name
+  character(len=strLen),public    :: vname_waterTake      = ''              ! variable name for water take (+ abstract, - injection)
+  character(len=strLen),public    :: vname_wtReach        = ''              ! variable name for reach ID data
+  character(len=strLen),public    :: vname_wtTime         = ''              ! variable name for time data
+  character(len=strLen),public    :: dname_wtReach        = ''              ! dimension name for reach ID
+  character(len=strLen),public    :: dname_wtTime         = ''              ! dimension name for time
   ! USER OPTIONS
-  logical(lgt)         ,public    :: qtakeOption          = .false.         ! option for abstraction/injection
+  integer(i4b)         ,public    :: qmodOption           = 0               ! option for streamflow modification
   integer(i4b)         ,public    :: hydGeometryOption    = compute         ! option for hydraulic geometry calculations (0=read from file, 1=compute)
   integer(i4b)         ,public    :: topoNetworkOption    = compute         ! option for network topology calculations (0=read from file, 1=compute)
   integer(i4b)         ,public    :: computeReachList     = compute         ! option to compute list of upstream reaches (0=do not compute, 1=compute)

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -19,7 +19,6 @@ CONTAINS
 
  ! global vars
  USE globalData, only:time_conv,length_conv  ! conversion factors
-
  ! metadata structures
  USE globalData, ONLY: meta_HRU             ! HRU properties
  USE globalData, ONLY: meta_HRU2SEG         ! HRU-to-segment mapping
@@ -31,18 +30,17 @@ CONTAINS
  USE globalData, ONLY: routeMethods         ! active routing method index and id
  USE globalData, ONLY: onRoute                 ! logical to indicate actiive routing method(s)
  USE globalData, ONLY: idxSUM,idxIRF,idxKWT, &
-                        idxKW, idxMC, idxDW
+                       idxKW,idxMC,idxDW
  ! named variables in each structure
  USE var_lookup, ONLY : ixHRU                ! index of variables for data structure
  USE var_lookup, ONLY : ixHRU2SEG            ! index of variables for data structure
  USE var_lookup, ONLY : ixSEG                ! index of variables for data structure
  USE var_lookup, ONLY : ixNTOPO              ! index of variables for data structure
  USE var_lookup, ONLY : ixPFAF               ! index of variables for data structure
- USE var_lookup, ONLY : ixRFLX, nVarsRFLX    ! index of variables for data structure
-
+ USE var_lookup, ONLY : ixRFLX               ! index of variables for data structure
  ! external subroutines
- USE ascii_util_module, only: file_open      ! open file (performs a few checks as well)
- USE ascii_util_module, only: get_vlines     ! get a list of character strings from non-comment lines
+ USE ascii_util_module, ONLY: file_open      ! open file (performs a few checks as well)
+ USE ascii_util_module, ONLY: get_vlines     ! get a list of character strings from non-comment lines
  USE nr_utility_module, ONLY: char2int       ! convert integer number to a array containing individual digits
 
  implicit none
@@ -50,7 +48,6 @@ CONTAINS
  character(*), intent(in)          :: ctl_fname      ! name of the control file
  integer(i4b), intent(out)         :: err            ! error code
  character(*), intent(out)         :: message        ! error message
- ! ------------------------------------------------------------------------------------------------------
  ! Local variables
  character(len=strLen),allocatable :: cLines(:)      ! vector of character strings
  character(len=strLen)             :: cName,cData    ! name and data from cLines(iLine)
@@ -76,7 +73,6 @@ CONTAINS
  call get_vlines(iunit,cLines,err,cmessage)
  if(err/=0)then; message=trim(message)//trim(cmessage);return;endif
 
- ! close the file unit
  close(iunit)
 
  ! loop through the non-comment lines in the input file, and extract the name and the information
@@ -153,13 +149,30 @@ CONTAINS
    ! SPATIAL CONSTANT PARAMETERS
    case('<param_nml>');            param_nml       = trim(cData)                   ! name of namelist including routing parameter value
    ! USER OPTIONS: Define options to include/skip calculations
-   case('<qtakeOption>');          read(cData,*,iostat=io_error) qtakeOption       ! option for abstraction/injection option
+   case('<qmodOption>');           read(cData,*,iostat=io_error) qmodOption       ! option for abstraction/injection option
    case('<hydGeometryOption>');    read(cData,*,iostat=io_error) hydGeometryOption ! option for hydraulic geometry calculations (0=read from file, 1=compute)
    case('<topoNetworkOption>');    read(cData,*,iostat=io_error) topoNetworkOption ! option for network topology calculations (0=read from file, 1=compute)
    case('<computeReachList>');     read(cData,*,iostat=io_error) computeReachList  ! option to compute list of upstream reaches (0=do not compute, 1=compute)
    ! TIME
    case('<time_units>');           time_units = trim(cData)                        ! time units. format should be <unit> since yyyy-mm-dd (hh:mm:ss). () can be omitted
    case('<calendar>');             calendar   = trim(cData)                        ! calendar name
+   ! GAUGE DATA
+   case('<gageMetaFile>');         gageMetaFile = trim(cData)                      ! name of csv file containing gauge metadata (gauge id, reach id, gauge lat/lon)
+   case('<outputAtGage>');         read(cData,*,iostat=io_error) outputAtGage      ! logical; T-> history file output at only gauge points
+   case('<fname_gageObs>');        fname_gageObs = trim(cData)                     ! netcdf name of gauge observed data
+   case('<vname_gageFlow>');       vname_gageFlow  = trim(cData)                   ! varialbe name for gauge site flow data
+   case('<vname_gageSite>');       vname_gageSite  = trim(cData)                   ! variable name for site name data
+   case('<vname_gageTime>');       vname_gageTime  = trim(cData)                   ! variable name for time data
+   case('<dname_gageSite>');       dname_gageSite  = trim(cData)                   ! dimension name for gauge site
+   case('<dname_gageTime>');       dname_gageTime  = trim(cData)                   ! dimension name for time
+   case('<strlen_gageSite>');      read(cData,*,iostat=io_error) strlen_gageSite   ! site name max character length
+   ! reach water take data
+   case('<fname_waterTake>');      fname_waterTake = trim(cData)                   ! netcdf name of reach water take file name
+   case('<vname_waterTake>');      vname_waterTake = trim(cData)                   ! varialbe name for water take (+ abstract, - injection)
+   case('<vname_wtReach>');        vname_wtReach   = trim(cData)                   ! variable name for reach ID data
+   case('<vname_wtTime>');         vname_wtTime    = trim(cData)                   ! variable name for time data
+   case('<dname_wtReach>');        dname_wtReach   = trim(cData)                   ! dimension name for reach ID
+   case('<dname_wtTime>');         dname_wtTime    = trim(cData)                   ! dimension name for time
    ! MISCELLANEOUS
    case('<debug>');                read(cData,*,iostat=io_error) debug             ! print out detailed information throught the probram
    case('<seg_outlet>'   );        read(cData,*,iostat=io_error) idSegOut          ! desired outlet reach id (if -9999 --> route over the entire network)
@@ -198,7 +211,6 @@ CONTAINS
    case('<varname_upsArea>'      ); meta_SEG    (ixSEG%upsArea         )%varName =trim(cData)  ! area above the top of the reach -- zero if headwater (m2)
    case('<varname_basUnderLake>' ); meta_SEG    (ixSEG%basUnderLake    )%varName =trim(cData)  ! Area of basin under lake  (m2)
    case('<varname_rchUnderLake>' ); meta_SEG    (ixSEG%rchUnderLake    )%varName =trim(cData)  ! Length of reach under lake (m)
-   case('<varname_qtake>'        ); meta_SEG    (ixSEG%Qtake           )%varName =trim(cData)  ! abstraction(-)/injection(+) (m3 s-1)
    case('<varname_minFlow>'      ); meta_SEG    (ixSEG%minFlow         )%varName =trim(cData)  ! minimum environmental flow
    ! network topology
    case('<varname_hruContribIx>' ); meta_NTOPO  (ixNTOPO%hruContribIx  )%varName =trim(cData)  ! indices of the vector of HRUs that contribute flow to each segment
@@ -220,14 +232,14 @@ CONTAINS
 
    ! if not in list then keep going
    case default
-    message=trim(message)//'unexpected text in control file -- provided '//trim(cName)&
+    message=trim(message)//'unexpected text in control file provided: '//trim(cName)&
                          //' (note strings in control file must match the variable names in public_var.f90)'
     err=20; return
   end select
 
   ! check I/O error
   if(io_error/=0)then
-   message=trim(message)//'problem with internal read of '//trim(cName); err=20; return
+    message=trim(message)//'problem with internal read of '//trim(cName); err=20; return
   endif
 
  end do  ! looping through lines in the control file
@@ -238,11 +250,9 @@ CONTAINS
  endif
 
  ! ---------- control river network writing option  ---------------------------------------------------------------------
-
  ! Case1- river network subset mode (idSegOut>0):  Write the network variables read from file over only upstream network specified idSegOut
  ! Case2- river network augment mode: Write full network variables over the entire network
  ! River network subset mode turnes off augmentation mode.
-
  ! Turned off ntopAugmentMode
  if (idSegOut>0) then
    ntopAugmentMode = .false.
@@ -281,7 +291,7 @@ CONTAINS
    case('m');  length_conv = 1._dp
    case('mm'); length_conv = 1._dp/1000._dp
    case default
-     message=trim(message)//'expect the length units to be "m" or "mm" [units='//trim(cLength)//']'
+     message=trim(message)//'expect the length units of runoff to be "m" or "mm" [units='//trim(cLength)//']'
      err=81; return
  end select
 
@@ -291,7 +301,7 @@ CONTAINS
    case('h','hr','hour');    time_conv = 1._dp/secprhour
    case('s','sec','second'); time_conv = 1._dp
    case default
-     message=trim(message)//'expect the time units to be "day"("d"), "hour"("h") or "second"("s") [time units = '//trim(cTime)//']'
+     message=trim(message)//'expect the time units of runoff to be "day"("d"), "hour"("h") or "second"("s") [time units = '//trim(cTime)//']'
      err=81; return
  end select
 
@@ -328,7 +338,7 @@ CONTAINS
  end do
 
  ! basin runoff routing option
- if (doesBasinRoute==0) meta_rflx(ixRFLX%instRunoff)%varFile=.false.
+ if (doesBasinRoute==0) meta_rflx(ixRFLX%instRunoff)%varFile = .false.
 
  END SUBROUTINE read_control
 

--- a/route/build/src/read_streamSeg.f90
+++ b/route/build/src/read_streamSeg.f90
@@ -142,10 +142,6 @@ contains
  ! -----------------------------------------------------------------------------------------------------------------
  ! ---------- read in data -----------------------------------------------------------------------------------------
  ! -----------------------------------------------------------------------------------------------------------------
- ! set flags if we want to turn on abstraction/injection option (require Qtake in network data)
- if(qtakeOption)then
-  meta_SEG(ixSEG%Qtake)%varFile = .true.
- endif
 
  ! set flags if we want to read hdraulic geometry from file
  if(hydGeometryOption==readFromFile)then

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -83,8 +83,6 @@ MODULE var_lookup
   integer(i4b)     :: basArea       = integerMissing  ! area of the local HRUs contributing to each reach (m2)
   integer(i4b)     :: upsArea       = integerMissing  ! area above the top of the reach -- zero if headwater (m2)
   integer(i4b)     :: totalArea     = integerMissing  ! basArea + upsArea -- area at the bottom of the reach (m2)
-  ! abstraction/injection from reach
-  integer(i4b)     :: QTAKE         = integerMissing  ! abstraction(-)/injection(+) coefficient [m3/s]
   ! lakes
   integer(i4b)     :: basUnderLake  = integerMissing  ! Area of basin under lake  (m2)
   integer(i4b)     :: rchUnderLake  = integerMissing  ! Length of reach under lake (m)
@@ -187,7 +185,7 @@ MODULE var_lookup
  type(iLook_qDims)    ,public,parameter :: ixqDims     = iLook_qDims    (1,2,3,4)
  type(iLook_HRU)      ,public,parameter :: ixHRU       = iLook_HRU      (1)
  type(iLook_HRU2SEG)  ,public,parameter :: ixHRU2SEG   = iLook_HRU2SEG  (1,2,3,4)
- type(iLook_SEG)      ,public,parameter :: ixSEG       = iLook_SEG      (1,2,3,4,5,6,7,8,9,10,11,12,13,14)
+ type(iLook_SEG)      ,public,parameter :: ixSEG       = iLook_SEG      (1,2,3,4,5,6,7,8,9,10,11,12,13)
  type(iLook_NTOPO)    ,public,parameter :: ixNTOPO     = iLook_NTOPO    (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17)
  type(iLook_PFAF)     ,public,parameter :: ixPFAF      = iLook_PFAF     (1)
  type(iLook_RFLX)     ,public,parameter :: ixRFLX      = iLook_RFLX     (1,2,3,4,5,6,7,8,9,10)


### PR DESCRIPTION
- New objects, csv, gage_meta, and gage_data to hold data and type-bound routines
- read gage meta data from csv, gage observation (for each time step and selected reach), and water take (for each time step and selected reach)
- water take (abstraction/injection) implementation

if qmodOption == 0 (default), the simulations should be identical to v1.2.2.

Direct insertion of observed discharge (qmodOption == 1) is not finished yet. 