### PR TITLE
water take from reach during routing

### DIFF
--- a/route/build/src/accum_runoff.f90
+++ b/route/build/src/accum_runoff.f90
@@ -159,16 +159,18 @@ CONTAINS
 
  ! check
  if(segIndex == ixDesire)then
-   write(fmt1,'(A,I5,A)') '(A,1X',nUps,'(1X,I10))'
-   write(fmt2,'(A,I5,A)') '(A,1X',nUps,'(1X,F20.7))'
    write(iulog,'(2a)') new_line('a'),'** Check upstream discharge accumulation **'
    write(iulog,'(a,x,I10,x,I10)') ' Reach index & ID =', segIndex, NETOPO_in(segIndex)%REACHID
-   write(iulog,'(a)')             ' * upstream reach index (NETOPO_in%UREACH) and discharge (uprflux) [m3/s] :'
-   write(iulog,fmt1)              ' UREACHK =', (NETOPO_in(segIndex)%UREACHK(iUps), iUps=1,nUps)
-   write(iulog,fmt2)              ' prflux  =', (RCHFLX_out(iens,NETOPO_in(segIndex)%UREACHI(iUps))%ROUTE(idxSUM)%REACH_Q, iUps=1,nUps)
+   if (nUps>0) then
+     write(fmt1,'(A,I5,A)') '(A,1X',nUps,'(1X,I10))'
+     write(fmt2,'(A,I5,A)') '(A,1X',nUps,'(1X,F20.7))'
+     write(iulog,'(a)')             ' * upstream reach index (NETOPO_in%UREACH) and discharge (uprflux) [m3/s] :'
+     write(iulog,fmt1)              ' UREACHK =', (NETOPO_in(segIndex)%UREACHK(iUps), iUps=1,nUps)
+     write(iulog,fmt2)              ' prflux  =', (RCHFLX_out(iens,NETOPO_in(segIndex)%UREACHI(iUps))%ROUTE(idxSUM)%REACH_Q, iUps=1,nUps)
+   end if
    write(iulog,'(a)')             ' * local area discharge (RCHFLX_out%BASIN_QR(1)) and final discharge (RCHFLX_out%ROUTE(idxSUM)%REACH_Q) [m3/s] :'
-   write(iulog,'(a,x,F15.7)')     ' RCHFLX_out%BASIN_QR(1) =', RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
-   write(iulog,'(a,x,F15.7)')     ' RCHFLX_out%ROUTE(idxSUM)%REACH_Q =', RCHFLX_out(iens,segIndex)%ROUTE(idxSUM)%REACH_Q
+   write(iulog,'(a,x,G15.4)')     ' RCHFLX_out%BASIN_QR(1) =', RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
+   write(iulog,'(a,x,G15.4)')     ' RCHFLX_out%ROUTE(idxSUM)%REACH_Q =', RCHFLX_out(iens,segIndex)%ROUTE(idxSUM)%REACH_Q
  endif
 
  END SUBROUTINE accum_qupstream

--- a/route/build/src/kw_route.f90
+++ b/route/build/src/kw_route.f90
@@ -6,7 +6,7 @@ USE dataTypes, ONLY: STRFLX            ! fluxes in each reach
 USE dataTypes, ONLY: STRSTA            ! state in each reach
 USE dataTypes, ONLY: RCHTOPO           ! Network topology
 USE dataTypes, ONLY: RCHPRP            ! Reach parameter
-USE dataTypes, ONLY: kwRCH             ! kw specific state data structure 
+USE dataTypes, ONLY: kwRCH             ! kw specific state data structure
 USE dataTypes, ONLY: subbasin_omp      ! mainstem+tributary data strucuture
 ! global data
 USE public_var, ONLY: iulog             ! i/o logical unit number
@@ -183,11 +183,11 @@ CONTAINS
  endif
 
  if(doCheck)then
