### PR TITLE
Direct insertion of observed discharge - serial code

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -275,6 +275,7 @@ end type subdomain
   type(fluxes), allocatable            :: ROUTE(:)          ! reach fluxes and states for each routing method
   real(dp)                             :: TAKE              ! water abstraction/injection [m3/s]
   real(dp)                             :: QOBS              ! observed flow [m3/s]
+  integer(i4b)                         :: Qelapsed          ! number of time step after observed flow is read [-]
  ENDTYPE STRFLX
 
  ! ---------- lake data types -----------------------------------------------------------------

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -262,6 +262,7 @@ end type subdomain
  type, public :: fluxes
    real(dp)        :: REACH_Q
    real(dp)        :: REACH_VOL(0:1)
+   real(dp)        :: Qerror
  end type fluxes
 
  ! fluxes in each reach
@@ -272,7 +273,8 @@ end type subdomain
   real(dp)                             :: BASIN_QR(0:1)     ! routed runoff volume from the local basin (m3/s)
   real(dp)                             :: BASIN_QR_IRF(0:1) ! routed runoff volume from all the upstream basin (m3/s)
   type(fluxes), allocatable            :: ROUTE(:)          ! reach fluxes and states for each routing method
-  real(dp)                             :: TAKE              ! average take
+  real(dp)                             :: TAKE              ! water abstraction/injection [m3/s]
+  real(dp)                             :: QOBS(0:1)         ! observed flow [m3/s]
  ENDTYPE STRFLX
 
  ! ---------- lake data types -----------------------------------------------------------------

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -274,7 +274,7 @@ end type subdomain
   real(dp)                             :: BASIN_QR_IRF(0:1) ! routed runoff volume from all the upstream basin (m3/s)
   type(fluxes), allocatable            :: ROUTE(:)          ! reach fluxes and states for each routing method
   real(dp)                             :: TAKE              ! water abstraction/injection [m3/s]
-  real(dp)                             :: QOBS(0:1)         ! observed flow [m3/s]
+  real(dp)                             :: QOBS              ! observed flow [m3/s]
  ENDTYPE STRFLX
 
  ! ---------- lake data types -----------------------------------------------------------------

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -174,10 +174,8 @@ CONTAINS
      if (qmodOption==1) then
        if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then
          RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS
-       else
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror, 0.0001)
        end if
+       RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror, 0.0001)
      end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
    end do

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -171,8 +171,13 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-     if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%TAKE>0._dp) then
-       RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%TAKE
+     if (qmodOption==1) then
+       if (RCHFLX_out(iens,iRch_ups)%QOBS(1)>0._dp) then
+         RCHFLX_out(iens, iRch_ups)%QOBS(0) = RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS(1) ! compute error
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS(1)
+       else
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(0), 0.0001)
+       end if
      end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
    end do

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -13,6 +13,7 @@ USE public_var,  ONLY: iulog             ! i/o logical unit number
 USE public_var,  ONLY: realMissing       ! missing value for real number
 USE public_var,  ONLY: integerMissing    ! missing value for integer number
 USE public_var,  ONLY: qmodOption        ! qmod option (use 1==direct insertion)
+USE public_var,  ONLY: ntsQmodStop       ! number of time steps for which direct insertion is performed
 USE globalData,  ONLY: idxDW
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
@@ -171,12 +172,17 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+
      if (qmodOption==1) then
        if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then
          RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
        end if
+       if (RCHFLX_out(iens,iRch_ups)%Qelapsed > ntsQmodStop) then
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%Qerror=0._dp
+       end if
        RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror, 0.0001)
      end if
+
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
    end do
  endif

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -172,11 +172,11 @@ CONTAINS
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
      if (qmodOption==1) then
-       if (RCHFLX_out(iens,iRch_ups)%QOBS(1)>0._dp) then
-         RCHFLX_out(iens, iRch_ups)%QOBS(0) = RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS(1) ! compute error
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS(1)
+       if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS
        else
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(0), 0.0001)
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror, 0.0001)
        end if
      end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q

--- a/route/build/src/get_basin_runoff.f90
+++ b/route/build/src/get_basin_runoff.f90
@@ -87,8 +87,8 @@ CONTAINS
 !  write(*,"(A,1PG15.7,A)") '  elapsed-time [runoff_input/remap] = ', elapsedTime, ' s'
 
   ! initialize TAKE for water abstract/injection
