### PR TITLE
enabling water-take and water-injection for other routing methods

### DIFF
--- a/route/build/src/accum_runoff.f90
+++ b/route/build/src/accum_runoff.f90
@@ -1,16 +1,17 @@
 MODULE accum_runoff_module
 
+! Accumulate upstream flow instantaneously
+
 USE nrtype
 ! data type
-USE dataTypes, ONLY: STRFLX         ! fluxes in each reach
-USE dataTypes, ONLY: RCHTOPO        ! Network topology
-USE dataTypes, ONLY: subbasin_omp   ! mainstem+tributary data structures
-
-! global parameters
-USE public_var
-USE globalData,ONLY: idxSUM        ! index of IRF method
+USE dataTypes,   ONLY: STRFLX         ! fluxes in each reach
+USE dataTypes,   ONLY: RCHTOPO        ! Network topology
+USE dataTypes,   ONLY: subbasin_omp   ! mainstem+tributary data structures
+! global data
+USE public_var,  ONLY: iulog         ! i/o logical unit number
+USE globalData,  ONLY: idxSUM        ! index of accumulation method
 ! subroutines: general
-USE perf_mod,  ONLY: t_startf,t_stopf ! timing start/stop
+USE perf_mod,    ONLY: t_startf,t_stopf ! timing start/stop
 USE model_utils, ONLY: handle_err
 
 implicit none
@@ -161,16 +162,18 @@ CONTAINS
 
  ! check
  if(segIndex == ixDesire)then
-   write(fmt1,'(A,I5,A)') '(A,1X',nUps,'(1X,I10))'
-   write(fmt2,'(A,I5,A)') '(A,1X',nUps,'(1X,F20.7))'
-   write(*,'(2a)') new_line('a'),'** Check upstream discharge accumulation **'
-   write(*,'(a,x,I10,x,I10)') ' Reach index & ID =', segIndex, NETOPO_in(segIndex)%REACHID
-   write(*,'(a)')             ' * upstream reach index (NETOPO_in%UREACH) and discharge (uprflux) [m3/s] :'
-   write(*,fmt1)              ' UREACHK =', (NETOPO_in(segIndex)%UREACHK(iUps), iUps=1,nUps)
-   write(*,fmt2)              ' prflux  =', (RCHFLX_out(iens,NETOPO_in(segIndex)%UREACHI(iUps))%ROUTE(idxSUM)%REACH_Q, iUps=1,nUps)
-   write(*,'(a)')             ' * local area discharge (RCHFLX_out%BASIN_QR(1)) and final discharge (RCHFLX_out%ROUTE(idxSUM)%REACH_Q) [m3/s] :'
-   write(*,'(a,x,F15.7)')     ' RCHFLX_out%BASIN_QR(1) =', RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
-   write(*,'(a,x,F15.7)')     ' RCHFLX_out%ROUTE(idxSUM)%REACH_Q =', RCHFLX_out(iens,segIndex)%ROUTE(idxSUM)%REACH_Q
+   write(iulog,'(2a)') new_line('a'),'** Check upstream discharge accumulation **'
+   write(iulog,'(a,x,I10,x,I10)') ' Reach index & ID =', segIndex, NETOPO_in(segIndex)%REACHID
+   if (nUps>0) then
+     write(fmt1,'(A,I5,A)') '(A,1X',nUps,'(1X,I10))'
+     write(fmt2,'(A,I5,A)') '(A,1X',nUps,'(1X,F20.7))'
+     write(iulog,'(a)')             ' * upstream reach index (NETOPO_in%UREACH) and discharge (uprflux) [m3/s] :'
+     write(iulog,fmt1)              ' UREACHK =', (NETOPO_in(segIndex)%UREACHK(iUps), iUps=1,nUps)
+     write(iulog,fmt2)              ' prflux  =', (RCHFLX_out(iens,NETOPO_in(segIndex)%UREACHI(iUps))%ROUTE(idxSUM)%REACH_Q, iUps=1,nUps)
+   end if
+   write(iulog,'(a)')             ' * local area discharge (RCHFLX_out%BASIN_QR(1)) and final discharge (RCHFLX_out%ROUTE(idxSUM)%REACH_Q) [m3/s] :'
+   write(iulog,'(a,x,G15.4)')     ' RCHFLX_out%BASIN_QR(1) =', RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
+   write(iulog,'(a,x,G15.4)')     ' RCHFLX_out%ROUTE(idxSUM)%REACH_Q =', RCHFLX_out(iens,segIndex)%ROUTE(idxSUM)%REACH_Q
  endif
 
  END SUBROUTINE accum_qupstream

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -342,26 +342,27 @@ implicit none
 
 
  ! ---------- reach fluxes --------------------------------------------------------------------
- type, public :: fluxes
-   real(dp)        :: REACH_Q
-   real(dp)        :: REACH_VOL(0:1)
- end type fluxes
+ type, public :: hydraulic
+   real(dp)        :: REACH_ELE              ! water height at current time step [m]
+   real(dp)        :: REACH_Q                ! discharge at current time step [m3/s]
+   real(dp)        :: REACH_VOL(0:1)         ! water volume at previous and current time steps [m3]
+ end type hydraulic
 
  ! fluxes and states in each reach
  type, public :: strflx
