### PR TITLE
groundwork on direct_to_outlet option for negative flow handling

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -284,6 +284,14 @@ implicit none
   integer(i4b)                               :: LAKEMODELTYPE! 1=Doll, 2=Hanasaki, 3=HYPE else=non-parameteric
  end type RCHTOPO
 
+ ! arbitrary element-to-element connection
+ type, public :: commLink
+   integer(i4b) :: srcTask   ! source task
+   integer(i4b) :: destTask  ! destination task
+   integer(i4b) :: srcIndex  ! source array index
+   integer(i4b) :: destIndex ! destination array index
+ end type commLink
+
  ! ---------- reach states --------------------------------------------------------------------
 
  !---------- Lagrangian kinematic wave states (collection of particles) ---------------------------------

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -28,6 +28,8 @@ MODULE globalData
   USE dataTypes, ONLY: runoff        ! data structure - runoff data type
   USE dataTypes, ONLY: wm            ! data structure - water management (flux to/from segment, target volume) data type
 
+  USE dataTypes, ONLY: commLink      ! data structure - arbitrary element-to-element link
+
   USE dataTypes, ONLY: subbasin_omp  ! data structure - omp domain decomposition
   USE dataTypes, ONLY: subbasin_mpi  ! data structure - mpi domain decomposition
 
@@ -209,22 +211,26 @@ MODULE globalData
   real(dp),           allocatable, public :: vol_wm_main(:)         ! SEG target volume (for lakes) (m3) for mainstem
 
   ! domain data
-  ! MPI
+  ! -- MPI
   type(subbasin_mpi), allocatable, public :: domains_mpi(:)         ! mpi domain decomposition data structure
   integer(i4b),                    public :: nDomain_mpi            ! number of mpi domains
-  ! OMP
+
+  ! -- OMP
   type(subbasin_omp), allocatable, public :: river_basin_main(:)    ! openMP domain decomposition for mainstem
   type(subbasin_omp), allocatable, public :: river_basin_trib(:)    ! openMP domain decomposition for tributary
 