-  RCHFLX(:,:)%TAKE    = 0.0_dp
-  RCHFLX(:,:)%QOBS(1) = 0.0_dp
+  RCHFLX(:,:)%TAKE = 0.0_dp
+  RCHFLX(:,:)%QOBS = 0.0_dp
   select case(qmodOption)
     case(no_mod) ! do nothing
     case(direct_insert)
@@ -107,7 +107,7 @@ CONTAINS
           qobs = gage_obs_data%get_obs(tix=1, six=ix)
 
           if (isnan(qobs) .or. qobs<0) cycle
-          RCHFLX(iens,reach_ix(ix))%QOBS(1) = qobs
+          RCHFLX(iens,reach_ix(ix))%QOBS = qobs
         end do
       end if
     case(qtake)

--- a/route/build/src/get_basin_runoff.f90
+++ b/route/build/src/get_basin_runoff.f90
@@ -86,15 +86,16 @@ CONTAINS
 !  elapsedTime = real(endTime-startTime, kind(dp))/real(cr)
 !  write(*,"(A,1PG15.7,A)") '  elapsed-time [runoff_input/remap] = ', elapsedTime, ' s'
 
-  ! initialize TAKE for water take or direct insersion
-  RCHFLX(:,:)%TAKE = 0.0_dp
+  ! initialize TAKE for water abstract/injection
+  RCHFLX(:,:)%TAKE    = 0.0_dp
+  RCHFLX(:,:)%QOBS(1) = 0.0_dp
   select case(qmodOption)
     case(no_mod) ! do nothing
     case(direct_insert)
       ! read gage observation [m3/s] at current time
       jx = gage_obs_data%time_ix(modTime(1))
 
-      if (jx/=integerMissing) then
+      if (jx/=integerMissing) then ! there is observation at this time step
         call gage_obs_data%read_obs(ierr, cmessage, index_time=jx)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
@@ -106,7 +107,7 @@ CONTAINS
           qobs = gage_obs_data%get_obs(tix=1, six=ix)
 
           if (isnan(qobs) .or. qobs<0) cycle
-          RCHFLX(iens,reach_ix(ix))%TAKE = qobs
+          RCHFLX(iens,reach_ix(ix))%QOBS(1) = qobs
         end do
       end if
     case(qtake)

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -187,11 +187,11 @@ CONTAINS
     do iUps = 1,nUps
       iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
       if (qmodOption==1) then
-        if (RCHFLX_out(iens,iRch_ups)%QOBS(1)>0._dp) then
-          RCHFLX_out(iens, iRch_ups)%QOBS(0) = RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(1) ! compute error
-          RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS(1)
+        if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then ! there is observation
+          RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
+          RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS
         else
-          RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(0), 0.0001)
+          RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxIRF)%Qerror, 0.0001)
         end if
       end if
       q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -166,7 +166,7 @@ CONTAINS
  character(len=strLen)                    :: fmt1           ! format string
  character(len=strLen)                    :: cmessage       ! error message from subroutine
 
- ierr=0; message='segment_irf/'
+ ierr=0; message='irf_rch/'
 
  ! initialize future discharge array at first time
   if (.not.allocated(RCHFLX_out(iens,segIndex)%QFUTURE_IRF))then
@@ -186,8 +186,13 @@ CONTAINS
   if (nUps>0) then
     do iUps = 1,nUps
       iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-      if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%TAKE>0._dp) then
-        RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,iRch_ups)%TAKE
+      if (qmodOption==1) then
+        if (RCHFLX_out(iens,iRch_ups)%QOBS(1)>0._dp) then
+          RCHFLX_out(iens, iRch_ups)%QOBS(0) = RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(1) ! compute error
+          RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS(1)
+        else
+          RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(0), 0.0001)
+        end if
       end if
       q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q
     end do

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -189,10 +189,8 @@ CONTAINS
       if (qmodOption==1) then
         if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then ! there is observation
           RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
-          RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS
-        else
-          RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxIRF)%Qerror, 0.0001)
         end if
+        RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxIRF)%Qerror, 0.0001)
       end if
       q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxIRF)%REACH_Q
     end do

--- a/route/build/src/kw_route.f90
+++ b/route/build/src/kw_route.f90
@@ -176,11 +176,11 @@ CONTAINS
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
      if (qmodOption==1) then
-       if (RCHFLX_out(iens,iRch_ups)%QOBS(1)>0._dp) then ! there is observation
-         RCHFLX_out(iens, iRch_ups)%QOBS(0) = RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS(1) ! compute error
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS(1)
+       if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then ! there is observation
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS
        else
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(0), 0.0001)
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror, 0.0001)
        end if
      end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q

