### PR TITLE
Minor naming changes

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -138,9 +138,9 @@ EXTINCLUDES =
 # data types
 DATATYPES = \
     nrtype.f90 \
-    nr_utility.f90 \
+    nr_utils.f90 \
     pio_utils.f90 \
-    ascii_util.f90 \
+    ascii_utils.f90 \
     public_var.f90 \
     dataTypes.f90 \
     var_lookup.f90 \

--- a/route/build/src/ascii_utils.f90
+++ b/route/build/src/ascii_utils.f90
@@ -1,4 +1,4 @@
-MODULE ascii_util_module
+MODULE ascii_utils
 
 USE nrtype
 
@@ -230,4 +230,4 @@ CONTAINS
 
  END FUNCTION lower
 
-END MODULE ascii_util_module
+END MODULE ascii_utils

--- a/route/build/src/csv_data.f90
+++ b/route/build/src/csv_data.f90
@@ -26,7 +26,7 @@ MODULE csv_data
 
 USE nrtype
 USE public_var
-USE ascii_util_module
+USE ascii_utils
 
 implicit none
 integer(i4b), parameter :: type_string  = 1  ! a character string cell

--- a/route/build/src/domain_decomposition.f90
+++ b/route/build/src/domain_decomposition.f90
@@ -9,9 +9,9 @@ USE dataTypes,         ONLY: subbasin_mpi  ! MPI domain data structure
 USE var_lookup,        ONLY: ixNTOPO       ! index of variables for the netowork topolgy
 USE var_lookup,        ONLY: ixHRU2SEG     ! index of variables for the netowork topolgy
 ! General utilities
-USE nr_utility_module, ONLY: indexx        ! sorting array
-USE nr_utility_module, ONLY: indexTrue     ! index at only true in array
-USE nr_utility_module, ONLY: arth          ! generate sequential array
+USE nr_utils,          ONLY: indexx        ! sorting array
+USE nr_utils,          ONLY: indexTrue     ! index at only true in array
+USE nr_utils,          ONLY: arth          ! generate sequential array
 ! updated and saved data
 USE public_var
 

--- a/route/build/src/gamma_func.f90
+++ b/route/build/src/gamma_func.f90
@@ -1,11 +1,14 @@
-module gamma_func_module
+MODULE gamma_func_module
+
 USE nrtype
-USE nr_utility_module,only:arth
+USE nr_utils, ONLY: arth
+
 ! contains functions that should really be part of the fortran standard, but are not
 implicit none
 private
 public::gammp
-contains
+
+CONTAINS
 
  ! ******************************************************************************************************************************
  ! public function gammp: compute cumulative probability using the Gamma distribution
@@ -117,4 +120,4 @@ contains
   sum(coef(:)/arth(x+1.0_dp,1.0_dp,size(coef))))/x)
  END FUNCTION gammln
 
-end module gamma_func_module
+END MODULE gamma_func_module

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -314,9 +314,9 @@ CONTAINS
  SUBROUTINE init_state_data(pid, nNodes, comm, ierr, message)
 
   ! external routines
-  USE ascii_util_module, ONLY: lower             ! convert string to lower case
-  USE read_restart,      ONLY: read_state_nc     ! read netcdf state output file
-  USE mpi_process,       ONLY: mpi_restart
+  USE ascii_utils,  ONLY: lower             ! convert string to lower case
+  USE read_restart, ONLY: read_state_nc     ! read netcdf state output file
+  USE mpi_process,  ONLY: mpi_restart
   ! shared data
   USE public_var, ONLY: dt                     ! simulation time step (seconds)
   USE public_var, ONLY: restart_dir            ! directory containing output data
@@ -688,7 +688,7 @@ CONTAINS
   USE globalData,          ONLY: ixRch_order              ! global reach index in the order of proc assignment (size = total number of reaches in the entire network)
   USE globalData,          ONLY: ixHRU_order              ! global HRU index in the order of proc assignment (size = total number of HRUs contributing to any reaches, nContribHRU)
   USE domain_decomposition,ONLY: omp_domain_decomposition ! domain decomposition for omp
-  USE nr_utility_module,   ONLY: findIndex                ! find index within a vector
+  USE nr_utils,            ONLY: findIndex                ! find index within a vector
 
   implicit none
   ! Argument variables

