### PR TITLE
A few fixes

### DIFF
--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -405,7 +405,7 @@ CONTAINS
        b(nMolecule%DW_ROUTE) = (1._dp-(1._dp-wck)*Ca)*Qlocal(nMolecule%DW_ROUTE,0) + (1-wck)*Ca*Qlocal(nMolecule%DW_ROUTE-1,0)
      else if (downstreamBC == neumannBC) then
        Sbc = (Qlocal(nMolecule%DW_ROUTE,0)-Qlocal(nMolecule%DW_ROUTE-1,0))
-       b(nMolecule%DW_ROUTE)     = 0*Sbc
+       b(nMolecule%DW_ROUTE)     = Sbc
      end if
      ! internal node points
      b(2:nMolecule%DW_ROUTE-1) = ((1._dp-wck)*Ca+2._dp*(1._dp-wdk))*Cd*Qlocal(1:nMolecule%DW_ROUTE-2,0)  &
@@ -476,7 +476,7 @@ CONTAINS
    rflux%ROUTE(idxDW)%REACH_VOL(1) = rflux%ROUTE(idxDW)%REACH_VOL(1) + (Qabs*dt - Qmod)
 
    ! modify computational molecule state (Q)
-   rstate%molecule%Q(nMolecule%DW_ROUTE) = Qlocal(1, nMolecule%DW_ROUTE) - max(abs(Qmod/dt)-rflux%BASIN_QR(1), 0._dp)
+   rstate%molecule%Q(nMolecule%DW_ROUTE) = Qlocal(nMolecule%DW_ROUTE,1) - max(abs(Qmod/dt)-rflux%BASIN_QR(1), 0._dp)
  end if
 
  if (doCheck) then

--- a/route/build/src/get_basin_runoff.f90
+++ b/route/build/src/get_basin_runoff.f90
@@ -41,6 +41,7 @@ CONTAINS
   character(len=strLen)         :: cmessage           ! error message from subroutine
   integer(i4b)                  :: iens=1
   integer(i4b)                  :: ix, jx
+  real(dp)                      :: qobs               ! elapsed time for the process
   integer(i4b), allocatable     :: reach_ix(:)
   integer(i4b), parameter       :: no_mod=0
   integer(i4b), parameter       :: direct_insert=1
@@ -101,7 +102,11 @@ CONTAINS
         reach_ix = gage_obs_data%link_ix()
         do ix=1,size(reach_ix)
           if (reach_ix(ix)==integerMissing) cycle
-          RCHFLX(iens,reach_ix(ix))%TAKE = gage_obs_data%get_obs(tix=1, six=ix)
+
+          qobs = gage_obs_data%get_obs(tix=1, six=ix)
+
+          if (isnan(qobs) .or. qobs<0) cycle
+          RCHFLX(iens,reach_ix(ix))%TAKE = qobs
         end do
       end if
     case(qtake)

--- a/route/build/src/obs_data.f90
+++ b/route/build/src/obs_data.f90
@@ -36,7 +36,7 @@ MODULE obs_data
   public:: gageObs
   public:: waterTake
 
-  type, abstract :: obs
+  type, abstract :: obsData
     private
     integer(i4b)                   :: ncid = integerMissing ! netCDF ID
     character(strLen)              :: varName_obs
@@ -72,9 +72,9 @@ MODULE obs_data
       procedure, private :: fn_get_obs_svec
       procedure, private :: fn_get_obs_scalar
 
-  end type obs
+  end type obsData
 
-  type, extends(obs) :: gageObs
+  type, extends(obsData) :: gageObs
     character(25),   allocatable   :: site(:)  ! list of gauge site id
     CONTAINS
       procedure,  public :: read_site
@@ -86,7 +86,7 @@ MODULE obs_data
       procedure, private :: fn_get_gageID_scalar
   end type gageObs
 
-  type, extends(obs) :: waterTake
+  type, extends(obsData) :: waterTake
     integer(i4b),   allocatable   :: reach(:)  ! list of all the reach id
     CONTAINS
       procedure,  public :: read_reach
@@ -212,7 +212,7 @@ MODULE obs_data
     SUBROUTINE openNC(this, fname, ierr, message)
       implicit none
       ! Argument variables
-      class(obs),   intent(inout)  :: this
+      class(obsData),   intent(inout)  :: this
       character(*),     intent(in)     :: fname
       integer(i4b),     intent(out)    :: ierr             ! error code
       character(*),     intent(out)    :: message          ! error message
@@ -233,7 +233,7 @@ MODULE obs_data
     ! ---------------------------------
     logical(lgt) FUNCTION isFileOpen(this)
       implicit none
-      class(obs), intent(inout) :: this
+      class(obsData), intent(inout) :: this
 
       isFileOpen = this%fileOpen
     END FUNCTION
@@ -243,7 +243,7 @@ MODULE obs_data
     ! ---------------------------------
     SUBROUTINE closeNC(this, ierr, message)
       implicit none
-      class(obs), intent(inout) :: this
+      class(obsData), intent(inout) :: this
       integer(i4b),     intent(out)    :: ierr             ! error code
       character(*),     intent(out)    :: message          ! error message
       ! local variables
@@ -360,7 +360,7 @@ MODULE obs_data
 
       implicit none
       ! Argument variables
-      class(obs),             intent(inout) :: this
+      class(obsData),         intent(inout) :: this
       integer(i4b),           intent(out)   :: ierr            ! error code
       character(*),           intent(out)   :: message         ! error message
       integer(i4b), optional, intent(in)    :: index_time(:)