+  ! -- reach and hru ordered index
   integer(i4b),       allocatable, public :: ixHRU_order(:)         ! global HRU index in the order of proc assignment (size = num of hrus contributing reach in entire network)
   integer(i4b),       allocatable, public :: ixRch_order(:)         ! global reach index in the order of proc assignment (size = num of reaches in entire network))
   integer(i4b),       allocatable, public :: hru_per_proc(:)        ! number of hrus assigned to each proc (size = num of procs
   integer(i4b),       allocatable, public :: rch_per_proc(:)        ! number of reaches assigned to each proc (size = num of procs)
-
   integer(i4b),       allocatable, public :: nTribOutlet            ! number of tributary reaches flowing into mainstem
   integer(i4b),       allocatable, public :: global_ix_main(:)      ! index array in mainstem array for tributary reach outlet (size = num of tributary outlets)
   integer(i4b),       allocatable, public :: global_ix_comm(:)      ! global index array for tributary reach outlet (size = num of tributary outlets)
   integer(i4b),       allocatable, public :: local_ix_comm(:)       ! local index array for tributary reach outlet (size = num of tributary outlets per proc)
   integer(i4b),       allocatable, public :: tribOutlet_per_proc(:) ! number of tributary outlet reaches assigned to each proc (size = num of procs)
+
+  ! -- reach to reach connection
+  type(commLink),     allocatable, public :: commRch(:)             ! reach-reach connections for reach flux transfer
 
 END MODULE globalData

--- a/route/build/src/network_topo.f90
+++ b/route/build/src/network_topo.f90
@@ -1,8 +1,7 @@
 MODULE network_topo
 
+USE nrtype
 ! data types
-USE nrtype,    ONLY: i4b,dp,lgt
-USE nrtype,    ONLY: strLen         ! length of a string
 USE dataTypes, ONLY: var_ilength    ! integer type:          var(:)%dat
 USE dataTypes, ONLY: var_dlength    ! double precision type: var(:)%dat
 
@@ -42,6 +41,8 @@ public :: reachOrder     ! define the processing order
 public :: streamOrdering ! get stream order for each reach
 public :: reach_list     ! get a list of reaches above each reach
 public :: reach_mask     ! get a mask that defines all segments above a given segment
+public :: destSegment    ! get destination reach ID and index for each reach
+public :: outletSegment  ! get the most downstream reach ID and index for each reach
 public :: reach_mask_orig     ! get a mask that defines all segments above a given segment
 
 CONTAINS
@@ -332,6 +333,52 @@ CONTAINS
  end subroutine up2downSegment
 
  ! *********************************************************************
+ ! public subroutine: find ID and index of target reach for each reach
+ ! *********************************************************************
+ SUBROUTINE destSegment(nRch, structNTOPO, ierr, message)
+
+   ! Descriptions:
+   ! Find destination segment index for reach flux transfer. destination ID needs to be provided through user-input
+   ! integerMissing => no destination
+
+   implicit none
+   ! Argument variables
+   integer(i4b)      , intent(in)                :: nRch              ! number of stream segments
+   type(var_ilength) , intent(inout)             :: structNTOPO(:)    ! network topology structure
+   integer(i4b)      , intent(out)               :: ierr              ! error code
+   character(*)      , intent(out)               :: message           ! error message
+   ! Local variables
+   character(len=strLen)                         :: cmessage          ! error message of downwind routine
+   integer(i4b)                                  :: iRch              ! loop index
+   integer(i4b)                                  :: segId(nRch)       ! temporary array holding segID
+   integer(i4b)                                  :: destSegId(nRch)   ! temporary array holding destination reach ID
+   integer(i4b)                                  :: destIndex(nRch)   ! temporary array holding destination reach index
+   integer(i4b)                                  :: nDest(nRch)       ! number of elements that each reach are connetcted to outlet
+
+   ierr=0; message='destSegment/'
+
+   do iRch=1,nRch
+     segId(iRch)     = structNTOPO(iRch)%var(ixNTOPO%segId)%dat(1)
+     destSegId(iRch) = structNTOPO(iRch)%var(ixNTOPO%destSegId)%dat(1)
+   end do
+
+   ! Get the index of the destination reach ID
+   call downReachIndex(nRch,          & ! input: number of reaches
+                       nRch,          & ! input: number of potential destination reaches
+                       segId,         & ! input: unique identifier of the stream segments
+                       destSegId,     & ! input: unique identifier of the destination segment
+                       destIndex,     & ! output: index of downstream stream segment
+                       nDest,         & ! output: number of destination elements
+                       ierr,cmessage)   ! error control
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+   do iRch=1,nRch
+     structNTOPO(iRch)%var(ixNTOPO%destSegIndex)%dat(1) = destIndex(iRch)
+   end do
+
+ END SUBROUTINE destSegment
+
+ ! *********************************************************************
  ! new subroutine: define index of downstream reach
  ! *********************************************************************
  subroutine downReachIndex(&
@@ -344,8 +391,7 @@ CONTAINS
                            downSegIndex, & ! index of downstream stream segment
                            nElement2Seg, & ! number of elements that drain into each segment
                            ierr,message)
- ! external modules
- !USE nr_utility_module, ONLY: indexx  ! Num. Recipies utilities
+
  implicit none
  ! input variables
  integer(i4b), intent(in)        :: nUp             ! number of upstream elements
@@ -786,7 +832,6 @@ CONTAINS
  !   Generates a list of all reaches upstream of a given reach
  !
  ! ----------------------------------------------------------------------------------------
- USE nrtype
  USE nr_utility_module, ONLY: arth                                 ! Num. Recipies utilities
  IMPLICIT NONE
  ! input variables
@@ -903,6 +948,43 @@ CONTAINS
 
  end subroutine reach_mask
 
+ ! *********************************************************************
+ ! public subroutine: find ID and index of target reach for each reach
+ ! *********************************************************************
+ SUBROUTINE outletSegment(nRch, structNTOPO, ierr, message)
+
+   implicit none
+   ! Argument variables
+   integer(i4b)      , intent(in)                :: nRch              ! number of stream segments
+   type(var_ilength) , intent(inout)             :: structNTOPO(:)    ! network topology structure
+   integer(i4b)      , intent(out)               :: ierr              ! error code
+   character(*)      , intent(out)               :: message           ! error message
+   ! Local variables
+   integer(i4b)                                  :: iRch,jRch         ! loop index
+
+   ierr=0; message='outletSegment/'
+
+   ! initialize: integerMissing => no destination
+   do iRch=1,nRch
+     structNTOPO(iRch)%var(ixNTOPO%destSegId)%dat(1)    = integerMissing
+     structNTOPO(iRch)%var(ixNTOPO%destSegIndex)%dat(1) = integerMissing
+   end do
+
+   ! process only if reach is outlet (i.e.,downstream reach index is missing values)
+   do iRch=1,nRch
+     if (structNTOPO(iRch)%var(ixNTOPO%downSegIndex)%dat(1)==-1) then ! downSeg index=-1 -> outlet
+       associate (allUpIdx => structNTOPO(iRch)%var(ixNTOPO%allUpSegIndices)%dat)
+       do jRch=1,size(allUpIdx)
+         structNTOPO(allUpIdx(jRch))%var(ixNTOPO%destSegId)%dat(1)    = structNTOPO(iRch)%var(ixNTOPO%segId)%dat(1)
+         structNTOPO(allUpIdx(jRch))%var(ixNTOPO%destSegIndex)%dat(1) = structNTOPO(iRch)%var(ixNTOPO%segIndex)%dat(1)
+       end do
+       end associate
+     end if
+   end do
+
+ END SUBROUTINE outletSegment
+
+
  ! ====================================================================================================
  ! ====================================================================================================
  ! ====================================================================================================
@@ -942,7 +1024,6 @@ CONTAINS
  !   Generates a list of all reaches upstream of a given reach
  !
  ! ----------------------------------------------------------------------------------------
- USE nrtype
  USE nr_utility_module, ONLY: arth                                 ! Num. Recipies utilities
  IMPLICIT NONE
  ! input variables

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -131,7 +131,7 @@ contains
  meta_SEG    (ixSEG%man_n            ) = var_info('man_n'          , 'Mannings n'                                        ,'weird' ,ixDims%seg   , .false.)
  meta_SEG    (ixSEG%hruArea          ) = var_info('hruArea'        , 'area of each contributing HRU'                     ,'m2'    ,ixDims%upHRU , .false.)
  meta_SEG    (ixSEG%weight           ) = var_info('weight'         , 'weight assigned to each HRU'                       ,'-'     ,ixDims%upHRU , .false.)
- meta_SEG    (ixSEG%timeDelayHist    ) = var_info('timeDelayHist'  , 'time delay histogram for each reach'               ,'s'     ,ixDims%uh    , .false.)
+ meta_SEG    (ixSEG%timeDelayHist    ) = var_info('timeDelayHist'  , 'time delay histogram for each reach'               ,'-'     ,ixDims%uh    , .false.)
  meta_SEG    (ixSEG%basArea          ) = var_info('basArea'        , 'total area of the contributing HRUs'               ,'m2'    ,ixDims%seg   , .false.)
  meta_SEG    (ixSEG%upsArea          ) = var_info('upsArea'        , 'area above the top of the reach -- 0 if headwater' ,'m2'    ,ixDims%seg   , .false.)
  meta_SEG    (ixSEG%totalArea        ) = var_info('totalArea'      , 'area above the bottom of the reach -- bas + ups'   ,'m2'    ,ixDims%seg   , .false.)
@@ -212,6 +212,8 @@ contains
  meta_NTOPO  (ixNTOPO%lakeIndex      ) = var_info('lakeIndex'      , 'index of each lake in the river network'            ,'-'    ,ixDims%seg   , .false.)
  meta_NTOPO  (ixNTOPO%isLakeInlet    ) = var_info('isLakeInlet'    , 'flag to define if a lake inlet (1=true)'            ,'-'    ,ixDims%seg   , .false.)
  meta_NTOPO  (ixNTOPO%userTake       ) = var_info('userTake'       , 'flag to define if user takes water (1=true)'        ,'-'    ,ixDims%seg   , .false.)
+ meta_NTOPO  (ixNTOPO%destSegId      ) = var_info('destSegId'      , 'id of destination segment to be sent'               ,'-'    ,ixDims%seg   , .false.)
+ meta_NTOPO  (ixNTOPO%destSegIndex   ) = var_info('destSegIndex'   , 'index of destination segment to be sent'            ,'-'    ,ixDims%seg   , .false.)
  meta_NTOPO  (ixNTOPO%goodBasin      ) = var_info('goodBasin'      , 'flag to define a good basin (1=true)'               ,'-'    ,ixDims%upSeg , .false.)
  meta_NTOPO  (ixNTOPO%islake         ) = var_info('islake'         , 'flag to define if the object is lake (1=true)'      ,'-'    ,ixDims%Seg   , .false.)
  meta_NTOPO  (ixNTOPO%LakeTargVol    ) = var_info('LakeTargVol'    , 'flag to define if lake follow target Vol (1=true)'  ,'-'    ,ixDims%Seg   , .false.)
@@ -232,7 +234,9 @@ contains
  call meta_rflx(ixRFLX%DWroutedRunoff   )%init('DWroutedRunoff'   , 'routed runoff in each reach-diffusive wave'           , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%volume           )%init('volume'           , 'lake and stream volume'                               , 'm3'  , pio_real, [ixQdims%seg,ixQdims%time], .true.)
 
+ ! HRU flux                                    varName              varDesc                                                  unit,   varType,  varDim,                     writeOut
  call meta_hflx(ixHFLX%basRunoff        )%init('basRunoff'        , 'basin runoff'                                         , 'm/s' , pio_real, [ixQdims%hru,ixQdims%time], .true.)
+
  ! ---------- populate segment restart metadata structures -------------------------------------------------------------------------------------------------------------------
  ! Lagrangian Kinematic Wave
  call meta_kwt(ixKWT%tentry   )%init('tentry'   , 'time when a wave enters a segment'             , 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -13,256 +13,266 @@ MODULE var_lookup
  ! ** define data structures
  ! ***********************************************************************************************************
  type, public  ::  iLook_struct
-  integer(i4b)     :: HRU          = integerMissing   ! HRU structure
-  integer(i4b)     :: HRU2SEG      = integerMissing   ! HRU-to-segment mapping structure
-  integer(i4b)     :: SEG          = integerMissing   ! stream segment structure
-  integer(i4b)     :: NTOPO        = integerMissing   ! network topology structure
-  integer(i4b)     :: PFAF         = integerMissing   ! Pfafstetter code structure
+  integer(i4b)     :: HRU          = integerMissing   ! 1. HRU structure
+  integer(i4b)     :: HRU2SEG      = integerMissing   ! 2. HRU-to-segment mapping structure
+  integer(i4b)     :: SEG          = integerMissing   ! 3. stream segment structure
+  integer(i4b)     :: NTOPO        = integerMissing   ! 4. network topology structure
+  integer(i4b)     :: PFAF         = integerMissing   ! 5. Pfafstetter code structure
  endtype iLook_struct
  ! ***********************************************************************************************************
  ! ** define dimensions
  ! ***********************************************************************************************************
  type, public  ::  iLook_dims
-  integer(i4b)     :: hru          = integerMissing   ! hru vector
-  integer(i4b)     :: seg          = integerMissing   ! stream segment vector
-  integer(i4b)     :: upHRU        = integerMissing   ! upstream HRUs
-  integer(i4b)     :: upSeg        = integerMissing   ! immediate upstream segments
-  integer(i4b)     :: upAll        = integerMissing   ! all upstream segments
-  integer(i4b)     :: uh           = integerMissing   ! all segment unit hydrographs
-  integer(i4b)     :: pfaf         = integerMissing   ! max pfaf code length
+  integer(i4b)     :: hru          = integerMissing   ! 1. hru vector
+  integer(i4b)     :: seg          = integerMissing   ! 2. stream segment vector
+  integer(i4b)     :: upHRU        = integerMissing   ! 3. upstream HRUs
+  integer(i4b)     :: upSeg        = integerMissing   ! 4. immediate upstream segments
+  integer(i4b)     :: upAll        = integerMissing   ! 5. all upstream segments
+  integer(i4b)     :: uh           = integerMissing   ! 6. all segment unit hydrographs
+  integer(i4b)     :: pfaf         = integerMissing   ! 7. max pfaf code length
  endtype iLook_dims
  ! For routing state variables
  type, public  ::  iLook_stateDims
-  integer(i4b)     :: seg          = integerMissing   ! stream segment vector
-  integer(i4b)     :: time         = integerMissing   ! time
-  integer(i4b)     :: tbound       = integerMissing   ! 2 elelment time bound vector
-  integer(i4b)     :: ens          = integerMissing   ! runoff ensemble
-  integer(i4b)     :: wave         = integerMissing   ! waves in a channel
-  integer(i4b)     :: mol_kw       = integerMissing   ! kw finite difference computational molecule
-  integer(i4b)     :: mol_mc       = integerMissing   ! mc finite difference computational molecule
-  integer(i4b)     :: mol_dw       = integerMissing   ! kw finite difference computational molecule
-  integer(i4b)     :: tdh_irf      = integerMissing   ! irf routed future channel flow in a segment
-  integer(i4b)     :: tdh          = integerMissing   ! uh routed future overland flow
+  integer(i4b)     :: seg          = integerMissing   !  1. stream segment vector
+  integer(i4b)     :: time         = integerMissing   !  2. time
+  integer(i4b)     :: tbound       = integerMissing   !  3. 2 elelment time bound vector
+  integer(i4b)     :: ens          = integerMissing   !  4. runoff ensemble
+  integer(i4b)     :: wave         = integerMissing   !  5. waves in a channel
+  integer(i4b)     :: mol_kw       = integerMissing   !  6. kw finite difference computational molecule
+  integer(i4b)     :: mol_mc       = integerMissing   !  7. mc finite difference computational molecule
+  integer(i4b)     :: mol_dw       = integerMissing   !  8. kw finite difference computational molecule
+  integer(i4b)     :: tdh_irf      = integerMissing   !  9. irf routed future channel flow in a segment
+  integer(i4b)     :: tdh          = integerMissing   ! 10. uh routed future overland flow
  endtype iLook_stateDims
  ! For river discharge variables
  type, public  ::  iLook_qDims
-  integer(i4b)     :: time         = integerMissing   ! time
-  integer(i4b)     :: seg          = integerMissing   ! stream segment vector
-  integer(i4b)     :: hru          = integerMissing   ! hru vector
-  integer(i4b)     :: ens          = integerMissing   ! runoff ensemble
+  integer(i4b)     :: time         = integerMissing   ! 1. time
+  integer(i4b)     :: seg          = integerMissing   ! 2. stream segment vector
+  integer(i4b)     :: hru          = integerMissing   ! 3. hru vector
+  integer(i4b)     :: ens          = integerMissing   ! 4. runoff ensemble
  endtype iLook_qDims
  ! ***********************************************************************************************************
  ! ** define variables desired for each HRU
  ! ***********************************************************************************************************
  type, public  ::  iLook_HRU
-  integer(i4b)     :: area         = integerMissing   ! basin area
+  integer(i4b)     :: area         = integerMissing   ! 1. basin area (m2)
  endtype iLook_HRU
  ! ***********************************************************************************************************
  ! ** define variables for the hru2segment mapping
  ! ***********************************************************************************************************
  type, public  ::  iLook_HRU2SEG
-  integer(i4b)     :: HRUid         = integerMissing  ! unique HRU id
-  integer(i4b)     :: HRUindex      = integerMissing  ! HRU index
-  integer(i4b)     :: hruSegId      = integerMissing  ! id of the stream segment below each HRU
-  integer(i4b)     :: hruSegIndex   = integerMissing  ! index of the stream segment below each HRU
+  integer(i4b)     :: HRUid         = integerMissing  ! 1. unique HRU id
+  integer(i4b)     :: HRUindex      = integerMissing  ! 2. HRU index
+  integer(i4b)     :: hruSegId      = integerMissing  ! 3. id of the stream segment below each HRU
+  integer(i4b)     :: hruSegIndex   = integerMissing  ! 4. index of the stream segment below each HRU
  endtype iLook_HRU2SEG
  ! ***********************************************************************************************************
  ! ** define variables desired for each HRU
  ! ***********************************************************************************************************
  type, public  ::  iLook_SEG
   ! reach properties
-  integer(i4b)     :: length           = integerMissing  ! length of segment  (m)
-  integer(i4b)     :: slope            = integerMissing  ! slope of segment   (-)
-  integer(i4b)     :: width            = integerMissing  ! width of segment   (m)
-  integer(i4b)     :: man_n            = integerMissing  ! Manning's n        (weird units)
+  integer(i4b)     :: length           = integerMissing  !  1. length of segment (m)
+  integer(i4b)     :: slope            = integerMissing  !  2. slope of segment (-)
+  integer(i4b)     :: width            = integerMissing  !  3. width of segment (m)
+  integer(i4b)     :: man_n            = integerMissing  !  4. Manning's n (weird units)
   ! contributing HRUs
-  integer(i4b)     :: hruArea          = integerMissing  ! contributing area for each HRU (m2)
-  integer(i4b)     :: weight           = integerMissing  ! weight assigned to each HRU (-)
+  integer(i4b)     :: hruArea          = integerMissing  !  5. contributing area for each HRU (m2)
+  integer(i4b)     :: weight           = integerMissing  !  6. weight assigned to each HRU (-)
   ! unit hydrograph routing
-  integer(i4b)     :: timeDelayHist    = integerMissing  ! time delay histogram for each reach (s)
-  integer(i4b)     :: basArea          = integerMissing  ! area of the local HRUs contributing to each reach (m2)
-  integer(i4b)     :: upsArea          = integerMissing  ! area above the top of the reach -- zero if headwater (m2)
-  integer(i4b)     :: totalArea        = integerMissing  ! basArea + upsArea -- area at the bottom of the reach (m2)
+  integer(i4b)     :: timeDelayHist    = integerMissing  !  7. time delay histogram for each reach (-)
+  integer(i4b)     :: basArea          = integerMissing  !  8. area of the local HRUs contributing to each reach (m2)
+  integer(i4b)     :: upsArea          = integerMissing  !  9. area above the top of the reach -- zero if headwater (m2)
+  integer(i4b)     :: totalArea        = integerMissing  ! 10. basArea + upsArea -- area at the bottom of the reach (m2)
   ! lakes
-  integer(i4b)     :: basUnderLake     = integerMissing  ! Area of basin under lake  (m2)
-  integer(i4b)     :: rchUnderLake     = integerMissing  ! Length of reach under lake (m)
-  integer(i4b)     :: D03_MaxStorage   = integerMissing  ! Doll 2003 parameter
-  integer(i4b)     :: D03_Coefficient  = integerMissing  ! Doll 2003 parameter
-  integer(i4b)     :: D03_Power        = integerMissing  ! Doll 2003 parameter
-
-  integer(i4b)     :: HYP_E_emr        = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_E_lim        = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_E_min        = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_E_zero       = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_Qrate_emr    = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_Erate_emr    = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_Qrate_prim   = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_Qrate_amp    = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_Qrate_phs    = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_prim_F       = integerMissing  ! HYPE parameter
-  integer(i4b)     :: HYP_A_avg        = integerMissing  ! HYPE parameter
-
-  integer(i4b)     :: H06_Smax         = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_alpha        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_envfact      = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_S_ini        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_c1           = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_c2           = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_exponent     = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_denominator  = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_c_compare    = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_frac_Sdead   = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_E_rel_ini    = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Jan        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Feb        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Mar        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Apr        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_May        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Jun        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Jul        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Aug        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Sep        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Oct        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Nov        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_Dec        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Jan        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Feb        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Mar        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Apr        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_May        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Jun        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Jul        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Aug        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Sep        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Oct        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Nov        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_Dec        = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_purpose      = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_mem_F      = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_mem_F      = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_I_mem_L      = integerMissing  ! Hanasaki 2006 parameter
-  integer(i4b)     :: H06_D_mem_L      = integerMissing  ! Hanasaki 2006 parameter
-
+  integer(i4b)     :: basUnderLake     = integerMissing  ! 11. Area of basin under lake (m2)
+  integer(i4b)     :: rchUnderLake     = integerMissing  ! 12. Length of reach under lake (m)
+  ! Doll 2003 parameter (Natural lake outflow)
+  integer(i4b)     :: D03_MaxStorage   = integerMissing  ! 13. Lake maximum volume (m3)
+  integer(i4b)     :: D03_Coefficient  = integerMissing  ! 14.
+  integer(i4b)     :: D03_Power        = integerMissing  ! 15.
+  ! HYPE parameter (reservoir outflow)
+  integer(i4b)     :: HYP_E_emr        = integerMissing  ! 16.
+  integer(i4b)     :: HYP_E_lim        = integerMissing  ! 17.
+  integer(i4b)     :: HYP_E_min        = integerMissing  ! 18.
+  integer(i4b)     :: HYP_E_zero       = integerMissing  ! 19.
+  integer(i4b)     :: HYP_Qrate_emr    = integerMissing  ! 20.
+  integer(i4b)     :: HYP_Erate_emr    = integerMissing  ! 21.
+  integer(i4b)     :: HYP_Qrate_prim   = integerMissing  ! 22.
+  integer(i4b)     :: HYP_Qrate_amp    = integerMissing  ! 23.
+  integer(i4b)     :: HYP_Qrate_phs    = integerMissing  ! 24.
+  integer(i4b)     :: HYP_prim_F       = integerMissing  ! 25.
+  integer(i4b)     :: HYP_A_avg        = integerMissing  ! 26.
+  ! Hanasaki 2006 parameter (reservoir outlfow)
+  integer(i4b)     :: H06_Smax         = integerMissing  ! 27.
+  integer(i4b)     :: H06_alpha        = integerMissing  ! 28.
+  integer(i4b)     :: H06_envfact      = integerMissing  ! 29.
+  integer(i4b)     :: H06_S_ini        = integerMissing  ! 30.
+  integer(i4b)     :: H06_c1           = integerMissing  ! 31.
+  integer(i4b)     :: H06_c2           = integerMissing  ! 32.
+  integer(i4b)     :: H06_exponent     = integerMissing  ! 33.
+  integer(i4b)     :: H06_denominator  = integerMissing  ! 34.
+  integer(i4b)     :: H06_c_compare    = integerMissing  ! 35.
+  integer(i4b)     :: H06_frac_Sdead   = integerMissing  ! 36.
+  integer(i4b)     :: H06_E_rel_ini    = integerMissing  ! 37.
+  integer(i4b)     :: H06_I_Jan        = integerMissing  ! 38.
+  integer(i4b)     :: H06_I_Feb        = integerMissing  ! 39.
+  integer(i4b)     :: H06_I_Mar        = integerMissing  ! 40.
+  integer(i4b)     :: H06_I_Apr        = integerMissing  ! 41.
+  integer(i4b)     :: H06_I_May        = integerMissing  ! 42.
+  integer(i4b)     :: H06_I_Jun        = integerMissing  ! 43.
+  integer(i4b)     :: H06_I_Jul        = integerMissing  ! 44.
+  integer(i4b)     :: H06_I_Aug        = integerMissing  ! 45.
+  integer(i4b)     :: H06_I_Sep        = integerMissing  ! 46.
+  integer(i4b)     :: H06_I_Oct        = integerMissing  ! 47.
+  integer(i4b)     :: H06_I_Nov        = integerMissing  ! 48.
+  integer(i4b)     :: H06_I_Dec        = integerMissing  ! 49.
+  integer(i4b)     :: H06_D_Jan        = integerMissing  ! 50.
+  integer(i4b)     :: H06_D_Feb        = integerMissing  ! 51.
+  integer(i4b)     :: H06_D_Mar        = integerMissing  ! 52.
+  integer(i4b)     :: H06_D_Apr        = integerMissing  ! 53.
+  integer(i4b)     :: H06_D_May        = integerMissing  ! 54.
+  integer(i4b)     :: H06_D_Jun        = integerMissing  ! 55.
+  integer(i4b)     :: H06_D_Jul        = integerMissing  ! 56.
+  integer(i4b)     :: H06_D_Aug        = integerMissing  ! 57.
+  integer(i4b)     :: H06_D_Sep        = integerMissing  ! 58.
+  integer(i4b)     :: H06_D_Oct        = integerMissing  ! 59.
+  integer(i4b)     :: H06_D_Nov        = integerMissing  ! 60.
+  integer(i4b)     :: H06_D_Dec        = integerMissing  ! 61.
+  integer(i4b)     :: H06_purpose      = integerMissing  ! 62.
+  integer(i4b)     :: H06_I_mem_F      = integerMissing  ! 63.
+  integer(i4b)     :: H06_D_mem_F      = integerMissing  ! 64.
+  integer(i4b)     :: H06_I_mem_L      = integerMissing  ! 65.
+  integer(i4b)     :: H06_D_mem_L      = integerMissing  ! 66.
   ! constraints
-  integer(i4b)     :: minFlow       = integerMissing  ! minimum environmental flow
+  integer(i4b)     :: minFlow       = integerMissing     ! 67. minimum environmental flow (m3/s)
  endtype iLook_SEG
  ! ***********************************************************************************************************
- ! ** define variables for the network topology
+ ! ** define variables for the network topology (all are unitless)
  ! ***********************************************************************************************************
  type, public  ::  iLook_NTOPO
   ! upstream HRUs
-  integer(i4b)     :: nHRU            = integerMissing  ! number of HRUs that contribute flow to each segment
-  integer(i4b)     :: hruContribIx    = integerMissing  ! indices of HRUs that contribute flow to each segment
-  integer(i4b)     :: hruContribId    = integerMissing  ! ids of the vector of HRUs that contribute flow to each segment
+  integer(i4b)     :: nHRU            = integerMissing  !  1. number of HRUs that contribute flow to each segment
+  integer(i4b)     :: hruContribIx    = integerMissing  !  2. indices of HRUs that contribute flow to each segment
+  integer(i4b)     :: hruContribId    = integerMissing  !  3. ids of the vector of HRUs that contribute flow to each segment
   ! individual segments
-  integer(i4b)     :: segId           = integerMissing  ! unique id of each stream segment
-  integer(i4b)     :: segIndex        = integerMissing  ! index of each stream segment (1, 2, 3, ..., n)
+  integer(i4b)     :: segId           = integerMissing  !  4. unique id of each stream segment
+  integer(i4b)     :: segIndex        = integerMissing  !  5. index of each stream segment (1, 2, 3, ..., n)
   ! downstream segments
-  integer(i4b)     :: downSegId       = integerMissing  ! unique id of the next downstream segment
-  integer(i4b)     :: downSegIndex    = integerMissing  ! index of downstream reach index
+  integer(i4b)     :: downSegId       = integerMissing  !  6. unique id of the next downstream segment
+  integer(i4b)     :: downSegIndex    = integerMissing  !  7. index of downstream reach index
   ! upstream segments
-  integer(i4b)     :: upSegIds        = integerMissing  ! ids for the vector of immediate upstream stream segments
-  integer(i4b)     :: upSegIndices    = integerMissing  ! indices for the vector of immediate upstream stream segments
-  integer(i4b)     :: allUpSegIndices = integerMissing  ! indices of all upstream stream segments
+  integer(i4b)     :: upSegIds        = integerMissing  !  8. ids for the vector of immediate upstream stream segments
+  integer(i4b)     :: upSegIndices    = integerMissing  !  9. indices for the vector of immediate upstream stream segments
+  integer(i4b)     :: allUpSegIndices = integerMissing  ! 10. indices of all upstream stream segments
   ! processing sequence
-  integer(i4b)     :: rchOrder        = integerMissing  ! order that stream segments are processed
+  integer(i4b)     :: rchOrder        = integerMissing  ! 11. order that stream segments are processed
   ! stream order
-  integer(i4b)     :: streamOrder     = integerMissing  ! Shreve Stream Order
+  integer(i4b)     :: streamOrder     = integerMissing  ! 12. Shreve Stream Order
   ! lakes
-  integer(i4b)     :: lakeId          = integerMissing  ! unique id of each lake in the river network
-  integer(i4b)     :: lakeIndex       = integerMissing  ! index of each lake in the river network
-  integer(i4b)     :: isLakeInlet     = integerMissing  ! flag to define if reach is a lake inlet (1=inlet, 0 otherwise)
-  integer(i4b)     :: islake          = integerMissing  ! flag to define a lake (1=lake, 0=reach)
-  integer(i4b)     :: LakeTargVol     = integerMissing  ! flag to define if a lake should follow target volume (1=follow, 0=parameteric)
-  integer(i4b)     :: LakeModelType   = integerMissing  ! identifies the lake model (1=Doll, 2=Hanasaki, else=non-parameteric)
+  integer(i4b)     :: lakeId          = integerMissing  ! 13. unique id of each lake in the river network
+  integer(i4b)     :: lakeIndex       = integerMissing  ! 14. index of each lake in the river network
+  integer(i4b)     :: isLakeInlet     = integerMissing  ! 15. flag to define if reach is a lake inlet (1=inlet, 0 otherwise)
+  integer(i4b)     :: islake          = integerMissing  ! 16. flag to define a lake (1=lake, 0=reach)
+  integer(i4b)     :: LakeTargVol     = integerMissing  ! 17. flag to define if a lake should follow target volume (1=follow, 0=parameteric)
+  integer(i4b)     :: LakeModelType   = integerMissing  ! 18. identifies the lake model (1=Doll, 2=Hanasaki, else=non-parameteric)
   ! irrigation
-  integer(i4b)     :: userTake        = integerMissing  ! flag to define if user takes water from reach (1=extract, 0 otherwise)
+  integer(i4b)     :: userTake        = integerMissing  ! 19. flag to define if user takes water from reach (1=extract, 0 otherwise)
+  integer(i4b)     :: destSegId       = integerMissing  ! 20. id of destination stream segment
+  integer(i4b)     :: destSegIndex    = integerMissing  ! 21. index of destination stream segment
   ! testing
-  integer(i4b)     :: goodBasin       = integerMissing  ! flag to define a good basin (1=good, 0=bad)
+  integer(i4b)     :: goodBasin       = integerMissing  ! 22. flag to define a good basin (1=good, 0=bad)
  endtype iLook_NTOPO
  ! ***********************************************************************************************************
  ! ** define variables for Pfafstetter code  (temporary:   separated from NTOPO because type of code is character
  ! ***********************************************************************************************************
  type, public  ::  iLook_PFAF
   ! pfafstetter code
-  integer(i4b)     :: code            = integerMissing  ! pfafstetter code
+  integer(i4b)     :: code            = integerMissing  ! 1. pfafstetter code
  endtype iLook_PFAF
  ! ***********************************************************************************************************
  ! ** define variables for segment fluxes/states variables
  ! ***********************************************************************************************************
  ! Reach fluxes
  type, public  ::  iLook_RFLX
-  integer(i4b)     :: instRunoff        = integerMissing  ! instantaneous runoff in each reach
-  integer(i4b)     :: dlayRunoff        = integerMissing  ! delayed runoff in each reac
-  integer(i4b)     :: sumUpstreamRunoff = integerMissing  ! sum of upstream runoff in each reach
-  integer(i4b)     :: KWTroutedRunoff   = integerMissing  ! Lagrangian KWT routed runoff in each reach
-  integer(i4b)     :: KWroutedRunoff    = integerMissing  ! KW routed runoff in each reach
-  integer(i4b)     :: MCroutedRunoff    = integerMissing  ! muskingum-cunge routed runoff in each reach
-  integer(i4b)     :: DWroutedRunoff    = integerMissing  ! diffusive wave routed runoff in each reach
-  integer(i4b)     :: IRFroutedRunoff   = integerMissing  ! IRF routed runoff in each reach
-  integer(i4b)     :: volume            = integerMissing  ! water volume
+  integer(i4b)     :: instRunoff        = integerMissing  ! 1. instantaneous runoff at reach outlet (m3/s)
+  integer(i4b)     :: dlayRunoff        = integerMissing  ! 2. delayed runoff at reach outlet (m3/s)
+  integer(i4b)     :: sumUpstreamRunoff = integerMissing  ! 3. sum of upstream runoff at reach outlet (m3/s)
+  integer(i4b)     :: KWTroutedRunoff   = integerMissing  ! 4. Lagrangian KWT routed runoff at reach outlet (m3/s)
+  integer(i4b)     :: KWroutedRunoff    = integerMissing  ! 5. KW routed runoff at reach outlet(m3/s)
+  integer(i4b)     :: MCroutedRunoff    = integerMissing  ! 6. muskingum-cunge routed runoff at reach outlet (m3/s)
+  integer(i4b)     :: DWroutedRunoff    = integerMissing  ! 7. diffusive wave routed runoff at reach outlet (m3/s)
+  integer(i4b)     :: IRFroutedRunoff   = integerMissing  ! 8. IRF routed runoff at reach outlet (m3/s)
+  integer(i4b)     :: volume            = integerMissing  ! 9. water volume in reach (m3)
  endtype iLook_RFLX
  ! HRU fluxes
  type, public  ::  iLook_HFLX
-  integer(i4b)     :: basRunoff         = integerMissing  ! basin runoff
+  integer(i4b)     :: basRunoff         = integerMissing  ! 1. basin runoff (m/s)
  endtype iLook_HFLX
  ! Reach inflow from basin
  type, public  ::  iLook_basinQ
-  integer(i4b)     :: q              = integerMissing  ! final discharge
+  integer(i4b)     :: q              = integerMissing  ! 1. final discharge (m3/s)
  endtype iLook_basinQ
  ! Basin IRF state/fluxes
  type, public  ::  iLook_IRFbas
-  integer(i4b)     :: qfuture        = integerMissing  ! future routed flow
+  integer(i4b)     :: qfuture        = integerMissing  ! 1. future routed flow (m3/s)
  endtype iLook_IRFbas
  !IRF state/fluxes
  type, public  ::  iLook_IRF
-  integer(i4b)     :: qfuture        = integerMissing  ! future routed flow
-  integer(i4b)     :: vol            = integerMissing  ! reach volume
+  integer(i4b)     :: qfuture        = integerMissing  ! 1. future routed flow (m3/s)
+  integer(i4b)     :: vol            = integerMissing  ! 2. reach volume (m3)
  endtype iLook_IRF
  ! KWT state/fluxes
  type, public  ::  iLook_KWT
-  integer(i4b)     :: tentry         = integerMissing  ! wave entry time at a segment
-  integer(i4b)     :: texit          = integerMissing  ! wave exit time at a segment
-  integer(i4b)     :: qwave          = integerMissing  ! wave flow
-  integer(i4b)     :: qwave_mod      = integerMissing  ! wave flow after merged
-  integer(i4b)     :: routed         = integerMissing  ! Routed out of a segment or not
+  integer(i4b)     :: tentry         = integerMissing  ! 1. wave entry time at a segment (s)
+  integer(i4b)     :: texit          = integerMissing  ! 2. wave exit time at a segment (s)
+  integer(i4b)     :: qwave          = integerMissing  ! 3. wave flow (m3/s)
+  integer(i4b)     :: qwave_mod      = integerMissing  ! 4. wave flow after merged (m3/s)
+  integer(i4b)     :: routed         = integerMissing  ! 5. Routed out of a segment or not (-)
  endtype iLook_KWT
  ! KW state/fluxes
  type, public  ::  iLook_KW
-  integer(i4b)     :: qsub           = integerMissing  ! discharge
-  integer(i4b)     :: vol            = integerMissing  ! reach volume
+  integer(i4b)     :: qsub           = integerMissing  ! 1. discharge (m3/s)
+  integer(i4b)     :: vol            = integerMissing  ! 2. reach volume (m3)
  endtype iLook_KW
  ! DW state/fluxes
  type, public  ::  iLook_DW
-  integer(i4b)     :: qsub           = integerMissing  ! discharge
-  integer(i4b)     :: vol            = integerMissing  ! reach volume
+  integer(i4b)     :: qsub           = integerMissing  ! 1. discharge (m3/s)
+  integer(i4b)     :: vol            = integerMissing  ! 2. reach volume (m3)
  endtype iLook_DW
  ! MC state/fluxes
  type, public  ::  iLook_MC
-  integer(i4b)     :: qsub           = integerMissing  ! discharge
-  integer(i4b)     :: vol            = integerMissing  ! reach volume
+  integer(i4b)     :: qsub           = integerMissing  ! 1. discharge (m3/s)
+  integer(i4b)     :: vol            = integerMissing  ! 2. reach volume (m3)
  endtype iLook_MC
  ! ***********************************************************************************************************
  ! ** define data vectors
  ! ***********************************************************************************************************
- type(iLook_struct)   ,public,parameter :: ixStruct    = iLook_struct   (1,2,3,4,5)
- type(iLook_dims)     ,public,parameter :: ixDims      = iLook_dims     (1,2,3,4,5,6,7)
- type(iLook_stateDims),public,parameter :: ixStateDims = iLook_stateDims(1,2,3,4,5,6,7,8,9,10)
- type(iLook_qDims)    ,public,parameter :: ixqDims     = iLook_qDims    (1,2,3,4)
- type(iLook_HRU)      ,public,parameter :: ixHRU       = iLook_HRU      (1)
- type(iLook_HRU2SEG)  ,public,parameter :: ixHRU2SEG   = iLook_HRU2SEG  (1,2,3,4)
- type(iLook_SEG)      ,public,parameter :: ixSEG       = iLook_SEG      (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67)
- type(iLook_NTOPO)    ,public,parameter :: ixNTOPO     = iLook_NTOPO    (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20)
- type(iLook_PFAF)     ,public,parameter :: ixPFAF      = iLook_PFAF     (1)
- type(iLook_RFLX)     ,public,parameter :: ixRFLX      = iLook_RFLX     (1,2,3,4,5,6,7,8,9)
- type(iLook_HFLX)     ,public,parameter :: ixHFLX      = iLook_HFLX     (1)
- type(iLook_basinQ)   ,public,parameter :: ixBasinQ    = iLook_basinQ   (1)
- type(iLook_IRFbas)   ,public,parameter :: ixIRFbas    = iLook_IRFbas   (1)
- type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      (1,2)
- type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      (1,2,3,4,5)
- type(iLook_KW)       ,public,parameter :: ixKW        = iLook_KW       (1,2)
- type(iLook_DW)       ,public,parameter :: ixDW        = iLook_DW       (1,2)
- type(iLook_MC)       ,public,parameter :: ixMC        = iLook_MC       (1,2)
+ type(iLook_struct)   ,public,parameter :: ixStruct    = iLook_struct   ( 1, 2, 3, 4, 5)
+ type(iLook_dims)     ,public,parameter :: ixDims      = iLook_dims     ( 1, 2, 3, 4, 5, 6, 7)
+ type(iLook_stateDims),public,parameter :: ixStateDims = iLook_stateDims( 1, 2, 3, 4, 5, 6, 7, 8, 9,10)
+ type(iLook_qDims)    ,public,parameter :: ixqDims     = iLook_qDims    ( 1, 2, 3, 4)
+ type(iLook_HRU)      ,public,parameter :: ixHRU       = iLook_HRU      ( 1)
+ type(iLook_HRU2SEG)  ,public,parameter :: ixHRU2SEG   = iLook_HRU2SEG  ( 1, 2, 3, 4)
+ type(iLook_SEG)      ,public,parameter :: ixSEG       = iLook_SEG      ( 1, 2, 3, 4, 5, 6, 7, 8, 9,10, &
+                                                                         11,12,13,14,15,16,17,18,19,20, &
+                                                                         21,22,23,24,25,26,27,28,29,30, &
+                                                                         31,32,33,34,35,36,37,38,39,40, &
+                                                                         41,42,43,44,45,46,47,48,49,50, &
+                                                                         51,52,53,54,55,56,57,58,59,60, &
+                                                                         61,62,63,64,65,66,67)
+ type(iLook_NTOPO)    ,public,parameter :: ixNTOPO     = iLook_NTOPO    ( 1, 2, 3, 4, 5, 6, 7, 8, 9,10, &
+                                                                         11,12,13,14,15,16,17,18,19,20, &
+                                                                         21,22)
+ type(iLook_PFAF)     ,public,parameter :: ixPFAF      = iLook_PFAF     ( 1)
+ type(iLook_RFLX)     ,public,parameter :: ixRFLX      = iLook_RFLX     ( 1, 2, 3, 4, 5, 6, 7, 8, 9)
+ type(iLook_HFLX)     ,public,parameter :: ixHFLX      = iLook_HFLX     ( 1)
+ type(iLook_basinQ)   ,public,parameter :: ixBasinQ    = iLook_basinQ   ( 1)
+ type(iLook_IRFbas)   ,public,parameter :: ixIRFbas    = iLook_IRFbas   ( 1)
+ type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      ( 1, 2)
+ type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      ( 1, 2, 3, 4, 5)
+ type(iLook_KW)       ,public,parameter :: ixKW        = iLook_KW       ( 1, 2)
+ type(iLook_DW)       ,public,parameter :: ixDW        = iLook_DW       ( 1, 2)
+ type(iLook_MC)       ,public,parameter :: ixMC        = iLook_MC       ( 1, 2)
  ! ***********************************************************************************************************
  ! ** define size of data vectors
  ! ***********************************************************************************************************

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -66,10 +66,10 @@
 ! ****************************************************************************************************************************
 ! cesm-coupler: negative flow (qgwl and excess irrigation demand) handling option
 ! ---------------------------
-! NOTE: <bypass_routing_option> is option of the method of handling negative runoff from land model (qbwl or excess irrigation demand).
-!       direct_in_place: put hru runoff separately from other runoff components and send thme to the nearest ocean point through a coupler.
-!       direct_to_outlet: send hru runoff directly to ocean or endoheic lake outlet and putting the total runoff into the reach.
-!       <qgwl_runoff_option> is option of method of handling qgwl runoff from CLM.
+! NOTE: <bypass_routing_option> is options for handling negative runoff from land model (qbwl or excess irrigation demand).
+!       direct_in_place: separate negative HRU runoff from other runoff components and send it to the nearest ocean point through a coupler.
+!       direct_to_outlet: send negative HRU runoff directly to the basin outlet (ocean or endoheic lake) and putting it into the outlet reach.
+!       <qgwl_runoff_option> is options for handling qgwl runoff from CLM.
 !       all: apply all qgwl runoff to bypass_routing, negative: apply only negative runoff, threshold: apply runoff below threshold
 <bypass_routing_option> direct_in_place            ! options: direct_in_place, or direct_to_outlet
 <qgwl_runoff_option>    threshold                  ! options: all, negative, or threshold


### PR DESCRIPTION
Added new river topology variables: destination reach: `destSegId` and `destSegIndex`. Each reach points to the other reach (one-to-one link) through reach ID or index. Destination reach can be used to directly send negative runoff to the ocean for cesm-coupling or discharge transfer from one reach to another.

A routine to compute each reach to its outlet reach. 

new derived data type: `commLink`. This is used to specify links of reaches using index and processor (task)