--- a/route/build/src/kw_route.f90
+++ b/route/build/src/kw_route.f90
@@ -175,8 +175,13 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-     if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%TAKE>0._dp) then
-       RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%TAKE
+     if (qmodOption==1) then
+       if (RCHFLX_out(iens,iRch_ups)%QOBS(1)>0._dp) then ! there is observation
+         RCHFLX_out(iens, iRch_ups)%QOBS(0) = RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS(1) ! compute error
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS(1)
+       else
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(0), 0.0001)
+       end if
      end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q
    end do
@@ -372,7 +377,6 @@ CONTAINS
  ! compute volume
  rflux%ROUTE(idxKW)%REACH_VOL(0) = rflux%ROUTE(idxKW)%REACH_VOL(1)
  rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dt
- rflux%ROUTE(idxKW)%REACH_VOL(1) = max(rflux%ROUTE(idxKW)%REACH_VOL(1), 0._dp)
 
  ! add catchment flow
  rflux%ROUTE(idxKW)%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)

--- a/route/build/src/kw_route.f90
+++ b/route/build/src/kw_route.f90
@@ -15,6 +15,7 @@ USE public_var, ONLY: iulog             ! i/o logical unit number
 USE public_var, ONLY: realMissing       ! missing value for real number
 USE public_var, ONLY: integerMissing    ! missing value for integer number
 USE public_var, ONLY: qmodOption        ! qmod option (use 1==direct insertion)
+USE public_var, ONLY: ntsQmodStop       ! number of time steps for which direct insertion is performed
 USE globalData, ONLY: idxKW
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
@@ -175,13 +176,18 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+
      if (qmodOption==1) then
        if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then ! there is observation
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
+         RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror = RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
        end if
-       RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror, 0.0001)
+       if (RCHFLX_out(iens,iRch_ups)%Qelapsed > ntsQmodStop) then
+         RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror=0._dp
+       end if
+       RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%REACH_Q = max(RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror, 0.0001)
      end if
-     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q
+
+     q_upstream = q_upstream + RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%REACH_Q
    end do
  endif
 

--- a/route/build/src/kw_route.f90
+++ b/route/build/src/kw_route.f90
@@ -178,10 +178,8 @@ CONTAINS
      if (qmodOption==1) then
        if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then ! there is observation
          RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS
-       else
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror, 0.0001)
        end if
+       RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror, 0.0001)
      end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxKW)%REACH_Q
    end do

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -176,10 +176,8 @@ CONTAINS
      if (qmodOption==1) then
        if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then ! there is observation
          RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS
-       else
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror, 0.0001)
        end if
+       RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror, 0.0001)
      end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
    end do

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -173,8 +173,13 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-     if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%TAKE>0._dp) then
-       RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = RCHFLX_out(iens,iRch_ups)%TAKE
+     if (qmodOption==1) then
+       if (RCHFLX_out(iens,iRch_ups)%QOBS(1)>0._dp) then ! there is observation
+         RCHFLX_out(iens, iRch_ups)%QOBS(0) = RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS(1) ! compute error
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS(1)
+       else
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(0), 0.0001)
+       end if
      end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
    end do
@@ -383,7 +388,6 @@ CONTAINS
  ! compute volume
  rflux%ROUTE(idxMC)%REACH_VOL(0) = rflux%ROUTE(idxMC)%REACH_VOL(1)
  rflux%ROUTE(idxMC)%REACH_VOL(1) = rflux%ROUTE(idxMC)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dt
- rflux%ROUTE(idxMC)%REACH_VOL(1) = max(rflux%ROUTE(idxMC)%REACH_VOL(1), 0._dp)
 
  ! add catchment flow
  rflux%ROUTE(idxMC)%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -15,6 +15,7 @@ USE public_var,  ONLY: iulog             ! i/o logical unit number
 USE public_var,  ONLY: realMissing       ! missing value for real number
 USE public_var,  ONLY: integerMissing    ! missing value for integer number
 USE public_var,  ONLY: qmodOption        ! qmod option (use 1==direct insertion)
+USE public_var,  ONLY: ntsQmodStop       ! number of time steps for which direct insertion is performed
 USE globalData,  ONLY: idxMC             ! index of IRF method
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
@@ -173,13 +174,18 @@ CONTAINS
    isHW = .false.
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
+
      if (qmodOption==1) then
        if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then ! there is observation
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
+         RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror = RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
        end if
