### PR TITLE
move fileVar (variable I/O control) changes in a separate suboutine

### DIFF
--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -161,6 +161,7 @@ CONTAINS
   USE globalData,  ONLY: reachID                ! reach ID vector
   USE globalData,  ONLY: runMode                ! mizuRoute run mode - standalone or ctsm-coupling
   ! external subroutines
+  USE read_streamSeg,       ONLY: mod_meta_varFile         ! modify variable I/O options
   USE model_utils,          ONLY: model_finalize
   USE mpi_process,          ONLY: comm_ntopo_data          ! mpi routine: initialize river network data in slave procs (incl. river data transfer from root proc)
   USE process_ntopo,        ONLY: put_data_struct          ! populate NETOPO and RPARAM data structure
@@ -186,6 +187,10 @@ CONTAINS
 
    ierr=0; message='init_ntopo_data/'
 
+   ! modify river and lake variable I/O options in meta
+   call mod_meta_varFile(ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
    ! populate various river network data strucutures for each proc
    if (masterproc) then
      ! read the river network data and compute additonal network attributes (inncludes spatial decomposition)
@@ -209,7 +214,6 @@ CONTAINS
 
    if (masterproc) then
      ! populate basiID and reachID vectors for output (in only master processor)
-
      allocate(basinID(nHRU), reachID(nRch), stat=ierr)
      if(ierr/=0)then; message=trim(message)//'problem allocating [basinID, reachID]'; return; endif
 


### PR DESCRIPTION
Reason for this PR:

meta data for river variables, e.g., meta_SEG, exist in all the processors. One of meta data component, meta(:)%varFile can change depending on model options. Before this PR, such changes are imbedded in getData routine, which is called in only main processor, so meta(:)%varFile changes happen in only main processor. Without correct varFile in all other processors, the program failed somewhere Line 394-463 in mpr_process.f90. So these changes are put in a separate subroutine (mod_meta_varFile), which is called in all the processors.

This is the same as PR https://github.com/ESCOMP/mizuRoute/pull/323 that was closed.