-  real(dp), allocatable                :: QFUTURE(:)             ! runoff volume in future time steps (m3/s)
-  real(dp), allocatable                :: QFUTURE_IRF(:)         ! runoff volume in future time steps for IRF routing (m3/s)
-  real(dp), allocatable                :: QPASTUP_IRF(:,:)       ! runoff volume in the past time steps for lake upstream (m3/s)
-  real(dp), allocatable                :: DEMANDPAST_IRF(:,:)    ! demand volume for lake (m3/s)
-  real(dp)                             :: BASIN_QI               ! instantaneous runoff volume from the local basin (m3/s)
-  real(dp)                             :: BASIN_QR(0:1)          ! routed runoff volume from the local basin (m3/s)
-  type(fluxes), allocatable            :: ROUTE(:)               ! reach fluxes and states for each routing method
-  real(dp)                             :: REACH_ELE              ! elevation of the water at the current time step [m]
-  real(dp)                             :: REACH_WM_FLUX          ! water management fluxes to and from each reach
-  real(dp)                             :: REACH_WM_FLUX_actual   ! water management fluxes to and from each reach
-  real(dp)                             :: REACH_WM_VOL           ! target volume from the second water management file (m3)
-  real(dp)                             :: basinEvapo             ! remapped river network catchment Evaporation (size: number of nHRU)
-  real(dp)                             :: basinPrecip            ! remapped river network catchment Precipitation (size: number of nHRU)
+  real(dp), allocatable                :: QFUTURE(:)             ! runoff volume in future time steps [m3/s]
+  real(dp), allocatable                :: QFUTURE_IRF(:)         ! runoff volume in future time steps for IRF routing [m3/s]
+  real(dp), allocatable                :: QPASTUP_IRF(:,:)       ! runoff volume in the past time steps for lake upstream [m3/s]
+  real(dp), allocatable                :: DEMANDPAST_IRF(:,:)    ! demand volume for lake [m3/s]
+  real(dp)                             :: BASIN_QI               ! instantaneous runoff volume from the local basin [m3/s]
+  real(dp)                             :: BASIN_QR(0:1)          ! routed runoff volume from the local basin [m3/s]
+  type(hydraulic), allocatable         :: ROUTE(:)               ! reach fluxes and states for each routing method
+  real(dp)                             :: REACH_WM_FLUX          ! water management fluxes to and from each reach [m3/s]
+  real(dp)                             :: REACH_WM_FLUX_actual   ! water management fluxes to and from each reach [m3/s]
+  real(dp)                             :: REACH_WM_VOL           ! target volume from the second water management file [m3]
+  real(dp)                             :: Qobs                   ! observed discharge [m3/s]
+  real(dp)                             :: basinEvapo             ! remapped river network catchment Evaporation [unit] (size: number of nHRU)
+  real(dp)                             :: basinPrecip            ! remapped river network catchment Precipitation [unit] (size: number of nHRU)
  end type strflx
 
  ! ---------- lake data types -----------------------------------------------------------------

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -96,7 +96,7 @@ CONTAINS
   USE public_var, ONLY: input_dir
   USE public_var, ONLY: param_nml
   USE public_var, ONLY: gageMetaFile
-  USE public_var, ONLY: gageOutput
+  USE public_var, ONLY: outputAtGage
   ! subroutines: populate metadata
   USE popMetadat_module, ONLY: popMetadat       ! populate metadata
   ! subroutines: model control