@@ -443,7 +443,7 @@ MODULE obs_data
 
       implicit none
       ! Argument variables
-      class(obs),              intent(inout) :: this
+      class(obsData),          intent(inout) :: this
       integer(i4b),            intent(out)   :: ierr             ! error code
       character(*),            intent(out)   :: message          ! error message
       integer(i4b), optional,  intent(in)    :: index_loc
@@ -504,7 +504,7 @@ MODULE obs_data
     ! -----------------------------------------------------
     FUNCTION fn_get_time_ix(this, datetime_in) result(ix)
       implicit none
-      class(obs), intent(in)     :: this
+      class(obsData), intent(in) :: this
       type(datetime), intent(in) :: datetime_in
       integer(i4b)               :: ix
       ix = get_time_ix(this%time, datetime_in)
@@ -531,7 +531,7 @@ MODULE obs_data
     ! -----------------------------------------------------
     pure FUNCTION fn_get_link_ix(this) result(ix)
       implicit none
-      class(obs), intent(in) :: this
+      class(obsData), intent(in) :: this
       integer(i4b), allocatable  :: ix(:)
       allocate(ix(size(this%link_index)))
       ix = this%link_index
@@ -598,7 +598,7 @@ MODULE obs_data
     ! -----------------------------------------------------
     FUNCTION fn_get_datetime(this) result(out_datetime)
       implicit none
-      class(obs),  intent(in)     :: this
+      class(obsData),  intent(in) :: this
       type(datetime), allocatable :: out_datetime(:)
       integer(i4b)                :: ix
       allocate(out_datetime(size(this%time)))
@@ -609,7 +609,7 @@ MODULE obs_data
 
     FUNCTION fn_get_datetime_vec(this, ix) result(out_datetime)
       implicit none
-      class(obs),   intent(in)    :: this
+      class(obsData), intent(in)  :: this
       integer(i4b), intent(in)    :: ix(:)
       type(datetime), allocatable :: out_datetime(:)
       integer(i4b)                :: jx
@@ -621,8 +621,8 @@ MODULE obs_data
 
     FUNCTION fn_get_datetime_scalar(this, ix) result(out_datetime)
       implicit none
-      class(obs),   intent(in) :: this
-      integer(i4b), intent(in) :: ix
+      class(obsData), intent(in) :: this
+      integer(i4b),   intent(in) :: ix
       type(datetime)           :: out_datetime
       out_datetime = this%time(ix)
     END FUNCTION fn_get_datetime_scalar
@@ -632,48 +632,48 @@ MODULE obs_data
     ! -----------------------------------------------------
     pure FUNCTION fn_get_obs(this) result(flow)
       implicit none
-      class(obs), intent(in) :: this
-      real(dp),allocatable   :: flow(:,:)
+      class(obsData), intent(in) :: this
+      real(dp), allocatable      :: flow(:,:)
       allocate(flow(size(this%obs,1), size(this%obs,2)))
       flow = this%obs
     END FUNCTION fn_get_obs
 
     pure FUNCTION fn_get_obs_vec(this, tix, six) result(flow)
       implicit none
-      class(obs),   intent(in) :: this
-      integer(i4b), intent(in) :: tix(:)
-      integer(i4b), intent(in) :: six(:)
-      real(dp),allocatable     :: flow(:,:)
+      class(obsData), intent(in) :: this
+      integer(i4b),   intent(in) :: tix(:)
+      integer(i4b),   intent(in) :: six(:)
+      real(dp), allocatable     :: flow(:,:)
       allocate(flow(size(tix),size(six)))
       flow = this%obs(tix, six)
     END FUNCTION fn_get_obs_vec
 
     pure FUNCTION fn_get_obs_tvec(this, tix, six) result(flow)
       implicit none
-      class(obs),   intent(in) :: this
-      integer(i4b), intent(in) :: tix(:)
-      integer(i4b), intent(in) :: six
-      real(dp),allocatable     :: flow(:)
+      class(obsData),intent(in) :: this
+      integer(i4b),  intent(in) :: tix(:)
+      integer(i4b),  intent(in) :: six
+      real(dp), allocatable     :: flow(:)
       allocate(flow(size(tix)))
       flow = this%obs(tix, six)
     END FUNCTION fn_get_obs_tvec
 
     pure FUNCTION fn_get_obs_svec(this, tix, six) result(flow)
       implicit none
-      class(obs),   intent(in) :: this
-      integer(i4b), intent(in) :: tix
-      integer(i4b), intent(in) :: six(:)
-      real(dp),allocatable     :: flow(:)
+      class(obsData), intent(in) :: this
+      integer(i4b),   intent(in) :: tix
+      integer(i4b),   intent(in) :: six(:)
+      real(dp), allocatable      :: flow(:)
       allocate(flow(size(six)))
       flow = this%obs(tix, six)
     END FUNCTION fn_get_obs_svec
 
     pure FUNCTION fn_get_obs_scalar(this, tix, six) result(flow)
       implicit none
-      class(obs),   intent(in) :: this
-      integer(i4b), intent(in) :: tix
-      integer(i4b), intent(in) :: six
-      real(dp)                 :: flow
+      class(obsData), intent(in) :: this
+      integer(i4b),  intent(in) :: tix
+      integer(i4b),  intent(in) :: six
+      real(dp)                  :: flow
       flow = this%obs(tix,six)
     END FUNCTION fn_get_obs_scalar
 


### PR DESCRIPTION
- dwf_route.f90:  boundary condition fixed, and Qlocal dimension order fixed.
- observed discharge check before putting in the reach flux data structures
- intel compile does not allow derived data type name and its element name to be the same