-       RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror, 0.0001)
+       if (RCHFLX_out(iens,iRch_ups)%Qelapsed > ntsQmodStop) then
+         RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror=0._dp
+       end if
+       RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%REACH_Q = max(RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror, 0.0001)
      end if
-     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
+
+     q_upstream = q_upstream + RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%REACH_Q
    end do
  endif
 

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -174,11 +174,11 @@ CONTAINS
    do iUps = 1,nUps
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
      if (qmodOption==1) then
-       if (RCHFLX_out(iens,iRch_ups)%QOBS(1)>0._dp) then ! there is observation
-         RCHFLX_out(iens, iRch_ups)%QOBS(0) = RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS(1) ! compute error
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS(1)
+       if (RCHFLX_out(iens,iRch_ups)%QOBS>0._dp) then ! there is observation
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%Qerror = RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q - RCHFLX_out(iens,iRch_ups)%QOBS ! compute error
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = RCHFLX_out(iens,iRch_ups)%QOBS
        else
-         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q-RCHFLX_out(iens,iRch_ups)%QOBS(0), 0.0001)
+         RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror, 0.0001)
        end if
      end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q

--- a/route/build/src/model_finalize.f90
+++ b/route/build/src/model_finalize.f90
@@ -2,7 +2,8 @@ MODULE model_finalize
 
 USE nrtype
 USE public_var, ONLY: iulog            ! i/o logical unit number
-USE public_var, ONLY: qmodOption       !
+USE public_var, ONLY: qmodOption       ! option for streamflow modification (DA)
+USE public_var, ONLY: takeWater        ! switch for water abstraction/injection
 USE globalData, ONLY: gage_obs_data
 USE globalData, ONLY: rch_qtake_data
 
@@ -22,11 +23,8 @@ CONTAINS
   integer(i4b)      :: ierr             ! error code
   character(strLen) :: cmessage         ! error message
 
-  if (qmodOption==1) then
-    call gage_obs_data%closeNC(ierr, cmessage)
-  else if (qmodOption==2) then
-    call rch_qtake_data%closeNC(ierr, cmessage)
-  end if
+  if (qmodOption/=0) call gage_obs_data%closeNC(ierr, cmessage)
+  if (takeWater) call rch_qtake_data%closeNC(ierr, cmessage)
 
   write(iulog,'(a)') new_line('a'), '--------------------'
   write(iulog,'(a)')                'Finished simulation'

--- a/route/build/src/model_setup.f90
+++ b/route/build/src/model_setup.f90
@@ -262,6 +262,8 @@ CONTAINS
     RCHFLX(:,:)%BASIN_QI = 0._dp
     RCHFLX(:,:)%BASIN_QR(0) = 0._dp
     RCHFLX(:,:)%BASIN_QR(1) = 0._dp
+    RCHFLX(:,:)%QOBS(0) = 0._dp
+    RCHFLX(:,:)%QOBS(1) = 0._dp
 
     do iRoute = 1, nRoutes
       if (routeMethods(iRoute)==impulseResponseFunc) then

--- a/route/build/src/model_setup.f90
+++ b/route/build/src/model_setup.f90
@@ -262,22 +262,23 @@ CONTAINS
     RCHFLX(:,:)%BASIN_QI = 0._dp
     RCHFLX(:,:)%BASIN_QR(0) = 0._dp
     RCHFLX(:,:)%BASIN_QR(1) = 0._dp
-    RCHFLX(:,:)%QOBS(0) = 0._dp
-    RCHFLX(:,:)%QOBS(1) = 0._dp
 
     do iRoute = 1, nRoutes
       if (routeMethods(iRoute)==impulseResponseFunc) then
         do ix = 1, size(RCHSTA(1,:))
           RCHFLX(iens,ix)%ROUTE(iRoute)%REACH_VOL(0:1) = 0._dp
+          RCHFLX(iens,ix)%ROUTE(iRoute)%Qerror = 0._dp
         end do
       else if (routeMethods(iRoute)==kinematicWaveTracking) then
         do ix = 1, size(RCHSTA(1,:))
           RCHFLX(iens,ix)%ROUTE(iRoute)%REACH_VOL(0:1) = 0._dp
+          RCHFLX(iens,ix)%ROUTE(iRoute)%Qerror = 0._dp
         end do
       else if (routeMethods(iRoute)==kinematicWave) then
         nMolecule%KW_ROUTE = 2
         do ix = 1, size(RCHSTA(1,:))
           RCHFLX(iens,ix)%ROUTE(iRoute)%REACH_VOL(0:1) = 0._dp