@@ -125,7 +125,7 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   ! read gauge metadata if specified in control file
-  if (gageOutput .and. trim(gageMetaFile)/=charMissing) then
+  if (outputAtGage .and. trim(gageMetaFile)/=charMissing) then
     call read_gage_meta(trim(ancil_dir)//trim(gageMetaFile),ierr,cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   end if

--- a/route/build/src/io_rpointfile.f90
+++ b/route/build/src/io_rpointfile.f90
@@ -1,7 +1,7 @@
 MODULE io_rpointfile
 
 USE nrtype
-USE public_var,  ONLY: gageOutput           ! ascii containing last restart and history files
+USE public_var,  ONLY: outputAtGage             ! ascii containing last restart and history files
 USE public_var,  ONLY: restart_dir              ! restart directory
 USE public_var,  ONLY: rpntfil                  !
 USE globalData,  ONLY: masterproc
@@ -34,7 +34,7 @@ CONTAINS
           open(1, file = trim(restart_dir)//trim(rpntfil), status='replace', action='write')
           write(1,'(a)') trim(rfileout)
           write(1,'(a)') trim(hfileout)
-          if (gageOutput) then
+          if (outputAtGage) then
             write(1,'(a)') trim(hfileout_gage)
           end if
           close(1)
@@ -43,7 +43,7 @@ CONTAINS
         open(1, file = trim(restart_dir)//trim(rpntfil), status='old', action='read')
         read(1, '(A)') rfileout
         read(1, '(A)') hfileout
-        if (gageOutput) then
+        if (outputAtGage) then
           read(1, '(A)') hfileout_gage
         end if
         close(1)

--- a/route/build/src/kwe_route.f90
+++ b/route/build/src/kwe_route.f90
@@ -14,6 +14,7 @@ USE dataTypes, ONLY: subbasin_omp      ! mainstem+tributary data strucuture
 USE public_var, ONLY: iulog             ! i/o logical unit number
 USE public_var, ONLY: realMissing       ! missing value for real number
 USE public_var, ONLY: integerMissing    ! missing value for integer number
+USE public_var, ONLY: qmodOption        ! qmod option (use 1==direct insertion)
 USE globalData, ONLY: idxKW             ! loop index of kw routing
 ! subroutines: general
 USE perf_mod,  ONLY: t_startf,t_stopf   ! timing start/stop
@@ -176,30 +177,35 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+     if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%Qobs/=realMissing) then
+       RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%Qobs
+     end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q
    end do
  endif
 
  if(doCheck)then
-   write(iulog,'(A)') 'CHECK Kinematic wave routing'
+   write(iulog,'(2A)') new_line('a'), '** CHECK Kinematic wave routing **'
    if (nUps>0) then
      do iUps = 1,nUps
        iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-       write(iulog,'(A,X,I12,X,G15.4)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q
+       write(iulog,'(A,X,I12,X,G12.5)') ' UREACHK, uprflux=',NETOPO_in(segIndex)%UREACHK(iUps),RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q
      enddo
    end if
    write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iEns,segIndex)%BASIN_QR(1)=',RCHFLX_out(iEns,segIndex)%BASIN_QR(1)
  endif
 
  ! perform river network KW routing
- call kinematic_wave(RPARAM_in(segIndex),                & ! input: parameter at segIndex reach
-                     T0,T1,                              & ! input: start and end of the time step
-                     q_upstream,                         & ! input: total discharge at top of the reach being processed
-                     isHW,                               & ! input: is this headwater basin?
-                     RCHSTA_out(iens,segIndex)%KW_ROUTE, & ! inout:
-                     RCHFLX_out(iens,segIndex),          & ! inout: updated fluxes at reach
-                     doCheck,                            & ! input: reach index to be examined
-                     ierr, cmessage)                       ! output: error control
+ call kinematic_wave(RPARAM_in(segIndex),                     & ! input: parameter at segIndex reach
+                     T0,T1,                                   & ! input: start and end of the time step
+                     q_upstream,                              & ! input: total discharge at top of the reach being processed
+                     RCHFLX_out(iens,segIndex)%REACH_WM_FLUX, & ! input: abstraction(-)/injection(+) [m3/s]
+                     RPARAM_in(segIndex)%MINFLOW,             & ! input: minimum environmental flow [m3/s]
+                     isHW,                                    & ! input: is this headwater basin?
+                     RCHSTA_out(iens,segIndex)%KW_ROUTE,      & ! inout:
+                     RCHFLX_out(iens,segIndex),               & ! inout: updated fluxes at reach
+                     doCheck,                                 & ! input: reach index to be examined
+                     ierr, cmessage)                            ! output: error control
  if(ierr/=0)then
    write(message, '(A,X,I12,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage); return
  endif
@@ -217,6 +223,8 @@ CONTAINS
  SUBROUTINE kinematic_wave(rch_param,     & ! input: river parameter data structure
                            T0,T1,         & ! input: start and end of the time step
                            q_upstream,    & ! input: discharge from upstream
+                           Qtake,         & ! input: abstraction(-)/injection(+) [m3/s]
+                           Qmin,          & ! input: minimum environmental flow [m3/s]
                            isHW,          & ! input: is this headwater basin?
                            rstate,        & ! inout: reach state at a reach
                            rflux,         & ! inout: reach flux at a reach
@@ -241,6 +249,8 @@ CONTAINS
  type(RCHPRP), intent(in)                 :: rch_param    ! River reach parameter
  real(dp),     intent(in)                 :: T0,T1        ! start and end of the time step (seconds)
  real(dp),     intent(in)                 :: q_upstream   ! total discharge at top of the reach being processed
+ real(dp),     intent(in)                 :: Qtake        ! abstraction(-)/injection(+) [m3/s]
+ real(dp),     intent(in)                 :: Qmin         ! minimum environmental flow [m3/s]
  logical(lgt), intent(in)                 :: isHW         ! is this headwater basin?
  type(kwRCH),  intent(inout)              :: rstate       ! curent reach states
  type(STRFLX), intent(inout)              :: rflux        ! current Reach fluxes
@@ -263,6 +273,9 @@ CONTAINS
  real(dp)                                 :: Qbar         !
  real(dp)                                 :: absErr(2)    ! absolute error of nonliear equation solution
  real(dp)                                 :: f0eval(2)    !
+ real(dp)                                 :: QupMod       ! modified total discharge at top of the reach being processed
+ real(dp)                                 :: Qabs         ! maximum allowable water abstraction rate [m3/s]
+ real(dp)                                 :: Qmod         ! abstraction rate to be taken from outlet discharge [m3/s]
  integer(i4b)                             :: imin         ! index at minimum value
 
  ierr=0; message='kinematic_wave/'
@@ -271,7 +284,13 @@ CONTAINS
  !  current time and outlet 4 (1,1) -> previous time and outlet 2 (0,1)
  Q(0,0) = rstate%molecule%Q(1)
  Q(0,1) = rstate%molecule%Q(2)
- dT = T1-T0
+ dt = T1-T0
+
+ ! Q injection, add at top of reach
+ QupMod = q_upstream
+ if (Qtake>0) then
+   QupMod = QupMod+ Qtake
+ end if
 
  if (.not. isHW) then
 
@@ -285,13 +304,17 @@ CONTAINS
    beta1  = 1._dp/beta
    alpha1 = (1.0/alpha)**beta1
    dX = rch_param%RLENGTH
-   theta = dT/dX
+   theta = dt/dX
 
    ! compute total flow rate and flow area at upstream end at current time step
-   Q(1,0) = q_upstream
+   Q(1,0) = QupMod
 
    if (doCheck) then
-     write(iulog,'(3(A,X,G12.5))') ' R_SLOPE=',rch_param%R_SLOPE,' R_WIDTH=',rch_param%R_WIDTH,' R_MANN=',rch_param%R_MAN_N
+     write(iulog,'(A,X,G12.5)') ' length [m]        =',rch_param%RLENGTH
+     write(iulog,'(A,X,G12.5)') ' slope [-]         =',rch_param%R_SLOPE
+     write(iulog,'(A,X,G12.5)') ' channel width [m] =',rch_param%R_WIDTH
+     write(iulog,'(A,X,G12.5)') ' manning coef. [-] =',rch_param%R_MAN_N
+     write(iulog,'(A)')         ' Initial 3 point discharge [m3/s]: '
      write(iulog,'(3(A,X,G12.5))') ' Q(0,0)=',Q(0,0),' Q(0,1)=',Q(0,1),' Q(1,0)=',Q(1,0)
    end if
 
@@ -350,11 +373,28 @@ CONTAINS
 
  ! compute volume
  rflux%ROUTE(idxKW)%REACH_VOL(0) = rflux%ROUTE(idxKW)%REACH_VOL(1)
- rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dT
+ rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dt
  rflux%ROUTE(idxKW)%REACH_VOL(1) = max(rflux%ROUTE(idxKW)%REACH_VOL(1), 0._dp)
 
  ! add catchment flow
  rflux%ROUTE(idxKW)%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)
+
+ ! Q abstraction
+ ! Compute actual abstraction (Qabs) m3/s - values should be negative
+ ! Compute abstraction (Qmod) m3 taken from outlet discharge (REACH_Q)
+ ! Compute REACH_Q subtracted from Qmod abstraction
+ ! Compute REACH_VOL subtracted from total abstraction minus abstraction from outlet discharge
+ if (Qtake<0) then
+   Qabs = max(-(rflux%ROUTE(idxKW)%REACH_VOL(1)/dt+rflux%ROUTE(idxKW)%REACH_Q-Qmin), Qtake)
+   Qabs = min(Qabs, 0._dp)  ! this should be <=0
+   Qmod = min(rflux%ROUTE(idxKW)%REACH_VOL(1) + Qabs*dt, 0._dp) ! this should be <= 0
+
+   rflux%ROUTE(idxKW)%REACH_Q      = rflux%ROUTE(idxKW)%REACH_Q + Qmod/dt
+   rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(1) + (Qabs*dt - Qmod)
+
+   ! modify computational molecule state (Q)
+   Q(1,1) = Q(1,1) - max(abs(Qmod/dt)-rflux%BASIN_QR(1), 0._dp)
+ end if
 
  ! update state
  rstate%molecule%Q(1) = Q(1,0)

--- a/route/build/src/kwt_route.f90
+++ b/route/build/src/kwt_route.f90
@@ -249,8 +249,6 @@ CONTAINS
      write(iulog,'(a,x,F15.7)')          ' RPARAM_in%R_WIDTH =', RPARAM_in(JRCH)%R_WIDTH
    end if
 
-   ! RCHFLX_out(IENS,JRCH)%TAKE=0.0_dp ! initialize take from this reach
-
     ! ----------------------------------------------------------------------------------------
     ! (1) EXTRACT FLOW FROM UPSTREAM REACHES & APPEND TO THE NON-ROUTED FLOW PARTICLES IN JRCH
     ! ----------------------------------------------------------------------------------------
@@ -269,7 +267,7 @@ CONTAINS
       endif
 
       if(JRCH==ixDesire)then
-        write(fmt1,'(A,I5,A)') '(A, 1X',size(Q_JRCH),'(1X,F20.7))'
+        write(fmt1,'(A,I5,A)') '(A, 1X',size(Q_JRCH),'(1X,G15.4))'
         write(iulog,'(a)') ' * Wave discharge from upstream reaches (Q_JRCH) [m2/s]:'
         write(iulog,fmt1)  ' Q_JRCH=',(Q_JRCH(IWV), IWV=0,size(Q_JRCH)-1)
       endif
@@ -290,7 +288,7 @@ CONTAINS
 
       if(JRCH==ixDesire) then
         write(iulog,'(a)') ' * Final discharge (RCHFLX_out(IENS,JRCH)%REACH_Q) [m3/s]:'
-        write(iulog,'(x,F20.7)') RCHFLX_out(IENS,JRCH)%ROUTE(idxKWT)%REACH_Q
+        write(iulog,'(x,G15.4)') RCHFLX_out(IENS,JRCH)%ROUTE(idxKWT)%REACH_Q
       end if
       return  ! no upstream reaches (routing for sub-basins done using time-delay histogram)
     endif
@@ -343,7 +341,7 @@ CONTAINS
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     if(JRCH == ixDesire)then
-      write(fmt1,'(A,I5,A)') '(A,1X',NQ1+1,'(1X,F20.7))'
+      write(fmt1,'(A,I5,A)') '(A,1X',NQ1+1,'(1X,G15.4))'
       write(fmt2,'(A,I5,A)') '(A,1X',NQ1+1,'(1X,L))'
       write(iulog,'(a)') ' * After routed: wave discharge (Q_JRCH) [m2/s], isExit(FROUTE), entry time (TENTRY) [s], and exit time (T_EXIT) [s]:'
       write(iulog,fmt1)  ' Q_JRCH=',(Q_JRCH(IWV), IWV=0,NQ1)
@@ -368,9 +366,9 @@ CONTAINS
 
     if(JRCH == ixDesire)then
       write(iulog,'(a)')          ' * Time-ave. wave discharge that exit (QNEW(1)) [m2/s], local-area discharge (RCHFLX_out%BASIN_QR(1)) [m3/s] and Final discharge (RCHFLX_out%REACH_Q) [m3/s]:'
-      write(iulog,"(A,1x,F15.7)") ' QNEW(1)                =', QNEW(1)
-      write(iulog,"(A,1x,F15.7)") ' RCHFLX_out%BASIN_QR(1) =', RCHFLX_out(IENS,JRCH)%BASIN_QR(1)
-      write(iulog,"(A,1x,F15.7)") ' RCHFLX_out%REACH_Q     =', RCHFLX_out(IENS,JRCH)%ROUTE(idxKWT)%REACH_Q
+      write(iulog,"(A,1x,G15.4)") ' QNEW(1)                =', QNEW(1)
+      write(iulog,"(A,1x,G15.4)") ' RCHFLX_out%BASIN_QR(1) =', RCHFLX_out(IENS,JRCH)%BASIN_QR(1)
+      write(iulog,"(A,1x,G15.4)") ' RCHFLX_out%REACH_Q     =', RCHFLX_out(IENS,JRCH)%ROUTE(idxKWT)%REACH_Q
     endif
 
     ! ----------------------------------------------------------------------------------------
@@ -394,7 +392,7 @@ CONTAINS
     endif
     ! insert the interpolated point (TI is irrelevant, as the point is "routed")
     RCHSTA_out(IENS,JRCH)%LKW_ROUTE%KWAVE(NR+1)%QF=Q_END;   RCHSTA_out(IENS,JRCH)%LKW_ROUTE%KWAVE(NR+1)%TI=TIMEI
-    RCHSTA_out(IENS,JRCH)%LKW_ROUTE%KWAVE(NR+1)%TR=T_END;   RCHSTA_out(IENS,JRCH)%LKW_ROUTE%KWAVE(NR+1)%RF=.TRUE.
+    RCHSTA_out(IENS,JRCH)%LKW_ROUTE%KWAVE(NR+1)%TR=T_END;   RCHSTA_out(IENS,JRCH)%LKW_ROUTE%KWAVE(NR+1)%RF=.true.
     ! add the output from kinwave...         - skip NR+1
     ! (when JRCH becomes IR routed points will be stripped out & the structures updated again)
     RCHSTA_out(IENS,JRCH)%LKW_ROUTE%KWAVE(0:NR)%QF=Q_JRCH(0:NR); RCHSTA_out(IENS,JRCH)%LKW_ROUTE%KWAVE(NR+2:NQ2+1)%QF=Q_JRCH(NR+1:NQ2)
@@ -523,9 +521,9 @@ CONTAINS
     call interp_rch(TENTRY(0:NR-1),Q_jrch_abs(0:NR-1), TP, Qavg, ierr,cmessage)
     Qabs = Qavg(1)*RPARAM_in(JRCH)%R_WIDTH
     write(*,'(a)')         ' * Target abstraction (Qtake) [m3/s], Available discharge (totQ) [m3/s], Actual abstraction (Qabs) [m3/s] '
-    write(*,'(a,x,F15.7)') ' Qtake =', Qtake
-    write(*,'(a,x,F15.7)') ' totQ  =', totQ
-    write(*,'(a,x,F15.7)') ' Qabs  =', Qabs
+    write(*,'(a,x,G15.4)') ' Qtake =', Qtake
+    write(*,'(a,x,G15.4)') ' totQ  =', totQ
+    write(*,'(a,x,G15.4)') ' Qabs  =', Qabs
   end if
 
   ! modify wave speed at modified wave discharge and re-compute exit time
@@ -539,7 +537,7 @@ CONTAINS
   T_EXIT(1:NR-1) = t_exit_mod(1:NR-1)
 
   if(JRCH == ixDesire)then
-    write(fmt1,'(A,I5,A)') '(A,1X',NR,'(1X,E15.7))'
+    write(fmt1,'(A,I5,A)') '(A,1X',NR,'(1X,G15.4))'
     write(*,'(a)') ' * After abstracted: wave discharge (Q_JRCH) [m2/s], entry time (TENTRY) [s], and exit time (T_EXIT) [s]:'
     write(*,fmt1)  ' Q_JRCH=',(Q_JRCH(iw), iw=0,NR-1)
     write(*,fmt1)  ' TENTRY=',(TENTRY(iw), iw=0,NR-1)
@@ -668,7 +666,7 @@ CONTAINS
                   RSTEP)                             ! optional input
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   if (JRCH == ixDesire) then
-    write(fmt1,'(A,I5,A)') '(A,1X',ND,'(1X,F15.7))'
+    write(fmt1,'(A,I5,A)') '(A,1X',ND,'(1X,G15.4))'
     write(*,'(a)')      ' * After qexmul_rch: # of routed wave from upstreams (ND) and wave discharge (QD) [m2/s]:'
     write(*,'(A,x,I5)') ' ND=', ND
     write(*,fmt1)       ' QD=', (QD(iw), iw=1,ND)
@@ -1386,7 +1384,7 @@ CONTAINS
  WC(1:NN) = ALFA*K**(1./ALFA)*Q1(1:NN)**((ALFA-1.)/ALFA)
 
  if(jRch==ixDesire) then
-   write(fmt1,'(A,I5,A)') '(A,1X',NN,'(1X,F15.7))'
+   write(fmt1,'(A,I5,A)') '(A,1X',NN,'(1X,G15.4))'
    write(iulog,'(a)')      ' * Wave discharge (q1) [m2/s] and wave celertiy (wc) [m/s]:'
    write(iulog,'(a,x,I3)') ' Number of wave =', NN
    write(iulog,fmt1)       ' q1=', (q1(iw), iw=1,NN)
@@ -1446,7 +1444,7 @@ CONTAINS
 
  ! check
  if(jRch==ixDesire) then
-   write(fmt1,'(A,I5,A)') '(A,1X',NN,'(1X,F15.7))'
+   write(fmt1,'(A,I5,A)') '(A,1X',NN,'(1X,G15.4))'
    write(iulog,'(a)')      ' * After wave merge: wave celertiy (wc) [m/s]:'
    write(iulog,'(a,x,I3)') ' Number of wave =', NN
    write(iulog,fmt1)       ' wc=', (wc(iw), iw=1,NN)

--- a/route/build/src/main_route.f90
+++ b/route/build/src/main_route.f90
@@ -103,16 +103,20 @@ CONTAINS
   allocate(reachRunoff_local(nSeg), stat=ierr)
   if(ierr/=0)then; message=trim(message)//'problem allocating arrays for [reachRunoff_local]'; return; endif
 
-  ! passing of the water management fluxes and lake target vol if presence
+  ! Initialize water-management flux (water take, lake volume threshold for release)
   if (is_flux_wm) then
     do iSeg = 1,nSeg
-      RCHFLX_out(iens,ixRchProcessed(iSeg))%REACH_WM_FLUX  =  reachflux_in(iSeg)  ! added or subtracted stremflow for each reach
+      RCHFLX_out(iens,ixRchProcessed(iSeg))%REACH_WM_FLUX = reachflux_in(iSeg)  ! added or subtracted stremflow for each reach
     end do
+  else
+    RCHFLX_out(iens,:)%REACH_WM_FLUX = 0._dp
   end if
-  if (is_vol_wm.and.is_lake_sim) then
+  if (is_vol_wm .and. is_lake_sim) then
     do iSeg = 1,nSeg
-      RCHFLX_out(iens,ixRchProcessed(iSeg))%REACH_WM_VOL   =  reachvol_in(iSeg)   ! target volume for the lakes
+      RCHFLX_out(iens,ixRchProcessed(iSeg))%REACH_WM_VOL = reachvol_in(iSeg)   ! target volume for the lakes
     end do
+  else
+    RCHFLX_out(iens,:)%REACH_WM_VOL = 0._dp
   end if
 
   ! 1. subroutine: map basin runoff to river network HRUs

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -1028,44 +1028,31 @@ CONTAINS
   end if
 
   ! --------------------------------
-  ! distribute (scatter) global runoff, evaporation
-  ! and precipitation array to local runoff arrays
+  ! distribute (i.e., scatter) forcing data from a global array to local ones in each task
+  ! water-balance: 1. runoff, 2. evaporation, 3. precipitation
+  ! water-management: 4. water injection/abstraction, 5. volume threshold for lake release
   !  - basinRunoff_main (only at master proc)
   !  - basinRunoff_trib (all procs)
   !  - basinEvapo_main  (only at master proc)
   !  - basinEvapo_trib  (all procs)
   !  - basinPrecip_main (only at master proc)
   !  - basinPrecip_trib (all procs)
+  !  - flux_wm_main (only at master proc)
+  !  - flux_wm_trib (all procs)
+  !  - vol_wm_main  (only at master proc)
+  !  - vol_wm_trib  (all procs)
   ! --------------------------------
   if (doesScatterData) then
     call t_startf ('route/scatter-runoff')
     call scatter_runoff(nNodes, comm, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     call t_stopf ('route/scatter-runoff')
-  else
-    if (masterproc) then
-      write(iulog,*) 'NOTE: HRU Runoff is already decomposed into mainstems and tributaries. No need for scatter_runoff'
-    end if
-  end if
 
-  ! --------------------------------
-  ! distribute (scatter) water managemnt flux and
-  ! volume in the
-  !  - flux_wm_main (only at master proc)
-  !  - flux_wm_trib (all procs)
-  !  - vol_wm_main  (only at master proc)
-  !  - vol_wm_trib  (all procs)
-  ! --------------------------------
-  if (is_flux_wm.or.(is_vol_wm.and.is_lake_sim)) then
-    if (doesScatterData) then
+    if (is_flux_wm .or. (is_vol_wm .and. is_lake_sim)) then
       call t_startf ('route/scatter-wm')
       call scatter_wm(nNodes, comm, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       call t_stopf ('route/scatter-wm')
-    else
-      if (masterproc) then
-        write(iulog,*) 'NOTE: reach flux and target volume are already decomposed into mainstems and tributaries. No need for scatter_wm'
-      end if
     end if
   end if
 

--- a/route/build/src/ncio_utils.f90
+++ b/route/build/src/ncio_utils.f90
@@ -360,7 +360,6 @@ CONTAINS
   character(len=strLen)           :: cmessage     ! error message of downwind routine
   integer(i4b)                    :: array_vec(1) ! output variable data
 
- ! initialize error control
  ierr=0; message='get_iscalar/'
 
  call get_ivec(fname, vname, array_vec, iStart, 1, ierr, cmessage)
@@ -1077,7 +1076,7 @@ CONTAINS
 
    implicit none
    ! input
-   integer(i4b), intent(in)             :: ncid                   ! Input: netcdf fine ID
+   integer(i4b), intent(in)             :: ncid                   ! Input: netcdf ID
    character(*), intent(in)             :: vname                  ! Input: variable name
    character(*), intent(in)             :: dimNames(:)            ! Input: variable dimension names
    integer(i4b), intent(in)             :: ivtype                 ! Input: variable type
@@ -1207,7 +1206,7 @@ CONTAINS
 
    implicit none
    ! input
-   integer(i4b), intent(in)             :: ncid                   ! Input: netcdf fine ID
+   integer(i4b), intent(in)     :: ncid      ! Input: netcdf fine ID
    ! output
    integer(i4b), intent(out)    :: ierr      ! error code
    character(*), intent(out)    :: message   ! error message

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -1,8 +1,10 @@
 MODULE public_var
+
   ! This module include variables that can be accessed from any other modules and values not altered
   ! except that variables read from control file are populated.
 
   USE nrtype
+
   implicit none
 
   save
@@ -13,7 +15,7 @@ MODULE public_var
   ! ---------- common constants ---------------------------------------------------------------------
 
   ! physical constants
-  real(dp),    parameter,public    :: pi=3.14159265359_dp   ! pi
+  real(dp),    parameter,public   :: pi=3.14159265359_dp    ! pi
 
   ! some common constant variables (not likely to change value)
   real(dp),    parameter,public   :: secprmin=60._dp        ! number of seconds in a minute
@@ -91,7 +93,7 @@ MODULE public_var
   logical(lgt),public             :: continue_run         = .false.         ! T-> append output in existing history files. F-> write output in new history file
   character(len=strLen),public    :: simStart             = ''              ! date string defining the start of the simulation
   character(len=strLen),public    :: simEnd               = ''              ! date string defining the end of the simulation
-  character(len=strLen),public    :: newFileFrequency     = 'annual'        ! frequency for new output files (day, month, annual, single)
+  character(len=strLen),public    :: newFileFrequency     = 'yearly'        ! frequency for new output files (daily, monthly, yearly, single)
   character(len=10)    ,public    :: routOpt              = '0'             ! routing scheme options  0: accum runoff, 1:IRF, 2:KWT, 3:KW, 4:MC, 5:DW
   integer(i4b)         ,public    :: doesBasinRoute       = 1               ! basin routing options   0-> no, 1->IRF, otherwise error
   logical(lgt),public             :: is_lake_sim          = .false.         ! logical if lakes are activated in simulation
@@ -109,7 +111,6 @@ MODULE public_var
   character(len=strLen),public    :: fname_ntopNew        = ''              ! new filename containing stream network topology information
   character(len=strLen),public    :: dname_sseg           = ''              ! dimension name of segment in river network data
   character(len=strLen),public    :: dname_nhru           = ''              ! dimension name of hru in river network data
-  integer(i4b)         ,public    :: idSegOut             = integerMissing  ! id of outlet stream segment
   ! RUNOFF, EVAPORATION AND PRECIPITATION FILE
   character(len=strLen),public    :: fname_qsim           = ''              ! simulated runoff netCDF name
   character(len=strLen),public    :: vname_qsim           = ''              ! variable name for simulated runoff
@@ -152,10 +153,18 @@ MODULE public_var
   character(len=strLen),public    :: fname_state_in       = charMissing     ! name of state file
   ! SPATIAL CONSTANT PARAMETERS
   character(len=strLen),public    :: param_nml            = ''              ! name of the namelist file
-  ! GAUGE METADATA
+  ! GAUGE DATA
   character(len=strLen),public    :: gageMetaFile         = charMissing     ! name of the gauge metadata csv
-  logical(lgt),public             :: gageOutput           = .false.         ! logical; T-> history file output at only gauge points
-  ! COMPUTATION OPTION
+  logical(lgt),public             :: outputAtGage         = .false.         ! logical; T-> history file output at only gauge points
+  character(len=strLen),public    :: fname_gageObs        = ''              ! gauge data netcdf name
+  character(len=strLen),public    :: vname_gageFlow       = ''              ! variable name for gauge flow data
+  character(len=strLen),public    :: vname_gageSite       = ''              ! variable name for site name data
+  character(len=strLen),public    :: vname_gageTime       = ''              ! variable name for time data
+  character(len=strLen),public    :: dname_gageSite       = ''              ! dimension name for gauge site
+  character(len=strLen),public    :: dname_gageTime       = ''              ! dimension name for time
+  integer(i4b)         ,public    :: strlen_gageSite      = 30              ! maximum character length for site name
+  ! USER OPTIONS
+  integer(i4b)         ,public    :: qmodOption           = 0               ! option for streamflow modification
   integer(i4b)         ,public    :: hydGeometryOption    = compute         ! option for hydraulic geometry calculations (0=read from file, 1=compute)
   integer(i4b)         ,public    :: topoNetworkOption    = compute         ! option for network topology calculations (0=read from file, 1=compute)
   integer(i4b)         ,public    :: computeReachList     = compute         ! option to compute list of upstream reaches (0=do not compute, 1=compute)
@@ -164,6 +173,7 @@ MODULE public_var
   character(len=strLen),public    :: calendar             = charMissing     ! calendar name
   ! MISCELLANEOUS
   logical(lgt)         ,public    :: debug                = .false.         ! print out detaled information
+  integer(i4b)         ,public    :: idSegOut             = integerMissing  ! id of outlet stream segment
   integer(i4b)         ,public    :: desireId             = integerMissing  ! turn off checks or speficy reach ID if necessary to print on screen
   ! PFAFCODE
   integer(i4b)         ,public    :: maxPfafLen           = 32              ! maximum digit of pfafstetter code (default 32).

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -145,7 +145,7 @@ CONTAINS
    select case(lower(trim(restart_write)))
      case('specified','last')
        restartAlarm = (dropDatetime==simDatetime(1))
-     case('annual')
+     case('yearly')
        restartAlarm = (dropDatetime%is_equal_mon(simDatetime(1)) .and. dropDatetime%is_equal_day(simDatetime(1)) .and. dropDatetime%is_equal_time(simDatetime(1)))
      case('monthly')
        restartAlarm = (dropDatetime%is_equal_day(simDatetime(1)) .and. dropDatetime%is_equal_time(simDatetime(1)))
@@ -154,7 +154,7 @@ CONTAINS
      case('never')
        restartAlarm = .false.
      case default
-       ierr=20; message=trim(message)//'Current accepted <restart_write> options: last, never, specified, annual, monthly, or daily '; return
+       ierr=20; message=trim(message)//'Accepted <restart_write> options (case insensitive): last, never, specified, yearly, monthly, or daily '; return
    end select
 
  END SUBROUTINE restart_alarm

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -6,6 +6,7 @@ USE var_lookup,     ONLY: ixRFLX, nVarsRFLX
 USE dataTypes,      ONLY: STRFLX
 USE datetime_data,  ONLY: datetime
 USE public_var,     ONLY: iulog
+USE public_var,     ONLY: integerMissing
 USE globalData,     ONLY: runMode           ! 'standalone' or 'cesm-coupling'
 USE globalData,     ONLY: pid, nNodes
 USE globalData,     ONLY: masterproc
@@ -123,8 +124,6 @@ CONTAINS
  ! *********************************************************************
  logical(lgt) FUNCTION newFileAlarm(inDatetime, alarmFrequency, ierr, message)
 
-   USE public_var,        ONLY: integerMissing
-
    implicit none
    ! Argument variables
    type(datetime), intent(in)    :: inDatetime(0:1)    ! datetime at previous and current timestep
@@ -139,7 +138,7 @@ CONTAINS
    endif
 
    ! check need for the new file
-   select case(lower(trim(newFileFrequency)))
+   select case(lower(trim(alarmFrequency)))
      case('single'); newFileAlarm=(inDatetime(0)%year() ==integerMissing)
      case('yearly'); newFileAlarm=(inDatetime(1)%year() /=inDatetime(0)%year())
      case('monthly');newFileAlarm=(inDatetime(1)%month()/=inDatetime(0)%month())

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -181,7 +181,7 @@ CONTAINS
      if (nRch_mainstem>0) then
        index_write_all(1:nRch_mainstem) = arth(1,1,nRch_mainstem)
      end if
-     index_write_all(nRch_mainstem+1:nRch_local) = arth(nRch_mainstem+nTribOutlet+1, 1, nRch_root)
+     index_write_all(nRch_mainstem+1:nRch_local) = arth(nRch_mainstem+nTribOutlet+1, 1, rch_per_proc(0))
    else
      nRch_local = rch_per_proc(pid)
      allocate(index_write_all(nRch_local))


### PR DESCRIPTION
Added water take and injection mechanism from reaches for KW, MC, and DW.

Other miscellaneous fixes:

use `yearly`, `monthly`, `daily` for both history and restart write frequency

rename `gageOutput` to `outputAtGage`

No simulation results change after this pull-request.