--- a/route/build/src/kwt_route.f90
+++ b/route/build/src/kwt_route.f90
@@ -17,7 +17,7 @@ USE public_var, ONLY: realMissing      ! missing value for real number
 USE public_var, ONLY: integerMissing   ! missing value for integer number
 USE globalData, ONLY: idxKWT           ! index of KWT method
 ! utilities
-USE nr_utility_module, ONLY: arth      ! Num. Recipies utilities
+USE nr_utils,   ONLY: arth      ! Num. Recipies utilities
 ! subroutines: general
 USE perf_mod,  ONLY: t_startf,t_stopf  ! timing start/stop
 USE model_utils, ONLY: handle_err

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -26,13 +26,13 @@ USE var_lookup, ONLY:ixHRU2SEG,nVarsHRU2SEG   ! index of variables for the hru2s
 USE var_lookup, ONLY:ixNTOPO,  nVarsNTOPO     ! index of variables for the network topology
 USE var_lookup, ONLY:ixPFAF,   nVarsPFAF      ! index of variables for the pfafstetter code
 ! general utility
-USE nr_utility_module, ONLY: indexx           ! create sorted index array
-USE nr_utility_module, ONLY: arth             ! build a vector of regularly spaced numbers
-USE nr_utility_module, ONLY: sizeo            ! get size of allocatable array (if not allocated, zero)
-USE nr_utility_module, ONLY: findIndex        ! find index within a vector
-USE nr_utility_module, ONLY: match_index      !
-USE perf_mod,          ONLY: t_startf         ! timing start
-USE perf_mod,          ONLY: t_stopf          ! timing stop
+USE nr_utils,  ONLY: indexx           ! create sorted index array
+USE nr_utils,  ONLY: arth             ! build a vector of regularly spaced numbers
+USE nr_utils,  ONLY: sizeo            ! get size of allocatable array (if not allocated, zero)
+USE nr_utils,  ONLY: findIndex        ! find index within a vector
+USE nr_utils,  ONLY: match_index      !
+USE perf_mod,  ONLY: t_startf         ! timing start
+USE perf_mod,  ONLY: t_stopf          ! timing stop
 ! MPI utility
 USE mpi_utils, ONLY: shr_mpi_bcast
 USE mpi_utils, ONLY: shr_mpi_gatherV

--- a/route/build/src/network_topo.f90
+++ b/route/build/src/network_topo.f90
@@ -28,9 +28,9 @@ USE var_lookup, ONLY:ixHRU2SEG,nVarsHRU2SEG ! index of variables for the hru2seg
 USE var_lookup, ONLY:ixNTOPO,  nVarsNTOPO   ! index of variables for the network topology
 
 ! external utilities
-USE nr_utility_module, ONLY: findIndex     ! Num. Recipies utilities
-USE nr_utility_module, ONLY: indexx        ! Num. Recipies utilities
-USE nr_utility_module, ONLY: arth          ! Num. Recipies utilities
+USE nr_utils, ONLY: findIndex     ! Num. Recipies utilities
+USE nr_utils, ONLY: indexx        ! Num. Recipies utilities
+USE nr_utils, ONLY: arth          ! Num. Recipies utilities
 
 implicit none
 
@@ -675,7 +675,7 @@ CONTAINS
  !     at each point in the river network)
  !
  ! ----------------------------------------------------------------------------------------
- USE nr_utility_module, ONLY: arth                          ! Num. Recipies utilities
+
  IMPLICIT NONE
  ! input variables
  INTEGER(I4B)      , INTENT(IN)                 :: NRCH            ! number of stream segments
@@ -832,7 +832,7 @@ CONTAINS
  !   Generates a list of all reaches upstream of a given reach
  !
  ! ----------------------------------------------------------------------------------------
- USE nr_utility_module, ONLY: arth                                 ! Num. Recipies utilities
+
  IMPLICIT NONE
  ! input variables
  integer(i4b)      , intent(in)                :: desireId          ! id of the desired reach
@@ -1024,7 +1024,7 @@ CONTAINS
  !   Generates a list of all reaches upstream of a given reach
  !
  ! ----------------------------------------------------------------------------------------
- USE nr_utility_module, ONLY: arth                                 ! Num. Recipies utilities
+
  IMPLICIT NONE
  ! input variables
  integer(i4b)      , intent(in)                :: desireId          ! id of the desired reach

--- a/route/build/src/nr_utils.f90
+++ b/route/build/src/nr_utils.f90
@@ -1,4 +1,4 @@
-MODULE nr_utility_module
+MODULE nr_utils
 
 USE nrtype
 