+          RCHFLX(iens,ix)%ROUTE(iRoute)%Qerror = 0._dp
           allocate(RCHSTA(iens,ix)%KW_ROUTE%molecule%Q(nMolecule%KW_ROUTE), stat=ierr, errmsg=cmessage)
           if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA]'; return; endif
           RCHSTA(iens,ix)%KW_ROUTE%molecule%Q(:) = 0._dp
@@ -286,6 +287,7 @@ CONTAINS
         nMolecule%MC_ROUTE = 2
         do ix = 1, size(RCHSTA(1,:))
           RCHFLX(iens,ix)%ROUTE(iRoute)%REACH_VOL(0:1) = 0._dp
+          RCHFLX(iens,ix)%ROUTE(iRoute)%Qerror = 0._dp
           allocate(RCHSTA(iens,ix)%MC_ROUTE%molecule%Q(nMolecule%MC_ROUTE), stat=ierr, errmsg=cmessage)
           if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA]'; return; endif
           RCHSTA(iens,ix)%MC_ROUTE%molecule%Q(:) = 0._dp
@@ -294,6 +296,7 @@ CONTAINS
         nMolecule%DW_ROUTE = 5
         do ix = 1, size(RCHSTA(1,:))
           RCHFLX(iens,ix)%ROUTE(iRoute)%REACH_VOL(0:1) = 0._dp
+          RCHFLX(iens,ix)%ROUTE(iRoute)%Qerror = 0._dp
           allocate(RCHSTA(iens,ix)%DW_ROUTE%molecule%Q(nMolecule%DW_ROUTE), stat=ierr, errmsg=cmessage)
           if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA]'; return; endif
           RCHSTA(iens,ix)%DW_ROUTE%molecule%Q(:) = 0._dp

--- a/route/build/src/ncio_utils.f90
+++ b/route/build/src/ncio_utils.f90
@@ -11,6 +11,7 @@ public::get_nc
 public::get_var_dims
 public::get_nc_dim_len
 public::get_var_attr
+public::check_variable
 public::check_attr
 public::put_global_attr
 public::def_nc
@@ -205,8 +206,29 @@ CONTAINS
 
  end subroutine get_nc_dim_len
 
+
  ! *********************************************************************
- ! subroutine: get attribute values for a variable
+ ! function: check if attribute in a variable exist
+ ! *********************************************************************
+ FUNCTION check_variable(ncid, vname)
+   implicit none
+   ! input
+   integer(i4b), intent(in)        :: ncid         ! NetCDF file ID
+   character(*), intent(in)        :: vname        ! variable name
+   logical(lgt)                    :: check_variable
+   ! local
+   integer(i4b)                    :: ierr         ! error code
+   integer(i4b)                    :: iVarID       ! variable ID
+
+   ! get the ID of the variable
+   ierr = nf90_inq_varid(ncid, trim(vname), iVarID)
+   check_variable = (ierr==nf90_noerr)
+
+ END FUNCTION check_variable
+
+
+ ! *********************************************************************
+ ! function: check if attribute in a variable exist
  ! *********************************************************************
  FUNCTION check_attr(ncid, vname, attr_name)
    implicit none

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -178,18 +178,22 @@ CONTAINS
  ! Kinematic Wave
  call meta_kw(ixKW%qsub  )%init('q_sub_kw',  'flow at computational moelcule', 'm3/s', nf90_double, [ixStateDims%seg,ixStateDims%mol_kw,ixStateDims%ens], .false.)
  call meta_kw(ixKW%volume)%init('volume_kw', 'reach volume'                  , 'm3'  , nf90_double, [ixStateDims%seg,ixStateDims%ens]                   , .false.)
+ call meta_kw(ixKW%qerror)%init('qerror_kw', 'discharge error'               , 'm3'  , nf90_double, [ixStateDims%seg,ixStateDims%ens]                   , .true.)
 
  ! Diffusive Wave
  call meta_dw(ixDW%qsub  )%init('q_sub_dw',  'flow at computational moelcule', 'm3/s', nf90_double, [ixStateDims%seg,ixStateDims%mol_dw,ixStateDims%ens], .false.)
  call meta_dw(ixDW%volume)%init('volume_dw', 'reach volume'                  , 'm3'  , nf90_double, [ixStateDims%seg,ixStateDims%ens]                   , .false.)