-   write(iulog,'(A)') 'CHECK Kinematic wave routing'
+   write(iulog,'(2A)') new_line('a'), '** CHECK Kinematic wave routing **'
    if (nUps>0) then
      do iUps = 1,nUps
        iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-       write(iulog,'(A,X,I6,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q
+       write(iulog,'(A,X,I12,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q
      enddo
    end if
    write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iEns,segIndex)%BASIN_QR(1)=',RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
@@ -197,6 +197,8 @@ CONTAINS
  call kinematic_wave(RPARAM_in(segIndex),                & ! input: parameter at segIndex reach
                      T0,T1,                              & ! input: start and end of the time step
                      q_upstream,                         & ! input: total discharge at top of the reach being processed
+                     RCHFLX_out(iens,segIndex)%TAKE,     & ! input: abstraction(-)/injection(+) [m3/s]
+                     RPARAM_in(segIndex)%MINFLOW,        & ! input: minimum environmental flow [m3/s]
                      isHW,                               & ! input: is this headwater basin?
                      RCHSTA_out(iens,segIndex)%KW_ROUTE, & ! inout:
                      RCHFLX_out(iens,segIndex),          & ! inout: updated fluxes at reach
@@ -220,6 +222,8 @@ CONTAINS
  SUBROUTINE kinematic_wave(rch_param,     & ! input: river parameter data structure
                            T0,T1,         & ! input: start and end of the time step
                            q_upstream,    & ! input: discharge from upstream
+                           Qtake,         & ! input: abstraction(-)/injection(+) [m3/s]
+                           Qmin,          & ! input: minimum environmental flow [m3/s]
                            isHW,          & ! input: is this headwater basin?
                            rstate,        & ! inout: reach state at a reach
                            rflux,         & ! inout: reach flux at a reach
@@ -244,6 +248,8 @@ CONTAINS
  type(RCHPRP), intent(in)                 :: rch_param    ! River reach parameter
  real(dp),     intent(in)                 :: T0,T1        ! start and end of the time step (seconds)
  real(dp),     intent(in)                 :: q_upstream   ! total discharge at top of the reach being processed
+ real(dp),     intent(in)                 :: Qtake        ! abstraction(-)/injection(+) [m3/s]
+ real(dp),     intent(in)                 :: Qmin         ! minimum environmental flow [m3/s]
  logical(lgt), intent(in)                 :: isHW         ! is this headwater basin?
  logical(lgt), intent(in)                 :: doCheck      ! reach index to be examined
  ! Input/Output
@@ -268,6 +274,9 @@ CONTAINS
  real(dp)                                 :: Qbar         !
  real(dp)                                 :: absErr(2)    ! absolute error of nonliear equation solution
  real(dp)                                 :: f0eval(2)    !
+ real(dp)                                 :: QupMod       ! modified total discharge at top of the reach being processed
+ real(dp)                                 :: Qabs         ! maximum allowable water abstraction rate [m3/s]
+ real(dp)                                 :: Qmod         ! abstraction rate to be taken from outlet discharge [m3/s]
  integer(i4b)                             :: imin         ! index at minimum value
 
  ierr=0; message='kinematic_wave/'
@@ -276,6 +285,13 @@ CONTAINS
  !  current time and outlet 4 (1,1) -> previous time and outlet 2 (0,1)
  Q(0,0) = rstate%molecule%Q(1)
  Q(0,1) = rstate%molecule%Q(2)
+ dt = T1-T0
+
+ ! Q injection, add at top of reach
+ QupMod = q_upstream
+ if (Qtake>0) then
+   QupMod = QupMod+ Qtake
+ end if
 
  if (.not. isHW) then
 
@@ -289,14 +305,17 @@ CONTAINS
    beta1  = 1._dp/beta
    alpha1 = (1.0/alpha)**beta1
    dX = rch_param%RLENGTH
-   dT = T1-T0
-   theta = dT/dX
+   theta = dt/dX
 
    ! compute total flow rate and flow area at upstream end at current time step
-   Q(1,0) = q_upstream
+   Q(1,0) = QupMod
 
    if (doCheck) then
-     write(iulog,'(3(A,X,G12.5))') ' R_SLOPE=',rch_param%R_SLOPE,' R_WIDTH=',rch_param%R_WIDTH,' R_MANN=',rch_param%R_MAN_N
+     write(iulog,'(A,X,G12.5)') ' length [m]        =',rch_param%RLENGTH
+     write(iulog,'(A,X,G12.5)') ' slope [-]         =',rch_param%R_SLOPE
+     write(iulog,'(A,X,G12.5)') ' channel width [m] =',rch_param%R_WIDTH
+     write(iulog,'(A,X,G12.5)') ' manning coef. [-] =',rch_param%R_MAN_N
+     write(iulog,'(A)')         ' Initial 3 point discharge [m3/s]: '
      write(iulog,'(3(A,X,G12.5))') ' Q(0,0)=',Q(0,0),' Q(0,1)=',Q(0,1),' Q(1,0)=',Q(1,0)
    end if
 
@@ -355,11 +374,28 @@ CONTAINS
 
  ! compute volume
  rflux%ROUTE(idxKW)%REACH_VOL(0) = rflux%ROUTE(idxKW)%REACH_VOL(1)
- rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dT
+ rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dt
  rflux%ROUTE(idxKW)%REACH_VOL(1) = max(rflux%ROUTE(idxKW)%REACH_VOL(1), 0._dp)
 
  ! add catchment flow
  rflux%ROUTE(idxKW)%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)
+
+ ! Q abstraction
+ ! Compute actual abstraction (Qabs) m3/s - values should be negative
+ ! Compute abstraction (Qmod) m3 taken from outlet discharge (REACH_Q)
+ ! Compute REACH_Q subtracted from Qmod abstraction
+ ! Compute REACH_VOL subtracted from total abstraction minus abstraction from outlet discharge
+ if (Qtake<0) then
+   Qabs = max(-(rflux%ROUTE(idxKW)%REACH_VOL(1)/dt+rflux%ROUTE(idxKW)%REACH_Q-Qmin), Qtake)
+   Qabs = min(Qabs, 0._dp)  ! this should be <=0
+   Qmod = min(rflux%ROUTE(idxKW)%REACH_VOL(1) + Qabs*dt, 0._dp) ! this should be <= 0
+
+   rflux%ROUTE(idxKW)%REACH_Q      = rflux%ROUTE(idxKW)%REACH_Q + Qmod/dt
+   rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(1) + (Qabs*dt - Qmod)
+
+   ! modify computational molecule state (Q)
+   Q(1,1) = Q(1,1) - max(abs(Qmod/dt)-rflux%BASIN_QR(1), 0._dp)
+ end if
 
  ! update state
  rstate%molecule%Q(1) = Q(1,0)

--- a/route/build/src/kwt_route.f90
+++ b/route/build/src/kwt_route.f90
@@ -292,7 +292,7 @@ CONTAINS
       endif
 
       if(JRCH==ixDesire)then
-        write(fmt1,'(A,I5,A)') '(A, 1X',size(Q_JRCH),'(1X,F20.7))'
+        write(fmt1,'(A,I5,A)') '(A, 1X',size(Q_JRCH),'(1X,G15.4))'
         write(*,'(a)') ' * Wave discharge from upstream reaches (Q_JRCH) [m2/s]:'
         write(*,fmt1)  ' Q_JRCH=',(Q_JRCH(IWV), IWV=0,size(Q_JRCH)-1)
       endif
@@ -313,7 +313,7 @@ CONTAINS
 
       if(JRCH==ixDesire) then
         write(*,'(a)') ' * Final discharge (RCHFLX_out(IENS,JRCH)%REACH_Q) [m3/s]:'
-        write(*,'(x,F20.7)') RCHFLX_out(IENS,JRCH)%ROUTE(idxKWT)%REACH_Q
+        write(*,'(x,G15.4)') RCHFLX_out(IENS,JRCH)%ROUTE(idxKWT)%REACH_Q
       end if
       return  ! no upstream reaches (routing for sub-basins done using time-delay histogram)
     endif
@@ -366,7 +366,7 @@ CONTAINS
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     if(JRCH == ixDesire)then
-      write(fmt1,'(A,I5,A)') '(A,1X',NQ1+1,'(1X,F20.7))'
+      write(fmt1,'(A,I5,A)') '(A,1X',NQ1+1,'(1X,G15.4))'
       write(fmt2,'(A,I5,A)') '(A,1X',NQ1+1,'(1X,L))'
       write(*,'(a)') ' * After routed: wave discharge (Q_JRCH) [m2/s], isExit(FROUTE), entry time (TENTRY) [s], and exit time (T_EXIT) [s]:'
       write(*,fmt1)  ' Q_JRCH=',(Q_JRCH(IWV), IWV=0,NQ1)
@@ -391,9 +391,9 @@ CONTAINS
 
     if(JRCH == ixDesire)then
       write(*,'(a)')          ' * Time-ave. wave discharge that exit (QNEW(1)) [m2/s], local-area discharge (RCHFLX_out%BASIN_QR(1)) [m3/s] and Final discharge (RCHFLX_out%REACH_Q) [m3/s]:'
-      write(*,"(A,1x,F15.7)") ' QNEW(1)                =', QNEW(1)
-      write(*,"(A,1x,F15.7)") ' RCHFLX_out%BASIN_QR(1) =', RCHFLX_out(IENS,JRCH)%BASIN_QR(1)
-      write(*,"(A,1x,F15.7)") ' RCHFLX_out%REACH_Q     =', RCHFLX_out(IENS,JRCH)%ROUTE(idxKWT)%REACH_Q
+      write(*,"(A,1x,G15.4)") ' QNEW(1)                =', QNEW(1)
+      write(*,"(A,1x,G15.4)") ' RCHFLX_out%BASIN_QR(1) =', RCHFLX_out(IENS,JRCH)%BASIN_QR(1)
+      write(*,"(A,1x,G15.4)") ' RCHFLX_out%REACH_Q     =', RCHFLX_out(IENS,JRCH)%ROUTE(idxKWT)%REACH_Q
     endif
 
     ! ----------------------------------------------------------------------------------------
@@ -541,9 +541,9 @@ CONTAINS
     call interp_rch(TENTRY(0:NR-1),Q_jrch_abs(0:NR-1), TP, Qavg, ierr,cmessage)
     Qabs = Qavg(1)*RPARAM_in(JRCH)%R_WIDTH
     write(*,'(a)')         ' * Target abstraction (Qtake) [m3/s], Available discharge (totQ) [m3/s], Actual abstraction (Qabs) [m3/s] '
-    write(*,'(a,x,F15.7)') ' Qtake =', Qtake
-    write(*,'(a,x,F15.7)') ' totQ  =', totQ
-    write(*,'(a,x,F15.7)') ' Qabs  =', Qabs
+    write(*,'(a,x,G15.4)') ' Qtake =', Qtake
+    write(*,'(a,x,G15.4)') ' totQ  =', totQ
+    write(*,'(a,x,G15.4)') ' Qabs  =', Qabs
   end if
 
   ! modify wave speed at modified wave discharge and re-compute exit time
@@ -557,7 +557,7 @@ CONTAINS
   T_EXIT(1:NR-1) = t_exit_mod(1:NR-1)
 
   if(JRCH == ixDesire)then
-    write(fmt1,'(A,I5,A)') '(A,1X',NR,'(1X,E15.7))'
+    write(fmt1,'(A,I5,A)') '(A,1X',NR,'(1X,G15.4))'
     write(*,'(a)') ' * After abstracted: wave discharge (Q_JRCH) [m2/s], entry time (TENTRY) [s], and exit time (T_EXIT) [s]:'
     write(*,fmt1)  ' Q_JRCH=',(Q_JRCH(iw), iw=0,NR-1)
     write(*,fmt1)  ' TENTRY=',(TENTRY(iw), iw=0,NR-1)
@@ -687,7 +687,7 @@ CONTAINS
                   RSTEP)                             ! optional input
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   if (JRCH == ixDesire) then
-    write(fmt1,'(A,I5,A)') '(A,1X',ND,'(1X,F15.7))'
+    write(fmt1,'(A,I5,A)') '(A,1X',ND,'(1X,G15.4))'
     write(*,'(a)')      ' * After qexmul_rch: # of routed wave from upstreams (ND) and wave discharge (QD) [m2/s]:'
     write(*,'(A,x,I5)') ' ND=', ND
     write(*,fmt1)       ' QD=', (QD(iw), iw=1,ND)
@@ -1414,7 +1414,7 @@ CONTAINS
  WC(1:NN) = ALFA*K**(1./ALFA)*Q1(1:NN)**((ALFA-1.)/ALFA)
 
  if(jRch==ixDesire) then
-   write(fmt1,'(A,I5,A)') '(A,1X',NN,'(1X,F15.7))'
+   write(fmt1,'(A,I5,A)') '(A,1X',NN,'(1X,G15.4))'
    write(*,'(a)')      ' * Wave discharge (q1) [m2/s] and wave celertiy (wc) [m/s]:'
    write(*,'(a,x,I3)') ' Number of wave =', NN
    write(*,fmt1)       ' q1=', (q1(iw), iw=1,NN)
@@ -1474,7 +1474,7 @@ CONTAINS
 
  ! check
  if(jRch==ixDesire) then
-   write(fmt1,'(A,I5,A)') '(A,1X',NN,'(1X,F15.7))'
+   write(fmt1,'(A,I5,A)') '(A,1X',NN,'(1X,G15.4))'
    write(*,'(a)')      ' * After wave merge: wave celertiy (wc) [m/s]:'
    write(*,'(a,x,I3)') ' Number of wave =', NN
    write(*,fmt1)       ' wc=', (wc(iw), iw=1,NN)

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -8,13 +8,13 @@ USE dataTypes,   ONLY: STRFLX            ! fluxes in each reach
 USE dataTypes,   ONLY: STRSTA            ! state in each reach
 USE dataTypes,   ONLY: RCHTOPO           ! Network topology
 USE dataTypes,   ONLY: RCHPRP            ! Reach parameter
-USE dataTypes,   ONLY: mcRCH             ! MC specific state data structure 
+USE dataTypes,   ONLY: mcRCH             ! MC specific state data structure
 USE dataTypes,   ONLY: subbasin_omp      ! mainstem+tributary data strucuture
 ! global data
 USE public_var,  ONLY: iulog             ! i/o logical unit number
 USE public_var,  ONLY: realMissing       ! missing value for real number
 USE public_var,  ONLY: integerMissing    ! missing value for integer number
-USE globalData,  ONLY: idxMC             ! index of IRF method 
+USE globalData,  ONLY: idxMC             ! index of IRF method
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
 
@@ -185,11 +185,11 @@ contains
  endif
 
  if(doCheck)then
-   write(iulog,'(A)') 'CHECK muskingum-cunge routing'
+   write(iulog,'(2A)') new_line('a'), '** Check muskingum-cunge routing **'
    if (nUps>0) then
      do iUps = 1,nUps
        iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-       write(iulog,'(A,X,I6,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
+       write(iulog,'(A,X,I12,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
      enddo
    end if
    write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iEns,segIndex)%BASIN_QR(1)=',RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
@@ -199,6 +199,8 @@ contains
  call muskingum_cunge(RPARAM_in(segIndex),                & ! input: parameter at segIndex reach
                       T0,T1,                              & ! input: start and end of the time step
                       q_upstream,                         & ! input: total discharge at top of the reach being processed
+                      RCHFLX_out(iens,segIndex)%TAKE,     & ! input: abstraction(-)/injection(+) [m3/s]
+                      RPARAM_in(segIndex)%MINFLOW,        & ! input: minimum environmental flow [m3/s]
                       isHW,                               & ! input: is this headwater basin?
                       RCHSTA_out(iens,segIndex)%MC_ROUTE, & ! inout:
                       RCHFLX_out(iens,segIndex),          & ! inout: updated fluxes at reach
@@ -222,6 +224,8 @@ contains
  SUBROUTINE muskingum_cunge(rch_param,     & ! input: river parameter data structure
                             T0,T1,         & ! input: start and end of the time step
                             q_upstream,    & ! input: discharge from upstream
+                            Qtake,         & ! input: abstraction(-)/injection(+) [m3/s]
+                            Qmin,          & ! input: minimum environmental flow [m3/s]
                             isHW,          & ! input: is this headwater basin?
                             rstate,        & ! inout: reach state at a reach
                             rflux,         & ! inout: reach flux at a reach
@@ -246,6 +250,8 @@ contains
  type(RCHPRP), intent(in)                 :: rch_param    ! River reach parameter
  real(dp),     intent(in)                 :: T0,T1        ! start and end of the time step (seconds)
  real(dp),     intent(in)                 :: q_upstream   ! total discharge at top of the reach being processed
+ real(dp),     intent(in)                 :: Qtake        ! abstraction(-)/injection(+) [m3/s]
+ real(dp),     intent(in)                 :: Qmin         ! minimum environmental flow [m3/s]
  logical(lgt), intent(in)                 :: isHW         ! is this headwater basin?
  logical(lgt), intent(in)                 :: doCheck      ! reach index to be examined
  ! Input/Output
@@ -273,6 +279,9 @@ contains
  real(dp)                                 :: C0,C1,C2     ! muskingum parameters
  real(dp), allocatable                    :: QoutLocal(:) ! out discharge [m3/s] at sub time step
  real(dp), allocatable                    :: QinLocal(:)  ! in discharge [m3/s] at sub time step
+ real(dp)                                 :: QupMod       ! modified total discharge at top of the reach being processed
+ real(dp)                                 :: Qabs         ! maximum allowable water abstraction rate [m3/s]
+ real(dp)                                 :: Qmod         ! abstraction rate to be taken from outlet discharge [m3/s]
  integer(i4b)                             :: ix           ! loop index
  integer(i4b)                             :: ntSub        ! number of sub time-step
  character(len=strLen)                    :: cmessage     ! error message from subroutine
@@ -283,6 +292,13 @@ contains
  Q(0,0) = rstate%molecule%Q(1) ! inflow at previous time step (t-1)
  Q(0,1) = rstate%molecule%Q(2) ! outflow at previous time step (t-1)
  Q(1,1) = realMissing
+ dt = T1-T0
+
+ ! Q injection, add at top of reach
+ QupMod = q_upstream
+ if (Qtake>0) then
+   QupMod = QupMod+ Qtake
+ end if
 
  if (.not. isHW) then
 
@@ -292,14 +308,17 @@ contains
    alpha = sqrt(rch_param%R_SLOPE)/(rch_param%R_MAN_N*rch_param%R_WIDTH**(2._dp/3._dp))
    beta  = 5._dp/3._dp
    dx = rch_param%RLENGTH
-   dt = T1-T0
    theta = dt/dx     ! [s/m]
 
    ! compute total flow rate and flow area at upstream end at current time step
-   Q(1,0) = q_upstream
+   Q(1,0) = QupMod
 
    if (doCheck) then
-     write(iulog,'(4(A,X,G12.5))') ' length [m] =',rch_param%RLENGTH,'slope [-] =',rch_param%R_SLOPE,'channel width [m] =',rch_param%R_WIDTH,'manning coef =',rch_param%R_MAN_N
+     write(iulog,'(A,X,G12.5)') ' length [m]        =',rch_param%RLENGTH
+     write(iulog,'(A,X,G12.5)') ' slope [-]         =',rch_param%R_SLOPE
+     write(iulog,'(A,X,G12.5)') ' channel width [m] =',rch_param%R_WIDTH
+     write(iulog,'(A,X,G12.5)') ' manning coef [-]  =',rch_param%R_MAN_N
+     write(iulog,'(A)')         ' Initial 3 point discharge [m3/s]: '
      write(iulog,'(3(A,X,G12.5))') ' Qin(t-1) Q(0,0)=',Q(0,0),' Qin(t) Q(0,1)=',Q(0,1),' Qout(t-1) Q(1,0)=',Q(1,0)
    end if
 
@@ -371,11 +390,28 @@ contains
 
  ! compute volume
  rflux%ROUTE(idxMC)%REACH_VOL(0) = rflux%ROUTE(idxMC)%REACH_VOL(1)
- rflux%ROUTE(idxMC)%REACH_VOL(1) = rflux%ROUTE(idxMC)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dT
+ rflux%ROUTE(idxMC)%REACH_VOL(1) = rflux%ROUTE(idxMC)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dt
  rflux%ROUTE(idxMC)%REACH_VOL(1) = max(rflux%ROUTE(idxMC)%REACH_VOL(1), 0._dp)
 
  ! add catchment flow
  rflux%ROUTE(idxMC)%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)
+
+ ! Q abstraction
+ ! Compute actual abstraction (Qabs) m3/s - values should be negative
+ ! Compute abstraction (Qmod) m3 taken from outlet discharge (REACH_Q)
+ ! Compute REACH_Q subtracted from Qmod abstraction
+ ! Compute REACH_VOL subtracted from total abstraction minus abstraction from outlet discharge
+ if (Qtake<0) then
+   Qabs = max(-(rflux%ROUTE(idxMC)%REACH_VOL(1)/dt+rflux%ROUTE(idxMC)%REACH_Q-Qmin), Qtake)
+   Qabs = min(Qabs, 0._dp)  ! this should be <=0
+   Qmod = min(rflux%ROUTE(idxMC)%REACH_VOL(1) + Qabs*dt, 0._dp) ! this should be <= 0
+
+   rflux%ROUTE(idxMC)%REACH_Q      = rflux%ROUTE(idxMC)%REACH_Q + Qmod/dt
+   rflux%ROUTE(idxMC)%REACH_VOL(1) = rflux%ROUTE(idxMC)%REACH_VOL(1) + (Qabs*dt - Qmod)
+
+   ! modify computational molecule state (Q)
+   Q(1,1) = Q(1,1) - max(abs(Qmod/dt)-rflux%BASIN_QR(1), 0._dp)
+ end if
 
  if (doCheck) then
    write(iulog,'(A,X,G12.5)') ' Qout(t)=',Q(1,1)


### PR DESCRIPTION
- Implemented qtake (abstraction and injection) for each routing method.
- format changes for reach verbose.

`qmodOption ==2` in control file uses qtake information from netcdf (does not have to have identical reach and time) and take out the water or add water at each time step and reach (if the data is available)

qtake information has to be read and netcdf name and its information need to be provided in control file.