@@ -420,4 +420,4 @@ CONTAINS
     end do
   END FUNCTION
 
-END MODULE nr_utility_module
+END MODULE nr_utils

--- a/route/build/src/pfafstetter.f90
+++ b/route/build/src/pfafstetter.f90
@@ -2,7 +2,7 @@ MODULE pfafstetter_module
 
 USE nrtype
 USE public_var
-USE nr_utility_module, ONLY: char2int
+USE nr_utils, ONLY: char2int
 
 implicit none
 

--- a/route/build/src/process_gage_meta.f90
+++ b/route/build/src/process_gage_meta.f90
@@ -44,9 +44,9 @@ MODULE process_gage_meta
 
     SUBROUTINE reach_subset(reachID_in, gage_data_in, compdof, index2)
 
-      USE nr_utility_module, ONLY: match_index
-      USE nr_utility_module, ONLY: arth
-      USE dataTypes,         ONLY: gage
+      USE nr_utils,  ONLY: match_index
+      USE nr_utils,  ONLY: arth
+      USE dataTypes, ONLY: gage
 
       implicit none
       ! Argument variables

--- a/route/build/src/process_remap.f90
+++ b/route/build/src/process_remap.f90
@@ -327,7 +327,7 @@ MODULE process_remap_module
                          ixSubRch,          & ! optional input: subset of reach indices to be processed
                          limitRunoff)         ! optional input: true->enforce min. flow, false->allow any flow (e.g., negative)
   ! External modules
-  USE nr_utility_module, ONLY : arth
+  USE nr_utils, ONLY : arth
 
   implicit none
 

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -42,9 +42,9 @@ CONTAINS
  USE var_lookup, ONLY: ixRFLX
  USE var_lookup, ONLY: ixHFLX
  ! external subroutines
- USE ascii_util_module, ONLY: file_open        ! open file (performs a few checks as well)
- USE ascii_util_module, ONLY: get_vlines       ! get a list of character strings from non-comment lines
- USE nr_utility_module, ONLY: char2int         ! convert integer number to a array containing individual digits
+ USE ascii_utils, ONLY: file_open        ! open file (performs a few checks as well)
+ USE ascii_utils, ONLY: get_vlines       ! get a list of character strings from non-comment lines
+ USE nr_utils,    ONLY: char2int         ! convert integer number to a array containing individual digits
 
  implicit none
  ! argument variables

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -101,6 +101,11 @@ CONTAINS
      write(iulog,'(x,a,a,a)') trim(cName), ' --> ', trim(cData)
    endif
 
+   if (index(cData, achar(9)) > 0) then
+     err=10; message=trim(message)//'Control variable:'//trim(cData)//' includes TABs. Use spaces'
+     return
+   end if
+
    ! populate variables
    select case(trim(cName))
 

--- a/route/build/src/read_param.f90
+++ b/route/build/src/read_param.f90
@@ -10,10 +10,10 @@ MODULE read_param_module
  CONTAINS
 
   SUBROUTINE read_param(fname, ierr, message)
-   USE ascii_util_module, ONLY: file_open          ! open file (performs a few checks as well)
-   USE globalData,        ONLY: fshape, tscale, &  ! basin IRF routing parameters
-                                velo, diff,     &  ! IRF routing parameters
-                                mann_n, wscale     ! KWT routing parameters
+   USE ascii_utils, ONLY: file_open          ! open file (performs a few checks as well)
+   USE globalData,  ONLY: fshape, tscale, &  ! basin IRF routing parameters
+                          velo, diff,     &  ! IRF routing parameters
+                          mann_n, wscale     ! KWT routing parameters
    implicit none
    ! Argument variables
    character(*),intent(in)    :: fname              ! parameter namelist name

--- a/route/build/src/read_streamSeg.f90
+++ b/route/build/src/read_streamSeg.f90
@@ -31,8 +31,8 @@ USE var_lookup, ONLY: ixPFAF,   nVarsPFAF    ! index of variables for the pfafst
 USE netcdf
 
 ! external utilities
-USE nr_utility_module, ONLY: arth    ! Num. Recipies utilities
-USE allocation,        ONLY: alloc_struct
+USE nr_utils,   ONLY: arth
+USE allocation, ONLY: alloc_struct
 
 implicit none
 

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -1,14 +1,13 @@
 MODULE model_setup
 