+ call meta_dw(ixDW%qerror)%init('qerror_dw', 'discharge error'               , 'm3'  , nf90_double, [ixStateDims%seg,ixStateDims%ens]                   , .true.)
 
  ! Muskingum-cunge
  call meta_mc(ixMC%qsub  )%init('q_sub_mc',  'flow at computational molecule', 'm3/s', nf90_double, [ixStateDims%seg,ixStateDims%mol_mc,ixStateDims%ens], .false.)
  call meta_mc(ixMC%volume)%init('volume_mc', 'reach volume'                  , 'm3'  , nf90_double, [ixStateDims%seg,ixStateDims%ens]                   , .false.)
+ call meta_mc(ixMC%qerror)%init('qerror_mc', 'discharge error'               , 'm3'  , nf90_double, [ixStateDims%seg,ixStateDims%ens]                   , .true.)
 
  ! Impulse Response Function
  call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series', 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%tdh_irf,ixStateDims%ens] , .true.)
  call meta_irf(ixIRF%volume )%init('irf_volume' , 'IRF reach volume'  , 'm3'     ,nf90_double, [ixStateDims%seg,ixStateDims%ens]                     , .true.)
+ call meta_irf(ixIRF%qerror )%init('qerror_irf' , 'discharge error'   , 'm3'     ,nf90_double, [ixStateDims%seg,ixStateDims%ens]                     , .true.)
 
  ! Basin Impulse Response Function
  call meta_irf_bas(ixIRFbas%qfuture)%init('qfuture', 'future flow series', 'm3/sec' ,nf90_double, [ixStateDims%seg,ixStateDims%tdh,ixStateDims%ens], .true.)

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -144,7 +144,9 @@ MODULE public_var
   character(len=strLen),public    :: dname_wtReach        = ''              ! dimension name for reach ID
   character(len=strLen),public    :: dname_wtTime         = ''              ! dimension name for time
   ! USER OPTIONS
-  integer(i4b)         ,public    :: qmodOption           = 0               ! option for streamflow modification
+  integer(i4b)         ,public    :: qmodOption           = 0               ! options for streamflow modification (DA): 0-> no DA, 1->direct insertion
+  integer(i4b)         ,public    :: ntsQmodStop          = 10              ! number of time steps for which streamflow modification is performed
+  logical(lgt)         ,public    :: takeWater            = .false.         ! switch for water abstraction and injection
   integer(i4b)         ,public    :: hydGeometryOption    = compute         ! option for hydraulic geometry calculations (0=read from file, 1=compute)
   integer(i4b)         ,public    :: topoNetworkOption    = compute         ! option for network topology calculations (0=read from file, 1=compute)
   integer(i4b)         ,public    :: computeReachList     = compute         ! option to compute list of upstream reaches (0=do not compute, 1=compute)

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -149,7 +149,9 @@ CONTAINS
    ! SPATIAL CONSTANT PARAMETERS
    case('<param_nml>');            param_nml       = trim(cData)                   ! name of namelist including routing parameter value
    ! USER OPTIONS: Define options to include/skip calculations
-   case('<qmodOption>');           read(cData,*,iostat=io_error) qmodOption       ! option for abstraction/injection option
+   case('<qmodOption>');           read(cData,*,iostat=io_error) qmodOption        ! option for streamflow modification (DA): 0->no DA, 1->direct insertion
+   case('<ntsQmodStop>');          read(cData,*,iostat=io_error) ntsQmodStop       ! number of time steps for which streamflow modification is performed
+   case('<takeWater>');            read(cData,*,iostat=io_error) takeWater         ! switch for abstraction/injection
    case('<hydGeometryOption>');    read(cData,*,iostat=io_error) hydGeometryOption ! option for hydraulic geometry calculations (0=read from file, 1=compute)
    case('<topoNetworkOption>');    read(cData,*,iostat=io_error) topoNetworkOption ! option for network topology calculations (0=read from file, 1=compute)
    case('<computeReachList>');     read(cData,*,iostat=io_error) computeReachList  ! option to compute list of upstream reaches (0=do not compute, 1=compute)

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -163,21 +163,25 @@ MODULE var_lookup
  type, public  ::  iLook_KW
   integer(i4b)     :: qsub           = integerMissing  ! discharge
   integer(i4b)     :: volume         = integerMissing  ! reach volume
+  integer(i4b)     :: qerror         = integerMissing  ! discharge error
  endtype iLook_KW
  ! DW state/fluxes
  type, public  ::  iLook_DW
   integer(i4b)     :: qsub           = integerMissing  ! discharge
   integer(i4b)     :: volume         = integerMissing  ! reach volume
