### PR TITLE
Fixed default value for newFileFrequency

### DIFF
--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -116,9 +116,9 @@ MODULE public_var
   character(len=strLen),public    :: simEnd               = ''              ! date string defining the end of the simulation
   character(len=10)    ,public    :: routOpt              = '0'             ! routing scheme options  0: accum runoff, 1:IRF, 2:KWT, 3:KW, 4:MC, 5:DW
   integer(i4b)         ,public    :: doesBasinRoute       = 1               ! basin routing options   0-> no, 1->IRF, otherwise error
-  character(len=strLen),public    :: newFileFrequency     = 'annual'        ! frequency for new output files (day, month, annual, single)
+  character(len=strLen),public    :: newFileFrequency     = 'yearly'        ! frequency for new output files (daily, monthly, yearly, single)
   ! STATES
-  character(len=strLen),public    :: restart_write        = 'never'         ! restart write option: N[n]ever-> never write, L[l]ast -> write at last time step, S[s]pecified, Monthly, Daily
+  character(len=strLen),public    :: restart_write        = 'never'         ! restart write option: never-> never write, last -> write at last time step, specified, yearly, monthly, daily
   character(len=strLen),public    :: restart_date         = charMissing     ! specifed restart date
   integer(i4b)         ,public    :: restart_month        = 1               ! restart periodic month. Default Jan (write every January of year)
   integer(i4b)         ,public    :: restart_day          = 1               ! restart periodic day.   Default 1st (write every 1st of month)


### PR DESCRIPTION
With this fix, mizuRoute can run without <newFileFrequency> control variable in the control file, and output every year