-USE nrtype,            ONLY: i4b,dp,lgt
-USE nrtype,            ONLY: strLen
+USE nrtype
 USE public_var,        ONLY: iulog
 USE public_var,        ONLY: debug
 USE public_var,        ONLY: integerMissing
 USE public_var,        ONLY: realMissing
 USE public_var,        ONLY: charMissing
-USE nr_utility_module, ONLY: unique         ! get unique element array
-USE nr_utility_module, ONLY: indexx         ! get rank of data value
+USE nr_utils,          ONLY: unique         ! get unique element array
+USE nr_utils,          ONLY: indexx         ! get rank of data value
 
 implicit none
 
@@ -182,8 +181,8 @@ CONTAINS
   USE dataTypes,           ONLY: infileinfo     ! the data type for storing the infromation of the nc files and its attributes
   USE datetime_data,       ONLY: datetime       ! datetime data
   ! subroutines
-  USE ascii_util_module,   ONLY: file_open      ! open file (performs a few checks as well)
-  USE ascii_util_module,   ONLY: get_vlines     ! get a list of character strings from non-comment lines
+  USE ascii_utils,         ONLY: file_open      ! open file (performs a few checks as well)
+  USE ascii_utils,         ONLY: get_vlines     ! get a list of character strings from non-comment lines
   USE ncio_utils,          ONLY: get_nc         ! get the
   USE ncio_utils,          ONLY: get_var_attr   ! get the attributes interface
   USE ncio_utils,          ONLY: get_nc_dim_len ! get the nc dimension length
@@ -389,7 +388,7 @@ CONTAINS
   ! - begDatetime, endDatetime:   simulationg start and end datetime
   ! - restDatetime, dropDatetime
 
-  USE ascii_util_module, ONLY : lower            ! convert string to lower case
+  USE ascii_utils, ONLY : lower            ! convert string to lower case
   ! derived datatype
   USE datetime_data, ONLY : datetime             ! datetime data
   ! public data

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -628,7 +628,7 @@ CONTAINS
       dropDatetime = restDatetime%add_sec(-dt, calendar, ierr, cmessage)
       if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [restDatetime->dropDatetime]'; return; endif
       restart_month = dropDatetime%month(); restart_day = dropDatetime%day(); restart_hour = dropDatetime%hour()
-    case('annual','monthly','daily')
+    case('yearly','monthly','daily')
       restDatetime = datetime(2000, restart_month, restart_day, restart_hour, 0, 0._dp)
       dropDatetime = restDatetime%add_sec(-dt, calendar, ierr, cmessage)
       if(ierr/=0) then; message=trim(message)//trim(cmessage)//' [ dropDatetime for periodical restart]'; return; endif
@@ -636,7 +636,7 @@ CONTAINS
     case('never')
       dropDatetime = datetime(integerMissing, integerMissing, integerMissing, integerMissing, integerMissing, realMissing)
     case default
-      ierr=20; message=trim(message)//'Current accepted <restart_write> options: last, never, specified, annual, monthly, daily'; return
+      ierr=20; message=trim(message)//'Accepted <restart_write> options (case insensitive): last, never, specified, yearly, monthly, or daily '; return
   end select
 
  END SUBROUTINE init_time

--- a/route/build/src/standalone/read_remap.f90
+++ b/route/build/src/standalone/read_remap.f90
@@ -1,35 +1,33 @@
-module read_remap
-! data types
-use nrtype
+MODULE read_remap
 
+USE nrtype
 ! global data
 USE public_var
 
 ! Netcdf
-use ncio_utils, only:get_nc
-use ncio_utils, only:get_nc_dim_len
+USE ncio_utils, ONLY: get_nc
+USE ncio_utils, ONLY: get_nc_dim_len
 
 implicit none
 
-! privacy
 private
 public::get_remap_data
 
-contains
+CONTAINS
 
  ! *****
  ! public subroutine: get mapping data between runoff hru and river network hru...
  ! ********************************************************************************