+  integer(i4b)     :: qerror         = integerMissing  ! discharge error
  endtype iLook_DW
  ! MC state/fluxes
  type, public  ::  iLook_MC
   integer(i4b)     :: qsub           = integerMissing  ! discharge
   integer(i4b)     :: volume         = integerMissing  ! reach volume
+  integer(i4b)     :: qerror         = integerMissing  ! discharge error
  endtype iLook_MC
  !IRF state/fluxes
  type, public  ::  iLook_IRF
   integer(i4b)     :: qfuture        = integerMissing  ! future routed flow
   integer(i4b)     :: volume         = integerMissing  ! reach volume
+  integer(i4b)     :: qerror         = integerMissing  ! discharge error
  endtype iLook_IRF
  ! ***********************************************************************************************************
  ! ** define data vectors
@@ -193,10 +197,10 @@ MODULE var_lookup
  type(iLook_PFAF)     ,public,parameter :: ixPFAF      = iLook_PFAF     (1)
  type(iLook_RFLX)     ,public,parameter :: ixRFLX      = iLook_RFLX     (1,2,3,4,5,6,7,8,9,10)
  type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      (1,2,3,4,5)
- type(iLook_KW)       ,public,parameter :: ixKW        = iLook_KW       (1,2)
- type(iLook_DW)       ,public,parameter :: ixDW        = iLook_DW       (1,2)
- type(iLook_MC)       ,public,parameter :: ixMC        = iLook_MC       (1,2)
- type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      (1,2)
+ type(iLook_KW)       ,public,parameter :: ixKW        = iLook_KW       (1,2,3)
+ type(iLook_DW)       ,public,parameter :: ixDW        = iLook_DW       (1,2,3)
+ type(iLook_MC)       ,public,parameter :: ixMC        = iLook_MC       (1,2,3)
+ type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      (1,2,3)
  type(iLook_IRFbas  ) ,public,parameter :: ixIRFbas    = iLook_IRFbas   (1)
  type(iLook_basinQ  ) ,public,parameter :: ixBasinQ    = iLook_basinQ   (1)
  ! ***********************************************************************************************************

--- a/route/build/src/write_restart.f90
+++ b/route/build/src/write_restart.f90
@@ -1021,7 +1021,7 @@ CONTAINS
   do iVar=1,nVarsIRF
     select case(iVar)
       case(ixIRF%qfuture); allocate(state%var(iVar)%array_3d_dp(nSeg, ntdh_irf, nens), stat=ierr)
-      case(ixIRF%volume);  allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
+      case(ixIRF%volume : ixIRF%qerror);  allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
       case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
     end select
     if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state '//trim(meta_irf(iVar)%varName); return; endif
@@ -1038,6 +1038,8 @@ CONTAINS
             state%var(iVar)%array_3d_dp(iSeg,numQF(iens,iSeg)+1:ntdh_irf,iens) = realMissing
           case(ixIRF%volume)
             state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX(iens,iSeg)%ROUTE(idxIRF)%REACH_VOL(1)
+          case(ixIRF%qerror)
+            state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX(iens,iSeg)%ROUTE(idxIRF)%Qerror
           case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
         end select
       enddo ! variable loop
@@ -1052,7 +1054,7 @@ CONTAINS
     select case(iVar)
       case(ixIRF%qfuture)
         call write_nc(ncid, trim(meta_irf(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,ntdh_irf,nens/), ierr, cmessage)
-      case(ixIRF%volume)
+      case(ixIRF%volume : ixIRF%qerror)
         call write_nc(ncid, trim(meta_irf(iVar)%varName), state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage)
       case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc writing'; return
       if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
@@ -1091,7 +1093,7 @@ CONTAINS
     do iVar=1,nVarsKW
       select case(iVar)
        case(ixKW%qsub);   allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nEns), stat=ierr)
-       case(ixKW%volume); allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
+       case(ixKW%volume : ixKW%qerror); allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
       end select
       if(ierr/=0)then; message1=trim(message1)//'problem allocating space for KW routing state '//trim(meta_kw(iVar)%varName); return; endif
@@ -1106,6 +1108,8 @@ CONTAINS
               state%var(iVar)%array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA(iens, iSeg)%KW_ROUTE%molecule%Q(1:nMesh)
             case(ixKW%volume)
               state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX(iens,iSeg)%ROUTE(idxKW)%REACH_VOL(1)
