### PR TITLE
Enabling gauge observation direct insertion at the gauge points

### DIFF
--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -12,6 +12,7 @@ USE dataTypes,   ONLY: subbasin_omp      ! mainstem+tributary data strucuture
 USE public_var,  ONLY: iulog             ! i/o logical unit number
 USE public_var,  ONLY: realMissing       ! missing value for real number
 USE public_var,  ONLY: integerMissing    ! missing value for integer number
+USE public_var,  ONLY: qmodOption        ! qmod option (use 1==direct insertion)
 USE globalData,  ONLY: idxDW
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
@@ -179,6 +180,9 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+     if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%TAKE>0._dp) then
+       RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%TAKE
+     end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
    end do
  endif

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -11,8 +11,9 @@ USE dataTypes,          only : irfRCH         ! irf specific state data structur
 USE public_var,         only : realMissing    ! missing value for real number
 USE public_var,         only : integerMissing ! missing value for integer number
 USE public_var,         ONLY : dt             ! routing time step duration [sec]
+USE public_var,         ONLY : qmodOption     ! qmod option (use 1==direct insertion)
 USE globalData,         only : nThreads       ! number of threads used for openMP
-USE globalData,         only : idxIRF          ! index of IRF method
+USE globalData,         only : idxIRF         ! index of IRF method
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
 
@@ -197,6 +198,9 @@ contains
   if (nUps>0) then
     do iUps = 1,nUps
       iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+      if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%TAKE>0._dp) then
+        RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,iRch_ups)%TAKE
+      end if
       q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q
     end do
   endif

--- a/route/build/src/kw_route.f90
+++ b/route/build/src/kw_route.f90
@@ -12,6 +12,7 @@ USE dataTypes, ONLY: subbasin_omp      ! mainstem+tributary data strucuture
 USE public_var, ONLY: iulog             ! i/o logical unit number
 USE public_var, ONLY: realMissing       ! missing value for real number
 USE public_var, ONLY: integerMissing    ! missing value for integer number
+USE public_var, ONLY: qmodOption        ! qmod option (use 1==direct insertion)
 USE globalData, ONLY: idxKW
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
@@ -178,6 +179,9 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+     if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%TAKE>0._dp) then
+       RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%TAKE
+     end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q
    end do
  endif

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -14,6 +14,7 @@ USE dataTypes,   ONLY: subbasin_omp      ! mainstem+tributary data strucuture
 USE public_var,  ONLY: iulog             ! i/o logical unit number
 USE public_var,  ONLY: realMissing       ! missing value for real number
 USE public_var,  ONLY: integerMissing    ! missing value for integer number
+USE public_var,  ONLY: qmodOption        ! qmod option (use 1==direct insertion)
 USE globalData,  ONLY: idxMC             ! index of IRF method
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
@@ -180,6 +181,9 @@ contains
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+     if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%TAKE>0._dp) then
+       RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = RCHFLX_out(iens,iRch_ups)%TAKE
+     end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
    end do
  endif

--- a/route/build/src/model_finalize.f90
+++ b/route/build/src/model_finalize.f90
@@ -1,12 +1,14 @@
 MODULE model_finalize
 
-USE nrtype,     ONLY: i4b
+USE nrtype
 USE public_var, ONLY: iulog            ! i/o logical unit number
+USE public_var, ONLY: qmodOption       !
+USE globalData, ONLY: gage_obs_data
+USE globalData, ONLY: rch_qtake_data
 
 implicit none
 
 private
-
 public :: finalize
 public :: handle_err
 
@@ -17,6 +19,15 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE finalize()
   implicit none
+  integer(i4b)      :: ierr             ! error code
+  character(strLen) :: cmessage         ! error message
+
+  if (qmodOption==1) then
+    call gage_obs_data%closeNC(ierr, cmessage)
+  else if (qmodOption==2) then
+    call rch_qtake_data%closeNC(ierr, cmessage)
+  end if
+
   write(iulog,'(a)') new_line('a'), '--------------------'
   write(iulog,'(a)')                'Finished simulation'
   write(iulog,'(a)')                '--------------------'


### PR DESCRIPTION
With `qmodOption==1` (also need gauge data needs to be specified in the control file), observed flow replaces the simulated flow at each time step and reach corresponding to the gauge location (which is specified in gageMetaFile).

In summary,   add these in control file.
```
! ****************************************************************************************************************************
! gauge data 
! --------------------------
<qmodOption>            0                                    ! 0-> do nothing, 1->gauge observed flow insertion, 2-> water take or injection   
<fname_gageObs>      gauge_obs_nc              ! netcdf name of gauge observed data
<gageMetaFile>          gauge_meta_csv          ! name of gauge meta data (csv format): gauge_id, reach_id, lat, lon 
<outputAtGage>          T                                   ! output at only gauge points (not implemented yet)   
<vname_gageFlow>        streamflow               ! variable name of observed flow
<vname_gageSite>        site                             ! variable name of gage site
<vname_gageTime>        time                          ! variable name of time
<dname_gageSite>        site                            !  dimension name of gage site
<dname_gageTime>        time                          ! dimension name of time
<strlen_gageSite>        25                                ! maximum character length of gauge site name 
! ****************************************************************************************************************************
! water take data
! --------------------------
<fname_waterTake>      waterTake.nc             ! netcdf name of reach water take file name
<vname_waterTake>       waterTake                 !  variable name of water take (positive- injection, negative - abstraction)
<vname_wtReach>         reachID                      ! variable name of reach 
<vname_wtTime>          time                             ! variable name of time
<dname_wtReach>         seg                             ! dimension name of reach  
<dname_wtTime>          time                             ! dimension name of time
```

This pull-request completes discharge modification (qmod) features (direct insertion of gauge data and water take).