- subroutine get_remap_data(fname,         &   ! input: file name
+ SUBROUTINE get_remap_data(fname,         &   ! input: file name
                            nSpatial,      &   ! input: number of spatial elements
                            remap_data_in, &   ! output: data structure to remap data from a polygon
                            ierr, message)     ! output: error control
- USE dataTypes,  only : remap                 ! remapping data type
+ USE dataTypes, ONLY: remap                 ! remapping data type
+
  implicit none
- ! input variables
+ ! Argument variables
  character(*), intent(in)           :: fname           ! filename
  integer(i4b), intent(in)           :: nSpatial(1:2)   ! number of spatial elements
- ! output variables
  type(remap),  intent(out)          :: remap_data_in   ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
  integer(i4b), intent(out)          :: ierr            ! error code
  character(*), intent(out)          :: message         ! error message
@@ -39,7 +37,6 @@ contains
  integer(i4b)                       :: nData           ! number of data (weight, runoff hru id) in mapping files
  character(len=strLen)              :: cmessage        ! error message from subroutine
 
- ! initialize error control
  ierr=0; message='get_remap_data/'
 
  ! get the number of HRUs
@@ -85,19 +82,20 @@ contains
  call check_remap_data(remap_data_in, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- end subroutine
+ END SUBROUTINE get_remap_data
 
  ! *****
  ! public subroutine: check spatial weight files
  ! ********************************************************************************
- subroutine check_remap_data(remap_data_in, &   ! inout: data structure to remap data
+ SUBROUTINE check_remap_data(remap_data_in, &   ! inout: data structure to remap data
                              ierr, message)     ! output: error control
- USE dataTypes,          ONLY : remap           ! remapping data type
- USE nr_utility_module,  ONLY : arth
+
+ USE dataTypes, ONLY: remap           ! remapping data type
+ USE nr_utils,  ONLY: arth
+
  implicit none
- ! input/output variables
+ ! Argument variables
  type(remap),  intent(inout)        :: remap_data_in     ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
- ! output variables
  integer(i4b), intent(out)          :: ierr              ! error code
  character(*), intent(out)          :: message           ! error message
  ! local variables
@@ -111,7 +109,6 @@ contains
  real(dp),     allocatable          :: real_array(:)     !
  integer(i8b), allocatable          :: int_array(:)      !
 
- ! initialize error control
  ierr=0; message='check_remap_data/'
 
  total_intersects = sum(remap_data_in%num_qhru)
@@ -169,6 +166,6 @@ contains
    end if
  end if
 
- end subroutine
+ END SUBROUTINE check_remap_data
 
-end module read_remap
+END MODULE read_remap

--- a/route/build/src/time_utils.f90
+++ b/route/build/src/time_utils.f90
@@ -26,85 +26,13 @@ USE public_var, ONLY: secprday,secprhour,secprmin, &   ! seconds in an (day, hou
 implicit none
 private
 public::extractTime
-public::ndays_month
-public::isLeapYear
 public::compJulday
 public::compJulday_noleap
 public::compCalday
 public::compCalday_noleap
 public::elapsedSec
+
 CONTAINS
-
- ! ******************************************************************************************
- ! public function: check leap year or not
- ! ******************************************************************************************
- logical(lgt) function isLeapYear(yr)
- implicit none
- integer(i4b), intent(in)  :: yr
- if (mod(yr, 4) == 0) then
-   if (mod(yr, 100) == 0) then
-     if (mod(yr, 400) == 0) then
-       isLeapYear = .True.
-     else
-       isLeapYear = .False.
-     end if
-   else
-     isLeapYear = .True.
-   end if
- else
-   isLeapYear = .False.
- end if
- end function isLeapYear
-
- ! ******************************************************************************************
- ! public subroutine: get number of days within a month
- ! ******************************************************************************************
- subroutine ndays_month(yr, mo, calendar, ndays, ierr, message)
- USE ascii_util_module, ONLY : lower ! convert string to lower case
- implicit none
- ! input
- integer(i4b),intent(in)           :: yr
- integer(i4b),intent(in)           :: mo
- character(*),intent(in)           :: calendar
- ! output
- integer(i4b)         ,intent(out) :: ndays     !
- integer(i4b),         intent(out) :: ierr         ! error code
- character(len=strLen),intent(out) :: message     ! error message
- ! local variables
- integer(i4b)                      :: yr_next, mo_next
- real(dp)                          :: julday1, julday2
- character(len=strLen)             :: cmessage          ! error message of downwind routine
-
- ierr=0; message="ndays_month/"
-
- select case(lower(trim(calendar)))
-   case ('standard','gregorian','proleptic_gregorian')
-     call compJulday(yr,mo,1,0,0,0._dp,julday1,ierr,cmessage)
-   case('noleap')
-     call compJulday_noleap(yr,mo,1,0,0,0._dp,julday1,ierr,cmessage)
-   case default; ierr=20; message=trim(message)//'calendar name: '//trim(calendar)//' invalid'; return
- end select
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
- if (mo == 12) then
-   mo_next = 1
-   yr_next = yr+1
- else
-   yr_next = yr
-   mo_next = mo+1
- end if
- select case(lower(trim(calendar)))
-   case ('standard','gregorian','proleptic_gregorian')
-     call compJulday(yr_next,mo_next,1,0,0,0._dp,julday2,ierr,cmessage)
-   case('noleap')
-     call compJulday_noleap(yr_next,mo_next,1,0,0,0._dp,julday2,ierr,cmessage)
-   case default; ierr=20; message=trim(message)//'calendar name: '//trim(calendar)//' invalid'; return
- end select
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
- ndays = nint(julday2-julday1)
-
- end subroutine ndays_month
 
  ! ******************************************************************************************
  ! public subroutine extractTime: extract year/month/day/hour/minute/second from units string

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -46,7 +46,7 @@ USE globalData,        ONLY: pioSystem
 USE globalData,        ONLY: runMode
 USE globalData,        ONLY: rfileout
 
-USE nr_utility_module, ONLY: arth
+USE nr_utils,          ONLY: arth
 USE pio_utils
 
 implicit none
@@ -106,7 +106,7 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE restart_alarm(restartAlarm, ierr, message)
 
-   USE ascii_util_module, ONLY: lower
+   USE ascii_utils, ONLY: lower
    USE public_var,        ONLY: calendar
    USE public_var,        ONLY: restart_write  ! restart write options
    USE public_var,        ONLY: restart_day

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -13,7 +13,7 @@ USE globalData,     ONLY: masterproc
 USE globalData,     ONLY: hfileout, hfileout_gage, rfileout
 USE historyFile,    ONLY: histFile
 USE io_rpointfile,  ONLY: io_rpfile
-USE ascii_util_module, ONLY: lower
+USE ascii_utils,    ONLY: lower
 USE pio_utils
 
 implicit none
@@ -159,7 +159,7 @@ CONTAINS
    USE globalData, ONLY: rch_per_proc      ! number of reaches assigned to each proc (size = num of procs+1)
    USE globalData, ONLY: nRch_mainstem     ! number of mainstem reach
    USE globalData, ONLY: nTribOutlet       ! number of
-   USE nr_utility_module, ONLY: arth
+   USE nr_utils,   ONLY: arth
 
    implicit none
    ! Argument variables:
@@ -205,7 +205,7 @@ CONTAINS
 
    USE globalData,        ONLY: hru_per_proc      ! number of hrus assigned to each proc (size = num of procs+1)
    USE globalData,        ONLY: rch_per_proc      ! number of reaches assigned to each proc (size = num of procs+1)
-   USE nr_utility_module, ONLY: arth
+   USE nr_utils,          ONLY: arth
 
    implicit none
    ! Argument variables

--- a/route/build/src/write_streamSeg.f90
+++ b/route/build/src/write_streamSeg.f90
@@ -1,8 +1,7 @@
 MODULE write_streamSeg
 
 ! data types
-USE nrtype,    ONLY: i4b,dp,lgt
-USE nrtype,    ONLY: strLen               ! string length
+USE nrtype
 USE dataTypes, ONLY: var_ilength          ! integer type:          var(:)%dat
 USE dataTypes, ONLY: var_dlength          ! double precision type: var(:)%dat
 USE dataTypes, ONLY: var_clength          ! character type:        var(:)%dat
@@ -34,8 +33,8 @@ USE netcdf
 USE ncio_utils, ONLY: write_nc
 
 ! external utilities
-USE nr_utility_module, ONLY: indexx  ! Num. Recipies utilities
-USE nr_utility_module, ONLY: arth    ! Num. Recipies utilities
+USE nr_utils, ONLY: indexx  !
+USE nr_utils, ONLY: arth    !
 
 implicit none
 


### PR DESCRIPTION
- utility module f90 ends with _utils.f90. 
- module name is the same as module f90 name
- remove two date utility subroutines (both are in datetime_data.f90)

For some reason, duplicated commits:  commit 83958656d70b96195821f3fe94a091d92d01efad (included here) and 3ffcc38cb4214a361d8836fe7a4a54e7106cc274