+            case(ixKW%qerror)
+              state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX(iens,iSeg)%ROUTE(idxKW)%Qerror
             case default; ierr=20; message1=trim(message1)//'unable to identify KW routing state variable index'; return
           end select
         enddo ! variable loop
@@ -1117,7 +1121,7 @@ CONTAINS
       select case(iVar)
        case(ixKW%qsub)
          call write_nc(ncid, trim(meta_kw(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMesh,nens/), ierr, cmessage)
-       case(ixKW%volume)
+       case(ixKW%volume : ixKW%qerror)
          call write_nc(ncid, trim(meta_kw(iVar)%varName), state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage)
        case default; ierr=20; message1=trim(message1)//'unable to identify KW variable index for nc writing'; return
       end select
@@ -1157,7 +1161,7 @@ CONTAINS
     do iVar=1,nVarsMC
       select case(iVar)
        case(ixMC%qsub);   allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nEns), stat=ierr)
-       case(ixMC%volume); allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
+       case(ixMC%volume : ixMC%qerror); allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
       end select
       if(ierr/=0)then; message1=trim(message1)//'problem allocating space for MC routing state '//trim(meta_mc(iVar)%varName); return; endif
@@ -1172,6 +1176,8 @@ CONTAINS
               state%var(iVar)%array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA(iens, iSeg)%MC_ROUTE%molecule%Q(1:nMesh)
             case(ixMC%volume)
               state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX(iens,iSeg)%ROUTE(idxMC)%REACH_VOL(1)
+            case(ixMC%qerror)
+              state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX(iens,iSeg)%ROUTE(idxMC)%Qerror
             case default; ierr=20; message1=trim(message1)//'unable to identify MC routing state variable index'; return
           end select
         enddo ! variable loop
@@ -1183,7 +1189,7 @@ CONTAINS
       select case(iVar)
        case(ixMC%qsub)
          call write_nc(ncid, trim(meta_mc(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMesh,nens/), ierr, cmessage)
-       case(ixMC%volume)
+       case(ixMC%volume : ixMC%qerror)
          call write_nc(ncid, trim(meta_mc(iVar)%varName), state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage)
        case default; ierr=20; message1=trim(message1)//'unable to identify MC variable index for nc writing'; return
       end select
@@ -1224,7 +1230,7 @@ CONTAINS
     do iVar=1,nVarsDW
       select case(iVar)
        case(ixDW%qsub);   allocate(state%var(iVar)%array_3d_dp(nSeg, nMesh, nEns), stat=ierr)
-       case(ixDW%volume); allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
+       case(ixDW%volume : ixDW%qerror); allocate(state%var(iVar)%array_2d_dp(nSeg, nens), stat=ierr)
        case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
       end select
       if(ierr/=0)then; message1=trim(message1)//'problem allocating space for DW routing state '//trim(meta_dw(iVar)%varName); return; endif
@@ -1239,6 +1245,8 @@ CONTAINS
               state%var(iVar)%array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA(iens, iSeg)%DW_ROUTE%molecule%Q(1:nMesh)
             case(ixDW%volume)
               state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX(iens,iSeg)%ROUTE(idxDW)%REACH_VOL(1)
+            case(ixDW%qerror)
+              state%var(iVar)%array_2d_dp(iSeg,iens) = RCHFLX(iens,iSeg)%ROUTE(idxDW)%Qerror
             case default; ierr=20; message1=trim(message1)//'unable to identify DW routing state variable index'; return
           end select
         enddo ! variable loop
@@ -1250,7 +1258,7 @@ CONTAINS
       select case(iVar)
        case(ixDW%qsub)
          call write_nc(ncid, trim(meta_dw(iVar)%varName), state%var(iVar)%array_3d_dp, (/1,1,1/), (/nSeg,nMesh,nens/), ierr, cmessage)
-       case(ixDW%volume)
+       case(ixDW%volume : ixDW%qerror)
          call write_nc(ncid, trim(meta_dw(iVar)%varName), state%var(iVar)%array_2d_dp, (/1,1/), (/nSeg,nens/), ierr, cmessage)
        case default; ierr=20; message1=trim(message1)//'unable to identify DW variable index for nc writing'; return
       end select


### PR DESCRIPTION
In control file, `qmodOption = 1` along with specifications of observed discharge input and gauge meta data enables direct insertion at reaches (reach-gauge link is given meta file) 

With `qmodOption=0` or no specification, routing without direct insertion (so backward compatibility is preserved)

direct insertion is implemented into `IRF` and `KW`, `MC`, `DF` not `KWT` routing method.

