### PR TITLE
separate simulation time-step and forcing time-step

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -138,10 +138,10 @@ EXTINCLUDES =
 # data types
 DATATYPES = \
     nrtype.f90 \
+    public_var.f90 \
     nr_utils.f90 \
     pio_utils.f90 \
     ascii_utils.f90 \
-    public_var.f90 \
     dataTypes.f90 \
     var_lookup.f90 \
     time_utils.f90 \

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -18,6 +18,7 @@ MODULE RtmMod
   USE RunoffMod,    ONLY: rtmCTL, RunoffInit         ! rof related data objects
 
   ! mizuRoute share routines
+  USE public_var,   ONLY: secprday                   ! second per day
   USE public_var,   ONLY: dt                         ! routing time step
   USE public_var,   ONLY: iulog
   USE public_var,   ONLY: qgwl_runoff_option
@@ -120,7 +121,7 @@ CONTAINS
       if (masterproc) then
         write(iulog,*) 'WARNING: Adjust mizuRoute dt to coupling_period'
       endif
-      dt = coupling_period*60.0*60.0*24.0
+      dt = coupling_period*secprday ! day->sec
     endif
 
     ! mizuRoute time initialize based on time from coupler
@@ -130,8 +131,8 @@ CONTAINS
     if (masterproc) then
       write(iulog,*) 'define run:'
       write(iulog,*) '   run type              = ',runtyp(nsrest+1)
-      write(iulog,*) '   coupling_period       = ',coupling_period, '[day]'
-      write(iulog,*) '   delt_mizuRoute        = ',dt, '[sec]'
+      write(iulog,*) '   coupling_frequency    = ',coupling_period, '[day]'
+      write(iulog,*) '   mizuRoute timestep    = ',dt, '[sec]'
       call shr_sys_flush(iulog)
     endif
 
@@ -384,7 +385,7 @@ CONTAINS
     call t_startf('mizuRoute_tot')
     call shr_sys_flush(iulog)
 
-    delt_coupling = coupling_period*60.0*60.0*24.0   ! day -> sec
+    delt_coupling = coupling_period*secprday   ! day -> sec
     if (first_call) then
       nsub_save = 1
       delt_save = dt

--- a/route/build/cpl/RtmTimeManager.F90
+++ b/route/build/cpl/RtmTimeManager.F90
@@ -110,16 +110,8 @@ CONTAINS
   ! number of time step from reference time to simulation end time
   nTime = int(endJulday - begJulday/dt_day) + 1
 
-  ! Create timeVar array: starting with 0 and increment of model time step in model unit (t_unit)
-  allocate(timeVar(nTime), stat=ierr)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-  timeVar(1) = (begJulday - refJulday)*timePerDay
-  if (nTime>1) then
-    do ix = 2, nTime
-      timeVar(ix) = timeVar(ix-1) + dt/secPerTime
-    end do
-  end if
+  ! Initialize timeVar : starting with 0 and increment of model time step in model time unit (t_unit)
+  timeVar = (begJulday - refJulday)*timePerDay
 
   ! check that the dates are aligned
   if(endDatetime < begDatetime) then; ierr=20; message=trim(message)//'simulation end is before simulation start'; return; endif
@@ -136,7 +128,7 @@ CONTAINS
     write(iulog,*) 'simDatetime           = ', simDatetime(1)%year(), simDatetime(1)%month(), simDatetime(1)%day(), simDatetime(1)%hour(), simDatetime(1)%minute(), simDatetime(1)%sec()
     write(iulog,*) 'dt [sec]              = ', dt
     write(iulog,*) 'nTime                 = ', nTime
-    write(iulog,*) 'iTime, timeVar(iTime) = ', iTime, timeVar(iTime)
+    write(iulog,*) 'iTime, timeVar(iTime) = ', iTime, timeVar
     call shr_sys_flush(iulog)
   end if
 

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -72,15 +72,6 @@ implicit none
    type(reach), allocatable :: branch(:)
  end type subbasin_omp
 
- ! -- Data structures to hold mainstem and independent tributary reaches separately
- !    Used for openMP
- type,public :: subbasin_omp_tmp
-  integer(i4b)               :: outIndex             ! index of outlet segment based on segment array
-  type(reach), allocatable   :: mainstem(:)          ! mainstem reach
-  type(reach), allocatable   :: tributary(:)         ! tributary reach
- end type subbasin_omp_tmp
-
-
  ! ---------- general data structures ----------------------------------------------------------------------
 
  ! ** double precision type

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -158,9 +158,7 @@ implicit none
  ! ---------- forcing and water management data  ----------------------------------------------------------------------
 
  type, public :: inputData
-   integer(i4b)                            :: nTime           ! number of time steps
    integer(i4b)                            :: nSpace(1:2)     ! number of spatial dimension
-   real(dp)                                :: time            ! time variable at one time step
    real(dp)                 , allocatable  :: sim(:)          ! flux simulation (HM_HRU) at one time step (size: nSpace(1))
    real(dp)                 , allocatable  :: sim2d(:,:)      ! flux simulation (x,y) at one time step (size: /nSpace(1),nSpace(2)/)
  end type inputData

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -124,8 +124,7 @@ implicit none
   type, public ::  inFileInfo
    integer(i4b)                            :: nTime            ! number of time step in a nc file
    integer(i4b)                            :: iTimebound(1:2)  ! time index of start and end of the
-   real(dp)                 , allocatable  :: timevar(:)       ! the time varibale from the netcdf file
-   real(dp)                                :: convTime2Days    ! the time varibale from the netcdf file
+   real(dp)                 , allocatable  :: timeVar(:)       ! the time varibale [day] from the netcdf file
    real(dp)                                :: ncrefjulday      ! the julian day for the reference of the nc file
    character(len=strLen)                   :: infilename       ! the name of the input file name
    character(len=strLen)                   :: calendar         ! the calendar

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -161,6 +161,7 @@ implicit none
    integer(i4b)                            :: nSpace(1:2)     ! number of spatial dimension
    real(dp)                 , allocatable  :: sim(:)          ! flux simulation (HM_HRU) at one time step (size: nSpace(1))
    real(dp)                 , allocatable  :: sim2d(:,:)      ! flux simulation (x,y) at one time step (size: /nSpace(1),nSpace(2)/)
+   real(dp)                                :: fillvalue       ! fillvalue
  end type inputData
 
  type, public, extends(inputData) :: runoff

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -148,14 +148,17 @@ implicit none
    integer(i4b)             , allocatable  :: qhru_ix(:)   ! Index of hrus associated with runoff simulation (="qhru")
  end type remap
 
- ! mapping time step between two time series e.g., simulation time step vs runoff time step for one simulation time step
+ ! mapping time step between two time series e.g., simulation time step and runoff time step for one simulation time step
+ ! runoff value used at each simulaition time step is weighted average of runoff(s) across input time step(s)
+ ! (can be one, but several if simulation step is larger than runoff time step)
+ ! This store indices of netCDF files in input file streams and time step weight of input variables from each input timestep
  type, public :: map_time
-   integer(i4b), allocatable :: iFile(:)
-   integer(i4b), allocatable :: iTime(:)
-   real(dp),     allocatable :: frac(:)
+   integer(i4b), allocatable :: iFile(:) ! index of input netCDF file
+   integer(i4b), allocatable :: iTime(:) ! index of time steps within the corresponding netCDF
+   real(dp),     allocatable :: frac(:)  ! weight
  end type map_time
 
- ! ---------- forcing and water management data  ----------------------------------------------------------------------
+ ! ---------- input forcing data  ----------------------------------------------------------------------
 
  type, public :: inputData
    integer(i4b)                            :: nSpace(1:2)     ! number of spatial dimension
@@ -164,19 +167,19 @@ implicit none
    real(dp)                                :: fillvalue       ! fillvalue
  end type inputData
 
- type, public, extends(inputData) :: runoff
+ type, public, extends(inputData) :: runoff  ! runoff data
    integer(i4b)             , allocatable  :: hru_id(:)       ! id of HM_HRUs or RN_HRUs at which runoff is stored (size: nSpace(1))
    integer(i4b)             , allocatable  :: hru_ix(:)       ! Index of RN_HRUs associated with river network (used only if HM_HRUs = RN_HRUs)
-   real(dp)                 , allocatable  :: basinRunoff(:)  ! remapped river network catchment runoff (size: number of nHRU)
-   real(dp)                 , allocatable  :: basinEvapo(:)   ! remapped river network catchment runoff (size: number of nHRU)
-   real(dp)                 , allocatable  :: basinPrecip(:)  ! remapped river network catchment runoff (size: number of nHRU)
+   real(dp)                 , allocatable  :: basinRunoff(:)  ! remapped river network catchment runoff [depth/time] (size: number of nHRU)
+   real(dp)                 , allocatable  :: basinEvapo(:)   ! remapped river network catchment evaporation [depth/time] (size: number of nHRU)
+   real(dp)                 , allocatable  :: basinPrecip(:)  ! remapped river network catchment precipitation [depth/time] (size: number of nHRU)
  end type runoff
 
- type, public, extends(inputData) :: wm
+ type, public, extends(inputData) :: wm  ! water-management
    integer(i4b)             , allocatable  :: seg_id(:)       ! id of reach in data (size: nSpace)
    integer(i4b)             , allocatable  :: seg_ix(:)       ! Index of river network reach IDs corresponding reach ID in data
-   real(dp)                 , allocatable  :: flux_wm(:)      ! allocated flux to existing river network using sort_flux (size: number of nRCH)
-   real(dp)                 , allocatable  :: vol_wm(:)       ! allocated target vol to existing river network using sort_flux (size: number of nRCH)
+   real(dp)                 , allocatable  :: flux_wm(:)      ! allocated flux to existing river network using sort_flux [m3/s] (size: number of nRCH)
+   real(dp)                 , allocatable  :: vol_wm(:)       ! allocated target vol to existing river network using sort_flux [m3/s] (size: number of nRCH)
  end type wm
 
  ! ---------- reach parameters ----------------------------------------------------------------------------

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -11,7 +11,7 @@ MODULE globalData
   USE dataTypes, ONLY: var_info      ! metadata type - variable
   USE objTypes,  ONLY: var_info_new  ! metadata type - variable
 
-  USE dataTypes, ONLY: infileinfo    ! data strture - information of input files
+  USE dataTypes, ONLY: inFileInfo    ! data strture - information of input files
   USE dataTypes, ONLY: gage          ! data structure - gauge metadata
 
   USE dataTypes, ONLY: RCHPRP        ! data structure - Reach parameters (properties)
@@ -25,6 +25,8 @@ MODULE globalData
   USE dataTypes, ONLY: LKFLX         ! data structure - lake fluxes
 
   USE dataTypes, ONLY: remap         ! data structure - remapping data type
+  USE dataTypes, ONLY: map_time      ! time step mapping
+
   USE dataTypes, ONLY: runoff        ! data structure - runoff data type
   USE dataTypes, ONLY: wm            ! data structure - water management (flux to/from segment, target volume) data type
 
@@ -86,7 +88,7 @@ MODULE globalData
   ! ---------- Date/Time data  -------------------------------------------------------------------------
 
   integer(i4b),                    public :: iTime                ! time index at simulation time step
-  real(dp),         allocatable,   public :: timeVar(:)           ! time variables (unit given by runoff data)
+  real(dp),                        public :: timeVar              ! time variables (unit given by time variable)
   real(dp),                        public :: TSEC(0:1)            ! begning and end of time step since simulation started (sec)
   type(datetime),                  public :: simDatetime(0:1)     ! previous and current simulation time (yyyy:mm:dd:hh:mm:ss)
   type(datetime),                  public :: begDatetime          ! simulation start date/time (yyyy:mm:dd:hh:mm:ss)
@@ -96,8 +98,8 @@ MODULE globalData
 
   ! ---------- input file information -------------------------------------------------------------------
 
-  type(infileinfo), allocatable,   public :: infileinfo_data(:)    ! input runoff file information
-  type(infileinfo), allocatable,   public :: infileinfo_data_wm(:) ! input water management (abstaction/injection) file information
+  type(infileinfo), allocatable,   public :: inFileInfo_ro(:)    ! input runoff/evapo/precipi file information
+  type(infileinfo), allocatable,   public :: inFileInfo_wm(:)    ! input water management (abstaction/injection) file information
 
   ! ---------- Misc. data -------------------------------------------------------------------------
   character(len=strLen),           public :: runMode='standalone'        ! run options: standalone or cesm-coupling
@@ -193,6 +195,8 @@ MODULE globalData
 
   ! mapping structures
   type(remap),                     public :: remap_data             ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
+  type(map_time), allocatable    , public :: tmap_sim_ro(:)         ! mapping between simulation time step and runoff time step
+  type(map_time), allocatable    , public :: tmap_sim_wm(:)         ! mapping between simulation time step and water management time step
 
   ! hru runoff data
   type(runoff),                    public :: runoff_data            ! HRU runoff data structure for one time step for LSM HRUs and River network HRUs

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -25,7 +25,6 @@ MODULE globalData
   USE dataTypes, ONLY: LKFLX         ! data structure - lake fluxes
 
   USE dataTypes, ONLY: remap         ! data structure - remapping data type
-  USE dataTypes, ONLY: map_time      ! time step mapping
 
   USE dataTypes, ONLY: runoff        ! data structure - runoff data type
   USE dataTypes, ONLY: wm            ! data structure - water management (flux to/from segment, target volume) data type
@@ -95,6 +94,8 @@ MODULE globalData
   type(datetime),                  public :: endDatetime          ! simulation end date/time (yyyy:mm:dd:hh:mm:ss)
   type(datetime),                  public :: restDatetime         ! desired restart date/time (yyyy:mm:dd:hh:mm:ss)
   type(datetime),                  public :: dropDatetime         ! restart dropoff date/time (yyyy:mm:dd:hh:mm:ss)
+  type(datetime),                  public :: roBegDatetime        ! forcing data start date/time (yyyy:mm:dd:hh:mm:ss)
+  type(datetime),                  public :: wmBegDatetime        ! water management data start date/time (yyyy:mm:dd:hh:mm:ss)
 
   ! ---------- input file information -------------------------------------------------------------------
 
@@ -195,8 +196,6 @@ MODULE globalData
 
   ! mapping structures
   type(remap),                     public :: remap_data             ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
-  type(map_time), allocatable    , public :: tmap_sim_ro(:)         ! mapping between simulation time step and runoff time step
-  type(map_time), allocatable    , public :: tmap_sim_wm(:)         ! mapping between simulation time step and water management time step
 
   ! hru runoff data
   type(runoff),                    public :: runoff_data            ! HRU runoff data structure for one time step for LSM HRUs and River network HRUs

--- a/route/build/src/historyFile.f90
+++ b/route/build/src/historyFile.f90
@@ -621,13 +621,13 @@ MODULE historyFile
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       endif
 
-      if (meta_rflx(ixRFLX%Fvolume)%varFile) then
+      if (meta_rflx(ixRFLX%IRFvolume)%varFile) then
         if (nRch_write>0) then
           do ix=1,nRch_write
             array_temp(ix) = RCHFLX_local(1,index_write(ix))%ROUTE(idxIRF)%REACH_VOL(1)
           end do
         end if
-        call write_pnetcdf_recdim(this%pioFileDesc, 'volume', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
+        call write_pnetcdf_recdim(this%pioFileDesc, 'IRFvolume', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       endif
 

--- a/route/build/src/historyFile.f90
+++ b/route/build/src/historyFile.f90
@@ -450,12 +450,13 @@ MODULE historyFile
     ! ---------------------------------
     ! writing flux (hru and/or rch)
     ! ---------------------------------
-    SUBROUTINE write_flux(this, time, index_write, ierr, message)
+    SUBROUTINE write_flux(this, time, RCHFLX_local, index_write, ierr, message)
 
       implicit none
       ! Argument variables
       class(histFile),           intent(inout) :: this
       real(dp),                  intent(in)    :: time
+      type(STRFLX),              intent(in)    :: RCHFLX_local(:,:)
       integer(i4b), allocatable, intent(in)    :: index_write(:)
       integer(i4b),              intent(out)   :: ierr             ! error code
       character(*),              intent(out)   :: message          ! error message
@@ -477,7 +478,7 @@ MODULE historyFile
         endif
       end if
 
-      call this%write_flux_rch(index_write, ierr, cmessage)
+      call this%write_flux_rch(RCHFLX_local, index_write, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       call sync_file(this%pioFileDesc, ierr, cmessage)
@@ -510,13 +511,12 @@ MODULE historyFile
     END SUBROUTINE write_flux_hru
 
 
-    SUBROUTINE write_flux_rch(this, index_write, ierr, message)
-
-      USE globalData, ONLY: RCHFLX_trib
+    SUBROUTINE write_flux_rch(this, RCHFLX_local, index_write, ierr, message)
 
       implicit none
       ! Argument variables
       class(histFile),           intent(inout) :: this
+      type(STRFLX),              intent(in)    :: RCHFLX_local(:,:)
       integer(i4b), allocatable, intent(in)    :: index_write(:)
       integer(i4b),              intent(out)   :: ierr             ! error code
       character(*),              intent(out)   :: message          ! error message
@@ -544,7 +544,7 @@ MODULE historyFile
       ! write instataneous local runoff in each stream segment (m3/s)
       if (meta_rflx(ixRFLX%instRunoff)%varFile) then
         if (nRch_write>0) then
-          array_temp(1:nRch_write) = RCHFLX_trib(1,index_write)%BASIN_QI
+          array_temp(1:nRch_write) = RCHFLX_local(1,index_write)%BASIN_QI
         end if
         call write_pnetcdf_recdim(this%pioFileDesc, 'instRunoff', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -553,7 +553,7 @@ MODULE historyFile
       ! write routed local runoff in each stream segment (m3/s)
       if (meta_rflx(ixRFLX%dlayRunoff)%varFile) then
         if (nRch_write>0) then
-          array_temp(1:nRch_write) = RCHFLX_trib(1,index_write)%BASIN_QR(1)
+          array_temp(1:nRch_write) = RCHFLX_local(1,index_write)%BASIN_QR(1)
         end if
         call write_pnetcdf_recdim(this%pioFileDesc, 'dlayRunoff', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -562,30 +562,28 @@ MODULE historyFile
       if (meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile) then
         if (nRch_write>0) then
           do ix=1,nRch_write
-            array_temp(ix) = RCHFLX_trib(1,index_write(ix))%ROUTE(idxSUM)%REACH_Q
+            array_temp(ix) = RCHFLX_local(1,index_write(ix))%ROUTE(idxSUM)%REACH_Q
           end do
         end if
         call write_pnetcdf_recdim(this%pioFileDesc, 'sumUpstreamRunoff', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       endif
 
-      call t_startf ('output/write_flux/kwt')
       if (meta_rflx(ixRFLX%KWTroutedRunoff)%varFile) then
         if (nRch_write>0) then
           do ix=1,nRch_write
-            array_temp(ix) = RCHFLX_trib(1,index_write(ix))%ROUTE(idxKWT)%REACH_Q
+            array_temp(ix) = RCHFLX_local(1,index_write(ix))%ROUTE(idxKWT)%REACH_Q
           end do
         end if
         call write_pnetcdf_recdim(this%pioFileDesc, 'KWTroutedRunoff', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       endif
-      call t_stopf ('output/write_flux/kwt')
 
       call t_startf ('output/write_flux/irf')
       if (meta_rflx(ixRFLX%IRFroutedRunoff)%varFile) then
         if (nRch_write>0) then
           do ix=1,nRch_write
-            array_temp(ix) = RCHFLX_trib(1,index_write(ix))%ROUTE(idxIRF)%REACH_Q
+            array_temp(ix) = RCHFLX_local(1,index_write(ix))%ROUTE(idxIRF)%REACH_Q
           end do
         end if
         call write_pnetcdf_recdim(this%pioFileDesc, 'IRFroutedRunoff', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
@@ -596,7 +594,7 @@ MODULE historyFile
       if (meta_rflx(ixRFLX%KWroutedRunoff)%varFile) then
         if (nRch_write>0) then
           do ix=1,nRch_write
-            array_temp(ix) = RCHFLX_trib(1,index_write(ix))%ROUTE(idxKW)%REACH_Q
+            array_temp(ix) = RCHFLX_local(1,index_write(ix))%ROUTE(idxKW)%REACH_Q
           end do
         end if
         call write_pnetcdf_recdim(this%pioFileDesc, 'KWroutedRunoff', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
@@ -606,7 +604,7 @@ MODULE historyFile
       if (meta_rflx(ixRFLX%MCroutedRunoff)%varFile) then
         if (nRch_write>0) then
           do ix=1,nRch_write
-            array_temp(ix) = RCHFLX_trib(1,index_write(ix))%ROUTE(idxMC)%REACH_Q
+            array_temp(ix) = RCHFLX_local(1,index_write(ix))%ROUTE(idxMC)%REACH_Q
           end do
         end if
         call write_pnetcdf_recdim(this%pioFileDesc, 'MCroutedRunoff', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
@@ -616,17 +614,17 @@ MODULE historyFile
       if (meta_rflx(ixRFLX%DWroutedRunoff)%varFile) then
         if (nRch_write>0) then
           do ix=1,nRch_write
-            array_temp(ix) = RCHFLX_trib(1,index_write(ix))%ROUTE(idxDW)%REACH_Q
+            array_temp(ix) = RCHFLX_local(1,index_write(ix))%ROUTE(idxDW)%REACH_Q
           end do
         end if
         call write_pnetcdf_recdim(this%pioFileDesc, 'DWroutedRunoff', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       endif
 
-      if (meta_rflx(ixRFLX%volume)%varFile) then
+      if (meta_rflx(ixRFLX%Fvolume)%varFile) then
         if (nRch_write>0) then
           do ix=1,nRch_write
-            array_temp(ix) = RCHFLX_trib(1,index_write(ix))%ROUTE(idxIRF)%REACH_VOL(1)
+            array_temp(ix) = RCHFLX_local(1,index_write(ix))%ROUTE(idxIRF)%REACH_VOL(1)
           end do
         end if
         call write_pnetcdf_recdim(this%pioFileDesc, 'volume', array_temp, this%ioDescRchFlux, this%iTime, ierr, cmessage)

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -280,6 +280,8 @@ CONTAINS
   USE public_var, ONLY: calendar          ! model calendar
   USE globalData, ONLY: TSEC              ! beginning/ending of simulation time step [sec]
   USE globalData, ONLY: iTime             ! time index at simulation time step
+  USE globalData, ONLY: timeVar           ! model time variables in time unit since reference time
+  USE public_var, ONLY: time_units        ! netcdf time units - t_unit since yyyy-mm-dd hh:mm:ss
   USE globalData, ONLY: endDatetime       ! model ending datetime
   USE globalData, ONLY: simDatetime       ! current model datetime
   USE write_simoutput_pio, ONLY: close_all
@@ -290,6 +292,7 @@ CONTAINS
    integer(i4b),              intent(out)   :: ierr             ! error code
    character(*),              intent(out)   :: message          ! error message
    ! local variables
+   character(len=7)                         :: t_unit           ! time unit - sec, min, hr, day
    character(len=strLen)                    :: cmessage         ! error message of downwind routine
 
    ierr=0; message='update_time/'
@@ -299,15 +302,28 @@ CONTAINS
      finished=.true.;return
    endif
 
-   ! update model time step bound,  time index and julian day
+   ! update model time step bound
    TSEC(0) = TSEC(0) + dt
    TSEC(1) = TSEC(0) + dt
 
+   ! update model time index
    iTime=iTime+1
 
-   ! increment model calendar
+   ! increment model datetime
    simDatetime(0) = simDatetime(1)
    simDatetime(1) = simDatetime(1)%add_sec(dt, calendar, ierr, cmessage)
+
+   ! model time stamp variable for output - dt is in second
+   t_unit = trim( time_units(1:index(time_units,' ')) )
+   select case( trim(t_unit) )
+     case('seconds','second','sec','s'); timeVar = timeVar+ dt
+     case('minutes','minute','min');     timeVar = timeVar+ dt/60._dp
+     case('hours','hour','hr','h');      timeVar = timeVar+ dt/1440._dp
+     case('days','day','d');             timeVar = timeVar+ dt/86400._dp
+     case default
+       ierr=20; message=trim(message)//'<tunit>= '//trim(t_unit)//': <tunit> must be seconds, minutes, hours or days.'; return
+   end select
+
 
  END SUBROUTINE update_time
 

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -318,7 +318,7 @@ CONTAINS
    select case( trim(t_unit) )
      case('seconds','second','sec','s'); timeVar = timeVar+ dt
      case('minutes','minute','min');     timeVar = timeVar+ dt/60._dp
-     case('hours','hour','hr','h');      timeVar = timeVar+ dt/1440._dp
+     case('hours','hour','hr','h');      timeVar = timeVar+ dt/3600._dp
      case('days','day','d');             timeVar = timeVar+ dt/86400._dp
      case default
        ierr=20; message=trim(message)//'<tunit>= '//trim(t_unit)//': <tunit> must be seconds, minutes, hours or days.'; return

--- a/route/build/src/main_route.f90
+++ b/route/build/src/main_route.f90
@@ -91,7 +91,6 @@ CONTAINS
    real(dp),           allocatable                :: reachPrecip_local(:) ! reach precipitation (m/s)
    integer(i4b)                                   :: nSeg                 ! number of reach to be processed
    integer(i4b)                                   :: iSeg                 ! index of reach
-   integer(i4b)                                   :: ixRoute              ! index of routing method
 
    ierr=0; message = "main_routing/"
 

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -281,7 +281,8 @@ CONTAINS
         destSegId(iSeg) = structNTOPO(jSeg)%var(ixNTOPO%destSegId)%dat(1)
       end do
       ! matching index in reachID
-      destSegIndex = match_index(reachID, destSegId)
+      destSegIndex = match_index(reachID, destSegId, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       nComm = 0
       do iSeg = 1,nRch_in

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -239,11 +239,12 @@ contains
 
  ! ---------- populate segment restart metadata structures -------------------------------------------------------------------------------------------------------------------
  ! Lagrangian Kinematic Wave
- call meta_kwt(ixKWT%tentry   )%init('tentry'   , 'time when a wave enters a segment'             , 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
- call meta_kwt(ixKWT%texit    )%init('texit'    , 'time when a wave is expected to exit a segment', 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
- call meta_kwt(ixKWT%qwave    )%init('qwave'    , 'flow of a wave'                                , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
- call meta_kwt(ixKWT%qwave_mod)%init('qwave_mod', 'modified flow of a wave'                       , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
- call meta_kwt(ixKWT%routed   )%init('routed'   , 'routing flag'                                  , '-'   , pio_int,    [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%tentry   )%init('tentry'    , 'time when a wave enters a segment'             , 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%texit    )%init('texit'     , 'time when a wave is expected to exit a segment', 's'   , pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%qwave    )%init('qwave'     , 'flow of a wave'                                , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%qwave_mod)%init('qwave_mod' , 'modified flow of a wave'                       , 'm2/s', pio_double, [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%routed   )%init('routed'    , 'routing flag'                                  , '-'   , pio_int,    [ixStateDims%seg,ixStateDims%wave,ixStateDims%ens], .true.)
+ call meta_kwt(ixKWT%vol      )%init('volume_kwt', 'volume in reach/lake'                          , 'm3'  , pio_double, [ixStateDims%seg,ixStateDims%ens],                  .true.)
 
  ! Kinematic Wave
  call meta_kw(ixKW%qsub)%init('q_sub_kw' , 'flow at computational moelcule', 'm3/s', pio_double, [ixStateDims%seg,ixStateDims%mol_kw,ixStateDims%ens], .true.)

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -222,7 +222,7 @@ contains
  ! PFAF CODE                                     varName        varDesc                                                varUnit, varType, varFile
  meta_PFAF  (ixPFAF%code             ) = var_info('code'           , 'pfafstetter code'                                   ,'-'    ,ixDims%seg   , .false.)
 
- ! ---------- populate segment fluxes/state metadata structures -------------------------------------------------------------------------------------------------------------------
+ ! ---------- populate history output segment fluxes/state metadata structures ----------------------------------------------------------------------------------------------------
  ! Reach Flux                                  varName              varDesc                                                  unit,   varType,  varDim,                     writeOut
  call meta_rflx(ixRFLX%instRunoff       )%init('instRunoff'       , 'instantaneous runoff in each reach'                   , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .false.)
  call meta_rflx(ixRFLX%dlayRunoff       )%init('dlayRunoff'       , 'delayed runoff in each reach'                         , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .false.)
@@ -232,7 +232,11 @@ contains
  call meta_rflx(ixRFLX%KWroutedRunoff   )%init('KWroutedRunoff'   , 'routed runoff in each reach-kinematic wave'           , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%MCroutedRunoff   )%init('MCroutedRunoff'   , 'routed runoff in each reach-muskingum-cunge'          , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
  call meta_rflx(ixRFLX%DWroutedRunoff   )%init('DWroutedRunoff'   , 'routed runoff in each reach-diffusive wave'           , 'm3/s', pio_real, [ixQdims%seg,ixQdims%time], .true.)
- call meta_rflx(ixRFLX%volume           )%init('volume'           , 'lake and stream volume'                               , 'm3'  , pio_real, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%IRFvolume        )%init('IRFvolume'        , 'lake and stream volume-impulse response function'     , 'm3'  , pio_real, [ixQdims%seg,ixQdims%time], .true.)
+ call meta_rflx(ixRFLX%KWTvolume        )%init('KWTvolume'        , 'lake and stream volume-lagrangian kinematic wave'     , 'm3'  , pio_real, [ixQdims%seg,ixQdims%time], .false.)
+ call meta_rflx(ixRFLX%KWvolume         )%init('KWvolume'        ,  'lake and stream volume-kinematic wave'                , 'm3'  , pio_real, [ixQdims%seg,ixQdims%time], .false.)
+ call meta_rflx(ixRFLX%MCvolume         )%init('MCvolume'        ,  'lake and stream volume-muskingum-cunge'               , 'm3'  , pio_real, [ixQdims%seg,ixQdims%time], .false.)
+ call meta_rflx(ixRFLX%DWvolume         )%init('DWvolume'        ,  'lake and stream volume-diffusive wave'                , 'm3'  , pio_real, [ixQdims%seg,ixQdims%time], .false.)
 
  ! HRU flux                                    varName              varDesc                                                  unit,   varType,  varDim,                     writeOut
  call meta_hflx(ixHFLX%basRunoff        )%init('basRunoff'        , 'basin runoff'                                         , 'm/s' , pio_real, [ixQdims%hru,ixQdims%time], .true.)

--- a/route/build/src/process_gage_meta.f90
+++ b/route/build/src/process_gage_meta.f90
@@ -42,7 +42,7 @@ MODULE process_gage_meta
 
     END SUBROUTINE read_gage_meta
 
-    SUBROUTINE reach_subset(reachID_in, gage_data_in, compdof, index2)
+    SUBROUTINE reach_subset(reachID_in, gage_data_in, ierr, message, compdof, index2)
 
       USE nr_utils,  ONLY: match_index
       USE nr_utils,  ONLY: arth
@@ -52,18 +52,25 @@ MODULE process_gage_meta
       ! Argument variables
       integer(i4b), allocatable,           intent(in)  :: reachID_in(:)
       type(gage),                          intent(in)  :: gage_data_in
+      integer(i4b),                        intent(out) :: ierr
+      character(len=strLen),               intent(out) :: message
       integer(i4b), allocatable, optional, intent(out) :: compdof(:)    ! gindex in gauge_data space
       integer(i4b), allocatable, optional, intent(out) :: index2(:)     ! index in the same size as reachID_in
       ! local variables
       integer(i4b), allocatable                        :: index1(:)
       integer(i4b)                                     :: nGage
       logical(lgt), allocatable                        :: mask(:)
+      character(len=strLen)                            :: cmessage
+
+      ierr=0; message='reach_subset/'
 
       ! array size = number of gauges in each mpi core
       allocate(index1(gage_data_in%nGage), mask(gage_data_in%nGage))
 
       ! Find index of matching reachID in reachID_in array
-      index1 = match_index(reachID_in, gage_data_in%reachID, missingValue=integerMissing)
+      index1 = match_index(reachID_in, gage_data_in%reachID, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); endif
+
       mask=(index1/=integerMissing)
       nGage = count(mask)
 

--- a/route/build/src/process_remap.f90
+++ b/route/build/src/process_remap.f90
@@ -37,14 +37,13 @@ MODULE process_remap_module
   ! ***************************************************************************************************************
   SUBROUTINE remap_runoff(runoff_data_in, remap_data_in, basinRunoff, ierr, message)
   implicit none
-  ! input
+  ! Argument variables
   type(runoff)         , intent(in)  :: runoff_data_in   ! runoff for one time step for all HRUs
   type(remap)          , intent(in)  :: remap_data_in    ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
-  ! output
   real(dp)             , intent(out) :: basinRunoff(:)   ! basin runoff
   integer(i4b)         , intent(out) :: ierr             ! error code
   character(len=strLen), intent(out) :: message          ! error message
-  ! local
+  ! local variables
   character(len=strLen)              :: cmessage         ! error message from subroutine
 
   ierr=0; message="remap_runoff/"
@@ -64,15 +63,15 @@ MODULE process_remap_module
   ! ***************************************************************************************************************
   ! case 1: hru in runoff layer is grid (stored in 2-dimension array)
   SUBROUTINE remap_2D_runoff(runoff_data_in, remap_data_in, basinRunoff, ierr, message)
+
   implicit none
-  ! input
+  ! Argument variables
   type(runoff)         , intent(in)  :: runoff_data_in      ! runoff for one time step for all HRUs
   type(remap)          , intent(in)  :: remap_data_in       ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
-  ! output
   real(dp)             , intent(out) :: basinRunoff(:)      ! basin runoff
   integer(i4b)         , intent(out) :: ierr                ! error code
   character(len=strLen), intent(out) :: message             ! error message
-  ! local
+  ! Local variables
   integer(i4b)                       :: iHRU,jHRU           ! index of basin in the routing layer
   integer(i4b)                       :: ixOverlap           ! index in ragged array of overlapping polygons
   integer(i4b)                       :: ii,jj               ! index of x and y in grid
@@ -82,6 +81,7 @@ MODULE process_remap_module
   integer(i4b), parameter            :: ixCheck=-huge(iHRU) ! basin to check
   integer(i4b), parameter            :: jxCheck=-huge(iHRU) ! basin to check
   logical(lgt), parameter            :: printWarn=.false.   ! flag to print warnings
+
   ierr=0; message="remap_2D_runoff/"
 
   ! initialize counter for the overlap vector
@@ -162,15 +162,16 @@ MODULE process_remap_module
   ! ***************************************************************************************************************
   ! case 2: hru in runoff layer is hru polygon different than river network layer (stored in 1-dimension array)
   SUBROUTINE remap_1D_runoff(runoff_data_in, remap_data_in, basinRunoff, ierr, message)
+
   implicit none
-  ! input
+
+  ! Argment variables
   type(runoff)         , intent(in)  :: runoff_data_in   ! runoff for one time step for all HRUs
   type(remap)          , intent(in)  :: remap_data_in    ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
-  ! output
   real(dp)             , intent(out) :: basinRunoff(:)   ! basin runoff
   integer(i4b)         , intent(out) :: ierr             ! error code
   character(len=strLen), intent(out) :: message          ! error message
-  ! local
+  ! local variables
   integer(i4b)                       :: iHRU,jHRU        ! index of basin in the routing layer
   integer(i4b)                       :: ixOverlap        ! index in ragged array of overlapping polygons
   integer(i4b)                       :: ixRunoff         ! index in the runoff vector
@@ -273,17 +274,15 @@ MODULE process_remap_module
                          sorted_flux,      & ! inout: sorted input states and fluxes based on hru/seg in network topology
                          ierr, message)
   implicit none
-  ! input
+  ! Argument variables
   integer(i4b)         , intent(in)    :: ID_in(:)            ! input: the array of ids for HRU/seg
   integer(i4b)         , intent(in)    :: IX_in(:)            ! input: the array of location of ids for HRU/seg in network topology
   real(dp)             , intent(in)    :: flux_in(:)          ! input: the array of input fluxes, should be the same size as ID_in
   logical(lgt)         , intent(in)    :: remove_negatives    ! flag to replace negative values to zeros
-  ! input/output
   real(dp)             , intent(inout) :: sorted_flux(:)      ! inout: sorted input states and fluxes based on hru/seg in network topology
-  ! output
   integer(i4b)         , intent(out)   :: ierr                ! error code
   character(len=strLen), intent(out)   :: message             ! error message
-  ! local
+  ! local variables
   integer(i4b)                         :: i,j                 ! index of basin in the routing layer
 
   ierr=0; message="sort_flux/"
@@ -326,24 +325,21 @@ MODULE process_remap_module
                          ierr, message,     & ! intent(out): error control
                          ixSubRch,          & ! optional input: subset of reach indices to be processed
                          limitRunoff)         ! optional input: true->enforce min. flow, false->allow any flow (e.g., negative)
-  ! External modules
+
   USE nr_utils, ONLY : arth
 
   implicit none
-
-  ! input
+  ! Argument variables
   real(dp)                  , intent(in)  :: basinRunoff(:)   ! basin runoff (m/s)
   type(RCHTOPO), allocatable, intent(in)  :: NETOPO_in(:)     ! River Network topology
   type(RCHPRP),  allocatable, intent(in)  :: RPARAM_in(:)     ! River (non-)physical parameters
-  ! output
   real(dp)                  , intent(out) :: reachRunoff(:)   ! reach runoff (m/s)
   integer(i4b)              , intent(out) :: ierr             ! error code
   character(len=strLen)     , intent(out) :: message          ! error message
-  ! input (optional)
   integer(i4b),  optional   , intent(in)  :: ixSubRch(:)     ! subset of reach indices to be processed
   logical(lgt),  optional   , intent(in)  :: limitRunoff     ! enforce minimum threshold flow or not
   ! ----------------------------------------------------------------------------------------------
-  ! local
+  ! local variables
   integer(i4b)                            :: nContrib         ! number of contributing HRUs
   integer(i4b)                            :: nSeg             ! number of reaches to be processed
   integer(i4b)                            :: iHRU             ! array index for contributing HRUs

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -84,9 +84,9 @@ MODULE public_var
 
   ! Control file variables
   ! DIRECTORIES
-  character(len=strLen),public    :: ancil_dir            = ''              ! directory containing ancillary data
-  character(len=strLen),public    :: input_dir            = ''              ! directory containing input data
-  character(len=strLen),public    :: output_dir           = ''              ! directory containing output data
+  character(len=strLen),public    :: ancil_dir            = ''              ! directory containing ancillary data (network, mapping, namelist)
+  character(len=strLen),public    :: input_dir            = ''              ! directory containing input forcing data
+  character(len=strLen),public    :: output_dir           = ''              ! directory for routed flow output (netCDF)
   character(len=strLen),public    :: restart_dir          = charMissing     ! directory for restart output (netCDF)
   ! RUN CONTROL
   character(len=strLen),public    :: case_name            = ''              ! name of simulation
@@ -105,7 +105,8 @@ MODULE public_var
   logical(lgt),public             :: is_vol_wm_jumpstart  = .false.         ! logical if true the volume is reset to target volume for the first time step of modeling
   logical(lgt),public             :: suppress_runoff      = .false.         ! logical to suppress the read runoff to zero(0)
   logical(lgt),public             :: suppress_P_Ep        = .false.         ! logical to suppress evaporation and precipitation to zero(0)
-  logical(lgt),public             :: compWB               = .true.          ! logical if cumulative water balance is computed
+  logical(lgt),public             :: compWB               = .true.          ! logical if entire domain water balance is computed
+  real(dp)             ,public    :: dt                   = realMissing     ! simulation time step (seconds)
   ! RIVER NETWORK TOPOLOGY
   character(len=strLen),public    :: fname_ntopOld        = ''              ! old filename containing stream network topology information
   logical(lgt)         ,public    :: ntopAugmentMode      = .false.         ! option for river network augmentation mode. terminate the program after writing augmented ntopo.
@@ -124,7 +125,7 @@ MODULE public_var
   character(len=strLen),public    :: dname_xlon           = ''              ! dimension name for x (j, longitude) dimension
   character(len=strLen),public    :: dname_ylat           = ''              ! dimension name for y (i, latitude) dimension
   character(len=strLen),public    :: units_qsim           = ''              ! units of simulated runoff data
-  real(dp)             ,public    :: dt                   = realMissing     ! time step (seconds)
+  real(dp)             ,public    :: dt_ro                = realMissing     ! runoff time step (seconds)
   real(dp)             ,public    :: input_fillvalue      = realMissing     ! fillvalue used for input variables (runoff, precipitation, evaporation)
   ! FLUXES TO/FROM REACHES AND LAKES STATES FILE
   character(len=strLen),public    :: fname_wm             = ''              ! the txt file name that includes nc files holesing the abstraction, injection, target volume values

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -94,18 +94,19 @@ MODULE public_var
   character(len=strLen),public    :: simStart             = ''              ! date string defining the start of the simulation
   character(len=strLen),public    :: simEnd               = ''              ! date string defining the end of the simulation
   character(len=strLen),public    :: newFileFrequency     = 'yearly'        ! frequency for new output files (daily, monthly, yearly, single)
+  character(len=strLen),public    :: timeAggregation      = 'none'          ! time aggregation for output: 'nh','nd','nm','ny' where n is number or 'none' no aggregation
   character(len=10)    ,public    :: routOpt              = '0'             ! routing scheme options  0: accum runoff, 1:IRF, 2:KWT, 3:KW, 4:MC, 5:DW
   integer(i4b)         ,public    :: doesBasinRoute       = 1               ! basin routing options   0-> no, 1->IRF, otherwise error
-  logical(lgt),public             :: is_lake_sim          = .false.         ! logical if lakes are activated in simulation
-  logical(lgt),public             :: lake_model_D03       = .false.         ! logical if Doll 2003 model is used, specify as 1 in lake_model_type in network topology
-  logical(lgt),public             :: lake_model_H06       = .false.         ! logical if Hanasaki 2006 model is used, specify as 2 in lake_model_type in network topology
-  logical(lgt),public             :: lake_model_HYPE      = .false.         ! logical if HYPE model is used, specify as 3 in lake_model_type in network topology
-  logical(lgt),public             :: is_flux_wm           = .false.         ! logical if flow is added or removed from a reach
-  logical(lgt),public             :: is_vol_wm            = .false.         ! logical if target volume is considered for a lake
-  logical(lgt),public             :: is_vol_wm_jumpstart  = .false.         ! logical if true the volume is reset to target volume for the first time step of modeling
-  logical(lgt),public             :: suppress_runoff      = .false.         ! logical to suppress the read runoff to zero(0)
-  logical(lgt),public             :: suppress_P_Ep        = .false.         ! logical to suppress evaporation and precipitation to zero(0)
-  logical(lgt),public             :: compWB               = .true.          ! logical if entire domain water balance is computed
+  logical(lgt)         ,public    :: is_lake_sim          = .false.         ! logical if lakes are activated in simulation
+  logical(lgt)         ,public    :: lake_model_D03       = .false.         ! logical if Doll 2003 model is used, specify as 1 in lake_model_type in network topology
+  logical(lgt)         ,public    :: lake_model_H06       = .false.         ! logical if Hanasaki 2006 model is used, specify as 2 in lake_model_type in network topology
+  logical(lgt)         ,public    :: lake_model_HYPE      = .false.         ! logical if HYPE model is used, specify as 3 in lake_model_type in network topology
+  logical(lgt)         ,public    :: is_flux_wm           = .false.         ! logical if flow is added or removed from a reach
+  logical(lgt)         ,public    :: is_vol_wm            = .false.         ! logical if target volume is considered for a lake
+  logical(lgt)         ,public    :: is_vol_wm_jumpstart  = .false.         ! logical if true the volume is reset to target volume for the first time step of modeling
+  logical(lgt)         ,public    :: suppress_runoff      = .false.         ! logical to suppress the read runoff to zero(0)
+  logical(lgt)         ,public    :: suppress_P_Ep        = .false.         ! logical to suppress evaporation and precipitation to zero(0)
+  logical(lgt)         ,public    :: compWB               = .true.          ! logical if entire domain water balance is computed
   real(dp)             ,public    :: dt                   = realMissing     ! simulation time step (seconds)
   ! RIVER NETWORK TOPOLOGY
   character(len=strLen),public    :: fname_ntopOld        = ''              ! old filename containing stream network topology information
@@ -114,8 +115,8 @@ MODULE public_var
   character(len=strLen),public    :: dname_sseg           = ''              ! dimension name of segment in river network data
   character(len=strLen),public    :: dname_nhru           = ''              ! dimension name of hru in river network data
   ! RUNOFF, EVAPORATION AND PRECIPITATION FILE
-  character(len=strLen),public    :: fname_qsim           = ''              ! simulated runoff netCDF name
-  character(len=strLen),public    :: vname_qsim           = ''              ! variable name for simulated runoff
+  character(len=strLen),public    :: fname_qsim           = ''              ! runoff netCDF name
+  character(len=strLen),public    :: vname_qsim           = ''              ! variable name for runoff
   character(len=strLen),public    :: vname_evapo          = ''              ! variable name for actual evapoartion
   character(len=strLen),public    :: vname_precip         = ''              ! variable name for precipitation
   character(len=strLen),public    :: vname_time           = ''              ! variable name for time
@@ -124,7 +125,7 @@ MODULE public_var
   character(len=strLen),public    :: dname_hruid          = ''              ! dimension name for hru in runoff data
   character(len=strLen),public    :: dname_xlon           = ''              ! dimension name for x (j, longitude) dimension
   character(len=strLen),public    :: dname_ylat           = ''              ! dimension name for y (i, latitude) dimension
-  character(len=strLen),public    :: units_qsim           = ''              ! units of simulated runoff data
+  character(len=strLen),public    :: units_qsim           = ''              ! units of runoff data
   real(dp)             ,public    :: dt_ro                = realMissing     ! runoff time step (seconds)
   real(dp)             ,public    :: input_fillvalue      = realMissing     ! fillvalue used for input variables (runoff, precipitation, evaporation)
   ! FLUXES TO/FROM REACHES AND LAKES STATES FILE

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -110,9 +110,9 @@ CONTAINS
    select case(trim(cName))
 
    ! DIRECTORIES
-   case('<ancil_dir>');            ancil_dir   = trim(cData)                           ! directory containing ancillary data
-   case('<input_dir>');            input_dir   = trim(cData)                           ! directory containing input data
-   case('<output_dir>');           output_dir  = trim(cData)                           ! directory containing output data
+   case('<ancil_dir>');            ancil_dir   = trim(cData)                           ! directory containing ancillary data (network, mapping, namelist)
+   case('<input_dir>');            input_dir   = trim(cData)                           ! directory containing input forcing netCDF, e.g. runoff
+   case('<output_dir>');           output_dir  = trim(cData)                           ! directory for routed flow output (netCDF)
    case('<restart_dir>');          restart_dir = trim(cData)                           ! directory for restart output (netCDF)
    ! RUN CONTROL
    case('<case_name>');            case_name   = trim(cData)                           ! name of simulation. used as head of model output and restart file
@@ -128,6 +128,7 @@ CONTAINS
    case('<is_vol_wm_jumpstart>');  read(cData,*,iostat=io_error) is_vol_wm_jumpstart   ! logical; jump to the first time step target volume is set to true
    case('<suppress_runoff>');      read(cData,*,iostat=io_error) suppress_runoff       ! logical; suppress the read runoff to zero (0) no host model
    case('<suppress_P_Ep>');        read(cData,*,iostat=io_error) suppress_P_Ep         ! logical; suppress the precipitation/evaporation to zero (0) no host model
+   case('<dt_qsim>');              read(cData,*,iostat=io_error) dt                    ! time interval of the simulation (To-do: change dt to dt_sim)
    ! RIVER NETWORK TOPOLOGY
    case('<fname_ntopOld>');        fname_ntopOld = trim(cData)                         ! name of file containing stream network topology information
    case('<ntopAugmentMode>');      read(cData,*,iostat=io_error) ntopAugmentMode       ! option for river network augmentation mode. terminate the program after writing augmented ntopo.
@@ -146,7 +147,7 @@ CONTAINS
    case('<dname_xlon>');           dname_xlon   = trim(cData)                          ! name of x (j,lon) dimension
    case('<dname_ylat>');           dname_ylat   = trim(cData)                          ! name of y (i,lat) dimension
    case('<units_qsim>');           units_qsim   = trim(cData)                          ! units of runoff
-   case('<dt_qsim>');              read(cData,*,iostat=io_error) dt                    ! time interval of the gridded runoff
+   case('<dt_ro>');                read(cData,*,iostat=io_error) dt_ro                 ! time interval of the runoff input with unit of units_qsim
    case('<input_fillvalue>');      read(cData,*,iostat=io_error) input_fillvalue       ! fillvalue used for input variable
    ! FLUXES TO/FROM REACHES AND LAKE STATES FILE
    case('<fname_wm>');             fname_wm        = trim(cData)                       ! name of text file containing ordered nc file names
@@ -168,7 +169,7 @@ CONTAINS
    case('<dname_hru_remap>');      dname_hru_remap      = trim(cData)                  ! name of dimension of river network HRU ID
    case('<dname_data_remap>');     dname_data_remap     = trim(cData)                  ! name of dimension of runoff HRU overlapping with river network HRU
    ! RESTART
-   case('<restart_write>');        restart_write        = trim(cData)                  ! restart write option: N[n]ever, L[l]ast, S[s]pecified, Monthly, Daily
+   case('<restart_write>');        restart_write        = trim(cData)                  ! restart write option (case-insensitive): never, last, specified, yearly, monthly, or daily
    case('<restart_date>');         restart_date         = trim(cData)                  ! specified restart date, yyyy-mm-dd (hh:mm:ss) for Specified option
    case('<restart_month>');        read(cData,*,iostat=io_error) restart_month         ! restart periodic month
    case('<restart_day>');          read(cData,*,iostat=io_error) restart_day           ! restart periodic day

--- a/route/build/src/standalone/get_basin_runoff.f90
+++ b/route/build/src/standalone/get_basin_runoff.f90
@@ -4,79 +4,62 @@ USE nrtype
 
 implicit none
 
-integer(i4b) :: iTime_local     ! time index at simulation time step for a given runoff file
-integer(i4b) :: iTime_local_wm  ! time index at simulation time step for a given water management file
-
 private
-
 public::get_hru_runoff
 
 CONTAINS
 
  ! *********************************************************************
- ! public subroutine: read runoff data
+ ! public subroutine: get forcing data at hru and current model time step
  ! *********************************************************************
- SUBROUTINE get_hru_runoff(ierr, message)     ! output: error control
+ SUBROUTINE get_hru_runoff(ierr, message)
 
- ! populate runoff_data with runoff values at LSM domain and at iTime step
+ ! get forcing data at current step at all the hrus
 
-  ! shared data
-  USE public_var,  ONLY:input_dir               ! directory containing input data
-  USE public_var,  ONLY:fname_qsim              ! simulated runoff netCDF name
-  USE public_var,  ONLY:fname_wm                ! flux and vol netCDF name
-  USE public_var,  ONLY:vname_qsim              ! varibale runoff in netCDF file
-  USE public_var,  ONLY:vname_evapo             ! varibale actual evaporation in netCDF file
-  USE public_var,  ONLY:vname_precip            ! varibale precipitation in netCDF file
-  USE public_var,  ONLY:vname_flux_wm           ! varibale precipitation in netCDF file
-  USE public_var,  ONLY:vname_vol_wm            ! varibale precipitation in netCDF file
-  USE public_var,  ONLY:is_remap                ! logical runnoff needs to be mapped to river network HRU
-  USE public_var,  ONLY:is_lake_sim             ! logical lake should be simulated
-  USE public_var,  ONLY:is_flux_wm              ! logical water management components fluxes should be read
-  USE public_var,  ONLY:is_vol_wm               ! logical water management components target volume should be read
-  USE public_var,  ONLY:suppress_runoff         ! logical suppress the read runoff to zero (0)
-  USE public_var,  ONLY:suppress_P_Ep           ! logical suppress the read precipitation/evaporation to zero (0)
-  USE globalData,  ONLY:nHRU                    ! number of routing sub-basin
-  USE globalData,  ONLY:nRch                    ! number of routing seg (reaches and lakes)
-  USE globalData,  ONLY:runoff_data             ! data structure to hru runoff data
-  USE globalData,  ONLY:wm_data                 ! data strcuture for water management
-  USE globalData,  ONLY:remap_data              ! data structure to remap data
-  ! subroutines
-  USE read_runoff,          ONLY: read_runoff_data ! read runoff value into runoff_data data strucuture
-  USE process_remap_module, ONLY: remap_runoff     ! mapping HM runoff to river network HRU runoff (HM_HRU /= RN_HRU)
-  USE process_remap_module, ONLY: sort_flux        ! mapping runoff, fluxes based on order of HRUs, Reaches in the network
+  USE public_var,           ONLY: input_dir         ! directory containing input data
+  USE public_var,           ONLY: vname_qsim        ! varibale runoff in netCDF file
+  USE public_var,           ONLY: vname_evapo       ! varibale actual evaporation in netCDF file
+  USE public_var,           ONLY: vname_precip      ! varibale precipitation in netCDF file
+  USE public_var,           ONLY: vname_flux_wm     ! varibale precipitation in netCDF file
+  USE public_var,           ONLY: vname_vol_wm      ! varibale precipitation in netCDF file
+  USE public_var,           ONLY: is_remap          ! logical runnoff needs to be mapped to river network HRU
+  USE public_var,           ONLY: is_lake_sim       ! logical lake should be simulated
+  USE public_var,           ONLY: is_flux_wm        ! logical water management components fluxes should be read
+  USE public_var,           ONLY: is_vol_wm         ! logical water management components target volume should be read
+  USE public_var,           ONLY: suppress_runoff   ! logical suppress the read runoff to zero (0)
+  USE public_var,           ONLY: suppress_P_Ep     ! logical suppress the read precipitation/evaporation to zero (0)
+  USE globalData,           ONLY: iTime             ! simulation time step index
+  USE globalData,           ONLY: runoff_data       ! data structure to hru runoff data
+  USE globalData,           ONLY: wm_data           ! data strcuture for water management
+  USE globalData,           ONLY: remap_data        ! data structure to remap data
+  USE globalData,           ONLY: tmap_sim_ro       ! time-step mapping betweein simulation and runoff
+  USE globalData,           ONLY: tmap_sim_wm       ! time-step mapping betweein simulation and water management
+  USE globalData,           ONLY: inFileInfo_ro     ! metadata for input files for runoff, evapo and precip
+  USE globalData,           ONLY: inFileInfo_wm     ! metadata for water-management input files
+  USE read_runoff,          ONLY: read_forcing_data ! read forcing variable into data data strucuture
+  USE process_remap_module, ONLY: remap_runoff      ! mapping HM runoff to river network HRU runoff (HM_HRU /= RN_HRU)
+  USE process_remap_module, ONLY: sort_flux         ! mapping runoff, fluxes based on order of HRUs, Reaches in the network
 
   implicit none
-  ! input variables: none
-  ! output variables
+  ! Argument variables
   integer(i4b), intent(out)     :: ierr               ! error code
   character(*), intent(out)     :: message            ! error message
   ! local variables
   logical(lgt)                  :: remove_negatives   ! flag to replace the negative values to zeros
   character(len=strLen)         :: cmessage           ! error message from subroutine
 
-
   ierr=0; message='get_hru_runoff/'
 
-  call infile_name(ierr, cmessage) ! read the infile name for given iTime
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-  if ( allocated(runoff_data%basinRunoff) ) then
-    deallocate(runoff_data%basinRunoff, stat=ierr)
-    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-  end if
-  allocate(runoff_data%basinRunoff(nHRU), stat=ierr)
-  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-  if (.not.suppress_runoff) then
-
+  if (suppress_runoff) then  ! not reading runoff data
+    runoff_data%basinRunoff = 0._dp
+  else
     ! get the simulated runoff for the current time step - runoff_data%sim(:) or %sim2D(:,:)
-    call read_runoff_data(trim(input_dir)//trim(fname_qsim), & ! input: filename
-                          trim(vname_qsim),                  & ! input: varname
-                          iTime_local,                       & ! input: time index
-                          runoff_data%nSpace,                & ! inout: runoff data structure
-                          runoff_data%sim,                   & ! inout: runoff data structure
-                          runoff_data%sim2D,                 & ! inout: runoff data structure
-                          ierr, cmessage)                      ! output: error control
+    call read_forcing_data(input_dir,              & ! input: directory
+                          inFileInfo_ro,          & ! input: meta for forcing input files
+                          vname_qsim,             & ! input: varname
+                          tmap_sim_ro(iTime),     & ! input: ro-sim time mapping at current simulation step
+                          runoff_data,            & ! inout: forcing data structure
+                          ierr, cmessage)           ! output: error control
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     ! Get river network HRU runoff into runoff_data data structure
@@ -84,7 +67,7 @@ CONTAINS
       call remap_runoff(runoff_data, remap_data, runoff_data%basinRunoff, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     else ! runoff is already remapped to river network HRUs
-      remove_negatives = .TRUE.
+      remove_negatives = .true.
       call sort_flux (runoff_data%hru_id,         &
                       runoff_data%hru_ix,         &
                       runoff_data%sim,            &
@@ -93,47 +76,23 @@ CONTAINS
                       ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     end if
-
-  else
-
-    runoff_data%basinRunoff  = 0._dp
-
   end if
 
-  if (is_lake_sim) then ! if is_lake_sim if true then read actual evaporation and preciptation
-
-    ! allocate the basinEvapo
-    if ( allocated(runoff_data%basinEvapo) ) then
-      deallocate(runoff_data%basinEvapo, stat=ierr)
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-    end if
-    allocate(runoff_data%basinEvapo(nHRU), stat=ierr)
-    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-    if ( allocated(runoff_data%basinPrecip) ) then
-      deallocate(runoff_data%basinPrecip, stat=ierr)
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-    end if
-    allocate(runoff_data%basinPrecip(nHRU), stat=ierr)
-    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+  ! Optional: lake module on -> read actual evaporation and preciptation
+  if (is_lake_sim) then
 
     if (suppress_P_Ep) then
-
       ! suppressing the read runoff or precipitation and evaporation
-      ! this section can be merged with the upper section so that the
       runoff_data%basinPrecip = 0._dp
       runoff_data%basinEvapo  = 0._dp
-
     else
-
       ! get the actual evaporation - runoff_data%sim(:) or %sim2D(:,:)
-      call read_runoff_data(trim(input_dir)//trim(fname_qsim), & ! input: filename
-                            trim(vname_evapo),                 & ! input: varname
-                            iTime_local,                       & ! input: time index
-                            runoff_data%nSpace,                & ! inout: runoff data structure
-                            runoff_data%sim,                   & ! inout: runoff data structure
-                            runoff_data%sim2D,                 & ! inout: runoff data structure
-                            ierr, cmessage)                      ! output: error control
+      call read_forcing_data(input_dir,              & ! input: directory
+                             inFileInfo_ro,          & ! input: meta for forcing input files
+                             vname_evapo,            & ! input: varname
+                             tmap_sim_ro(iTime),     & ! input: ro-sim time mapping at current simulation step
+                             runoff_data,            & ! inout: forcing data structure
+                             ierr, cmessage)           ! output: error control
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! Get river network HRU runoff into runoff_data data structure
@@ -141,7 +100,7 @@ CONTAINS
         call remap_runoff(runoff_data, remap_data, runoff_data%basinEvapo, ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       else ! runoff is already remapped to river network HRUs
-        remove_negatives = .TRUE.
+        remove_negatives = .true.
         call sort_flux  (runoff_data%hru_id,        &
                          runoff_data%hru_ix,        &
                          runoff_data%sim,           &
@@ -152,13 +111,12 @@ CONTAINS
       end if
 
       ! get the precepitation - runoff_data%sim(:) or %sim2D(:,:)
-      call read_runoff_data(trim(input_dir)//trim(fname_qsim), & ! input: filename
-                            trim(vname_precip),                & ! input: varname
-                            iTime_local,                       & ! input: time index
-                            runoff_data%nSpace,                & ! inout: runoff data structure
-                            runoff_data%sim,                   & ! inout: runoff data structure
-                            runoff_data%sim2D,                 & ! inout: runoff data structure
-                            ierr, cmessage)                      ! output: error control
+      call read_forcing_data(input_dir,              & ! input: directory
+                             inFileInfo_ro,          & ! input: meta for forcing input files
+                             vname_precip,           & ! input: varname
+                             tmap_sim_ro(iTime),     & ! input: ro-sim time mapping at current simulation step
+                             runoff_data,            & ! inout: forcing data structure
+                             ierr, cmessage)           ! output: error control
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! Get river network HRU runoff into runoff_data data structure
@@ -166,7 +124,7 @@ CONTAINS
         call remap_runoff(runoff_data, remap_data, runoff_data%basinPrecip, ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       else ! runoff is already remapped to river network HRUs
-        remove_negatives = .TRUE.
+        remove_negatives = .true.
         call sort_flux  (runoff_data%hru_id,        &
                          runoff_data%hru_ix,        &
                          runoff_data%sim,           &
@@ -174,39 +132,46 @@ CONTAINS
                          runoff_data%basinPrecip,   &
                          ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+      end if ! is_remap
+    end if ! suppress_P_Ep
 
-      end if
+    ! Optional: target volume based water release on -> read target lake volume
+    if (is_vol_wm) then
 
-    end if
+      ! get the added or subtracted discharge from river segments
+      call read_forcing_data(input_dir,          & ! input: input directory
+                             inFileInfo_wm,      & ! input: meta for water-management input files
+                             vname_vol_wm,       & ! input: varname
+                             tmap_sim_wm(iTime), & ! input: wm-sim time mapping at current simulation step
+                             wm_data,            & ! inout: water management data structure
+                             ierr, cmessage)       ! output: error control
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-  end if
-
-  ! reading the abstraction and subtraction to river segment
-  if (is_flux_wm) then
-
-    ! get the added or subtracted discharge from river segments
-    call read_runoff_data(trim(input_dir)//trim(fname_wm),   & ! input: filename
-                          trim(vname_flux_wm),               & ! input: varname
-                          iTime_local_wm,                    & ! input: time index
-                          wm_data%nSpace,                    & ! inout: runoff data structure
-                          wm_data%sim,                       & ! inout: runoff data structure
-                          wm_data%sim2D,                     & ! inout: runoff data structure
-                          ierr, cmessage)                      ! output: error control
-    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-    !!!! should be removed...
-    print*, 'water balance: ',wm_data%sim
-
-
-    if ( allocated(wm_data%flux_wm) ) then
-      deallocate(wm_data%flux_wm, stat=ierr)
+      ! sorting wm_data%sim(:) into wm_data%vol_wm
+      remove_negatives = .true.
+      call sort_flux  (wm_data%seg_id,        &
+                       wm_data%seg_ix,        &
+                       wm_data%sim,           &
+                       remove_negatives,      &
+                       wm_data%vol_wm,        &
+                       ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     end if
-    allocate(wm_data%flux_wm(nRch), stat=ierr)
+  end if ! is_lake_sim
+
+  ! Optional: reading water abstraction and subtraction
+  if (is_flux_wm) then
+    ! get the added or subtracted discharge from river segments
+    call read_forcing_data(input_dir,             & ! input: input directory
+                           inFileInfo_wm,         & ! input: meta for water-management input files
+                           vname_flux_wm,         & ! input: varname
+                           tmap_sim_wm(iTime),    & ! input: wm-sim time mapping at current simulation step
+                           wm_data,               & ! inout: water management data structure
+                           ierr, cmessage)          ! output: error control
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-    ! sorting the read_runoff into wm_data%flux_wm
-    remove_negatives = .FALSE.
+    ! sorting wm_data%sim(:) into wm_data%flux_wm
+    remove_negatives = .false.
     call sort_flux  (wm_data%seg_id,        &
                      wm_data%seg_ix,        &
                      wm_data%sim,           &
@@ -216,100 +181,6 @@ CONTAINS
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   end if
 
-  ! reading the target volume for lakes if is_lake_sim is activated
-  if ((is_lake_sim).and.(is_vol_wm)) then
-
-    ! get the added or subtracted discharge from river segments
-    call read_runoff_data(trim(input_dir)//trim(fname_wm),   & ! input: filename
-                          trim(vname_vol_wm),                & ! input: varname
-                          iTime_local_wm,                    & ! input: time index
-                          wm_data%nSpace,                    & ! inout: runoff data structure
-                          wm_data%sim,                       & ! inout: runoff data structure
-                          wm_data%sim2D,                     & ! inout: runoff data structure
-                          ierr, cmessage)                      ! output: error control
-    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-    if ( allocated(wm_data%vol_wm) ) then
-      deallocate(wm_data%vol_wm, stat=ierr)
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-    end if
-    allocate(wm_data%vol_wm(nRch), stat=ierr)
-    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-    ! sorting the read_runoff into wm_data%vol_wm
-    remove_negatives = .TRUE.
-    call sort_flux  (wm_data%seg_id,        &
-                     wm_data%seg_ix,        &
-                     wm_data%sim,           &
-                     remove_negatives,      &
-                     wm_data%vol_wm,        &
-                     ierr, cmessage)
-    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-  end if
-
  END SUBROUTINE get_hru_runoff
-
-
- ! *********************************************************************
- ! private subroutine: get the name of input file based current time
- ! *********************************************************************
- SUBROUTINE infile_name(ierr, message)  ! output
-
-  ! Shared data
-  USE public_var, ONLY: fname_qsim             ! simulated runoff netCDF name
-  USE public_var, ONLY: fname_wm               ! water management netCDF name
-  USE public_var, ONLY: is_lake_sim            ! logical whether or not abstraction or injection should be read
-  USE public_var, ONLY: is_flux_wm             ! logical whether or not abstraction or injection should be read
-  USE public_var, ONLY: is_vol_wm              ! logical whether or not target volume should be read
-  USE globalData, ONLY: iTime                  ! time index at simulation time step
-  USE globalData, ONLY: infileinfo_data        ! the information of the input files for runoff, evapo and precip
-  USE globalData, ONLY: infileinfo_data_wm     ! the information of the input files
-
-  implicit none
-
-  ! output:
-  integer(i4b),              intent(out)    :: ierr             ! error code
-  character(*),              intent(out)    :: message          ! error message
-  ! local variable
-  integer(i4b)                              :: ix
-  logical(lgt)                              :: wm_not_read_flag ! to turn false if there is a iTime_local_wn to be read
-  !character(len=strLen)                    :: cmessage         ! error message
-
-  ! initialize error control
-  ierr=0; message='infile_name/'; wm_not_read_flag = .true.
-
-  ! fast forward time to time index at simStart
-  ixloop: do ix = 1, size(infileinfo_data) !loop over number of file
-   !print*, 'runoff file', infileinfo_data(ix)%iTimebound(1), infileinfo_data(ix)%iTimebound(2)
-   if ((iTime >= infileinfo_data(ix)%iTimebound(1)).and.(iTime <= infileinfo_data(ix)%iTimebound(2))) then
-    iTime_local = iTime - infileinfo_data(ix)%iTimebound(1) + 1
-    fname_qsim = trim(infileinfo_data(ix)%infilename)
-    exit ixloop
-   endif
-  enddo ixloop
-
-  !print*, 'itime, itime_local', iTime, iTime_local
-
-  ! fast forward time to time index at simStart for water management nc file
-  if ((is_flux_wm).or.(is_vol_wm.and.is_lake_sim)) then
-    iyloop: do ix = 1, size(infileinfo_data_wm) !loop over number of file
-     !print*, 'wm file', infileinfo_data_wm(ix)%iTimebound(1), infileinfo_data_wm(ix)%iTimebound(2)
-     if ((iTime >= infileinfo_data_wm(ix)%iTimebound(1)).and.(iTime <= infileinfo_data_wm(ix)%iTimebound(2))) then
-      iTime_local_wm = iTime - infileinfo_data_wm(ix)%iTimebound(1) + 1
-      fname_wm = trim(infileinfo_data_wm(ix)%infilename)
-      wm_not_read_flag = .false. ! file is read so the not read flag is turned false
-      exit iyloop
-     endif
-    enddo iyloop
-  endif
-
-    !print*, 'itime, itime_local_wm', iTime, iTime_local_wm
-
-  ! check if the two files are identified in case is flux and vol flags are set to true
-  if ((wm_not_read_flag).and.((is_flux_wm).or.(is_vol_wm.and.is_lake_sim))) then
-    ierr=20; message=trim(message)//'iTime local is out of bound for the water management netcdf file inputs based on given simulation date and time in control file'; return ;
-  endif
-
- END SUBROUTINE infile_name
 
 END MODULE get_runoff

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -647,7 +647,6 @@ CONTAINS
    USE public_var,  ONLY: vname_precip         ! name of simulated precipitation varibale
    USE public_var,  ONLY: vname_hruid          ! name of name of varibale hruid
    USE public_var,  ONLY: vname_time           ! name of varibale time
-   USE public_var,  ONLY: dname_time           ! name of dimension for variable time
    USE public_var,  ONLY: dname_hruid          ! name of dimension for varibale hruid
    USE public_var,  ONLY: dname_xlon           ! name of dimension for lon
    USE public_var,  ONLY: dname_ylat           ! name of dimension for lat
@@ -655,7 +654,6 @@ CONTAINS
    USE public_var,  ONLY: vname_vol_wm         ! name of varibale target volume
    USE public_var,  ONLY: vname_time_wm        ! name of varibale time for abstraction/injection
    USE public_var,  ONLY: vname_segid_wm       ! name of varibale river network hruid for abs/inj
-   USE public_var,  ONLY: dname_time_wm        ! name of dimension time for ans/inj
    USE public_var,  ONLY: dname_segid_wm       ! name of dimension hruid
    USE public_var,  ONLY: fname_remap          ! name of runoff mapping netCDF name
    USE public_var,  ONLY: calendar             ! name of calendar
@@ -695,13 +693,11 @@ CONTAINS
    call read_runoff_metadata(fname,                           & ! input: filename
                              vname_qsim,                      & ! input: varibale name for simulated runoff
                              vname_time,                      & ! input: varibale name for time
-                             dname_time,                      & ! input: dimension of variable time
                              vname_hruid,                     & ! input: varibale hruid
                              dname_hruid,                     & ! input: dimension of varibale hru
                              dname_ylat,                      & ! input: dimension of lat
                              dname_xlon,                      & ! input: dimension of lon
                              runoff_data%nSpace,              & ! nSpace of the input in runoff or wm strcuture
-                             runoff_data%nTime,               & ! nTime of the input in runoff or wm strcuture
                              runoff_data%sim,                 & ! 1D simulation
                              runoff_data%sim2D,               & ! 2D simulation
                              runoff_data%hru_id,              & ! ID of seg or hru in data
@@ -803,13 +799,11 @@ CONTAINS
      call read_runoff_metadata(fname,                         & ! input: filename
                                vname_flux_wm,                 & ! input: varibale name for simulated runoff
                                vname_time_wm,                 & ! input: varibale name for time
-                               dname_time_wm,                 & ! input: dimension of variable time
                                vname_segid_wm,                & ! input: varibale hruid
                                dname_segid_wm,                & ! input: dimension of varibale hru
                                dname_ylat,                    & ! input: dimension of lat
                                dname_xlon,                    & ! input: dimension of lon
                                wm_data%nSpace,                & ! nSpace of the input in runoff or wm strcuture
-                               wm_data%nTime,                 & ! nTime of the input in runoff or wm strcuture
                                wm_data%sim,                   & ! 1D simulation
                                wm_data%sim2D,                 & ! 2D simulation
                                wm_data%seg_id,                & ! ID of seg or hru in data

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -270,7 +270,8 @@ CONTAINS
     case default
       ierr=20; message=trim(message)//'<time_units>= '//trim(t_unit)//': <time_units> must be seconds, minutes, hours or days.'; return
    end select
-   inputFileInfo(iFile)%convTime2Days = convTime2Days
+   ! convert timeValue unit to day
+   inputFileInfo(iFile)%timeVar(:) = inputFileInfo(iFile)%timeVar(:)/convTime2Days
 
    ! get the reference julian day from the nc file
    call refDatetime%str2datetime(trim(inputFileInfo(iFile)%unit), ierr, message)
@@ -325,14 +326,14 @@ CONTAINS
   ! set the reference julday based on the first nc file of simulation
   nFile               = size(inputFileInfo_ro)
   nFile_wm            = size(inputFileInfo_wm)
-  day_runoff_start    = inputFileInfo_ro(1)%timeVar(1)/inputFileInfo_ro(1)%convTime2Days+inputFileInfo_ro(1)%ncrefjulday
+  day_runoff_start    = inputFileInfo_ro(1)%timeVar(1)+inputFileInfo_ro(1)%ncrefjulday
 
   do iFile=1,nFile_wm
 
     nt = inputFileInfo_wm(iFile)%nTime ! get the number of time
 
-    day_start_diff = inputFileInfo_wm(iFile)%timeVar(1) /inputFileInfo_wm(iFile)%convTime2Days+inputFileInfo_wm(iFile)%ncrefjulday - day_runoff_start
-    day_end_diff   = inputFileInfo_wm(iFile)%timeVar(nt)/inputFileInfo_wm(iFile)%convTime2Days+inputFileInfo_wm(iFile)%ncrefjulday - day_runoff_start
+    day_start_diff = inputFileInfo_wm(iFile)%timeVar(1) +inputFileInfo_wm(iFile)%ncrefjulday - day_runoff_start
+    day_end_diff   = inputFileInfo_wm(iFile)%timeVar(nt)+inputFileInfo_wm(iFile)%ncrefjulday - day_runoff_start
 
     inputFileInfo_wm(iFile)%iTimebound(1) = int(day_start_diff * secprday/dt_ro, kind=i4b) + 1 ! to convert the day difference into time step difference
     inputFileInfo_wm(iFile)%iTimebound(2) = int(day_end_diff   * secprday/dt_ro, kind=i4b) + 1 ! to convert the day difference into time step difference
@@ -450,7 +451,7 @@ CONTAINS
   do iFile=1,nFile
     nt = inFileInfo_ro(iFile)%nTime
     roJulday(counter:counter+nt-1) = &
-    inFileInfo_ro(iFile)%timeVar(1:nt)/inFileInfo_ro(iFile)%convTime2Days+inFileInfo_ro(iFile)%ncrefjulday
+    inFileInfo_ro(iFile)%timeVar(1:nt)+inFileInfo_ro(iFile)%ncrefjulday
     counter = counter + inFileInfo_ro(iFile)%nTime
   end do
 
@@ -530,7 +531,7 @@ CONTAINS
     do iFile=1,nFile_wm
       nt = inFileInfo_wm(iFile)%nTime
       roJulday_wm(counter:counter+nt-1) = &
-      inFileInfo_wm(iFile)%timeVar(1:nt)/inFileInfo_wm(iFile)%convTime2Days+inFileInfo_wm(iFile)%ncrefjulday
+      inFileInfo_wm(iFile)%timeVar(1:nt)+inFileInfo_wm(iFile)%ncrefjulday
       counter = counter + inFileInfo_wm(iFile)%nTime
     enddo
 

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -646,18 +646,14 @@ CONTAINS
    USE public_var,  ONLY: vname_evapo          ! name of simulated evaporation varibale
    USE public_var,  ONLY: vname_precip         ! name of simulated precipitation varibale
    USE public_var,  ONLY: vname_hruid          ! name of name of varibale hruid
-   USE public_var,  ONLY: vname_time           ! name of varibale time
    USE public_var,  ONLY: dname_hruid          ! name of dimension for varibale hruid
    USE public_var,  ONLY: dname_xlon           ! name of dimension for lon
    USE public_var,  ONLY: dname_ylat           ! name of dimension for lat
    USE public_var,  ONLY: vname_flux_wm        ! name of varibale abstraction/injection
    USE public_var,  ONLY: vname_vol_wm         ! name of varibale target volume
-   USE public_var,  ONLY: vname_time_wm        ! name of varibale time for abstraction/injection
    USE public_var,  ONLY: vname_segid_wm       ! name of varibale river network hruid for abs/inj
    USE public_var,  ONLY: dname_segid_wm       ! name of dimension hruid
    USE public_var,  ONLY: fname_remap          ! name of runoff mapping netCDF name
-   USE public_var,  ONLY: calendar             ! name of calendar
-   USE public_var,  ONLY: time_units           ! time units
    USE public_var,  ONLY: is_remap             ! logical whether or not runnoff needs to be mapped to river network HRU
    USE public_var,  ONLY: is_lake_sim          ! logical if lakes simulations are activated
    USE public_var,  ONLY: is_flux_wm           ! logical whether or not abstraction or injection should be read
@@ -692,7 +688,6 @@ CONTAINS
    ! get runoff metadata for simulated runoff, evaporation and precipitation
    call read_runoff_metadata(fname,                           & ! input: filename
                              vname_qsim,                      & ! input: varibale name for simulated runoff
-                             vname_time,                      & ! input: varibale name for time
                              vname_hruid,                     & ! input: varibale hruid
                              dname_hruid,                     & ! input: dimension of varibale hru
                              dname_ylat,                      & ! input: dimension of lat
@@ -701,7 +696,7 @@ CONTAINS
                              runoff_data%sim,                 & ! 1D simulation
                              runoff_data%sim2D,               & ! 2D simulation
                              runoff_data%hru_id,              & ! ID of seg or hru in data
-                             time_units, calendar,            & ! output: number of time steps, time units, calendar
+                             runoff_data%fillvalue,           & ! fillvalue for data
                              ierr, cmessage)                    ! output: error control
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
@@ -798,7 +793,6 @@ CONTAINS
 
      call read_runoff_metadata(fname,                         & ! input: filename
                                vname_flux_wm,                 & ! input: varibale name for simulated runoff
-                               vname_time_wm,                 & ! input: varibale name for time
                                vname_segid_wm,                & ! input: varibale hruid
                                dname_segid_wm,                & ! input: dimension of varibale hru
                                dname_ylat,                    & ! input: dimension of lat
@@ -806,8 +800,8 @@ CONTAINS
                                wm_data%nSpace,                & ! nSpace of the input in runoff or wm strcuture
                                wm_data%sim,                   & ! 1D simulation
                                wm_data%sim2D,                 & ! 2D simulation
-                               wm_data%seg_id,                & ! ID of seg or hru in data
-                               time_units, calendar,          & ! output: number of time steps, time units, calendar
+                               wm_data%seg_id,                & ! ID of seg in data
+                               wm_data%fillvalue,             & ! fillvalue for data
                                ierr, cmessage)                  ! output: error control
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -103,13 +103,12 @@ CONTAINS
 
 
  ! *********************************************************************
- ! public subroutine: initiate the reading of the netcdf files for runoff
+ ! private subroutine: initiate the reading of the netcdf files for runoff
  ! or abstraction or injection
  ! *********************************************************************
 
  SUBROUTINE init_inFile_pop (ierr, message)  ! output
 
-  ! Shared data
   USE public_var, ONLY: input_dir               ! directory containing the text files of fname_qsim and fname_wm
   USE public_var, ONLY: fname_qsim              ! simulated runoff txt file that includes the NetCDF file names
   USE public_var, ONLY: vname_time              ! variable name for time
@@ -123,15 +122,12 @@ CONTAINS
   USE public_var, ONLY: is_flux_wm              ! logical whether or not abstraction and injection should be read from the file
   USE public_var, ONLY: is_vol_wm               ! logical whether or not target volume for lakes should be read
 
-
-  ! output: error control
+  ! Argument variables
   integer(i4b),         intent(out)    :: ierr             ! error code
   character(*),         intent(out)    :: message          ! error message
-
-  ! local:
+  ! local variables
   character(len=strLen)                :: cmessage         ! error message of downwind routine
 
-  ! initialize error control
   ierr=0; message='init_inFile_pop/'
 
   call inFile_pop(input_dir,         & ! input: name of the directory of the txt file
@@ -177,43 +173,37 @@ CONTAINS
                        inputfileinfo,    & ! output: input file information
                        ierr, message)      ! output: error control
 
-  ! data types
   USE dataTypes,           ONLY: infileinfo     ! the data type for storing the infromation of the nc files and its attributes
   USE datetime_data,       ONLY: datetime       ! datetime data
-  ! subroutines
   USE ascii_utils,         ONLY: file_open      ! open file (performs a few checks as well)
   USE ascii_utils,         ONLY: get_vlines     ! get a list of character strings from non-comment lines
-  USE ncio_utils,          ONLY: get_nc         ! get the
-  USE ncio_utils,          ONLY: get_var_attr   ! get the attributes interface
+  USE ncio_utils,          ONLY: get_nc         ! Read netCDF variable data
+  USE ncio_utils,          ONLY: get_var_attr   ! Read attributes variables
   USE ncio_utils,          ONLY: get_nc_dim_len ! get the nc dimension length
-  ! Shared data
   USE public_var,          ONLY: time_units     ! get the time units from control file and replace if not provided in nc files
   USE public_var,          ONLY: calendar       ! get the calendar from control file and replace if not provided in nc files
 
-  ! input
-  character(len=strLen), intent(in)    :: dir_name         ! the name of the directory that the txt file located
-  character(len=strLen), intent(in)    :: file_name        ! the name of the file that include the nc file names
-  character(len=strLen), intent(in)    :: time_var_name    ! the name of the time variable
-  character(len=strLen), intent(in)    :: time_dim_name    ! the name of dimension time
-  ! inoutput
-  type(infileinfo),     intent(inout), allocatable :: inputfileinfo(:)    ! the name of structure that hold the infile information
-  ! output
-  integer(i4b),         intent(out)                :: ierr             ! error code
-  character(*),         intent(out)                :: message          ! error message
+  ! Argument variables
+  character(len=strLen), intent(in)                 :: dir_name         ! the name of the directory that the txt file located
+  character(len=strLen), intent(in)                 :: file_name        ! the name of the file that include the nc file names
+  character(len=strLen), intent(in)                 :: time_var_name    ! the name of the time variable
+  character(len=strLen), intent(in)                 :: time_dim_name    ! the name of dimension time
+  type(infileinfo),      intent(inout), allocatable :: inputfileinfo(:) ! the name of structure that hold the infile information
+  integer(i4b),          intent(out)                :: ierr             ! error code
+  character(*),          intent(out)                :: message          ! error message
   ! local varibales
-  integer(i4b)                         :: unit             ! file unit (free unit output from file_open)
-  character(len=7)                     :: t_unit           ! time units. "<time_step> since yyyy-MM-dd hh:mm:ss"
-  integer(i4b)                         :: iFile            ! counter for forcing files
-  integer(i4b)                         :: nFile            ! number of nc files identified in the text file
-  integer(i4b)                         :: nTime            ! hard coded for now
-  type(datetime)                       :: refDatetime      ! reference datetime for each file
-  real(dp)                             :: convTime2Days    ! conversion of the day to the local time
-  character(len=strLen)                :: infilename       ! input filename
-  character(len=strLen),allocatable    :: dataLines(:)     ! vector of lines of information (non-comment lines)
-  character(len=strLen)                :: filenameData     ! name of forcing datafile
-  character(len=strLen)                :: cmessage         ! error message of downwind routine
+  integer(i4b)                                      :: unit             ! file unit (free unit output from file_open)
+  character(len=7)                                  :: t_unit           ! time units. "<time_step> since yyyy-MM-dd hh:mm:ss"
+  integer(i4b)                                      :: iFile            ! counter for forcing files
+  integer(i4b)                                      :: nFile            ! number of nc files identified in the text file
+  integer(i4b)                                      :: nTime            ! hard coded for now
+  type(datetime)                                    :: refDatetime      ! reference datetime for each file
+  real(dp)                                          :: convTime2Days    ! conversion of the day to the local time
+  character(len=strLen)                             :: infilename       ! input filename
+  character(len=strLen),allocatable                 :: dataLines(:)     ! vector of lines of information (non-comment lines)
+  character(len=strLen)                             :: filenameData     ! name of forcing datafile
+  character(len=strLen)                             :: cmessage         ! error message of downwind routine
 
-  ! initialize error control
   ierr=0; message='inFile_pop/'
 
   ! build filename and its path containing list of NetCDF files
@@ -316,31 +306,24 @@ CONTAINS
                              inputfileinfo_wm,   & ! inout: input file information
                              ierr, message)        ! output: error control
 
-  ! data types
-  USE dataTypes, ONLY: infileinfo               ! the data type for storing the infromation of the nc files and its attributes
-
-  ! public data
+  USE dataTypes,  ONLY: infileinfo    ! the data type for storing the infromation of the nc files and its attributes
   USE public_var, ONLY: dt            ! simulation time step in seconds
   USE public_var, ONLY: secprday      ! conversion of steps in days to seconds
 
-  ! input
-  type(infileinfo),         intent(in)              :: inputfileinfo(:)       ! the name of structure that hold the infile information
-  ! inout
-  type(infileinfo),         intent(inout)           :: inputfileinfo_wm(:)    ! the name of structure that hold the infile information
-  ! output
-  integer(i4b),             intent(out)             :: ierr             ! error code
-  character(*),             intent(out)             :: message          ! error message
-  ! local
+  ! Argument variables
+  type(infileinfo),         intent(in)              :: inputfileinfo(:)      ! the name of structure that hold the infile information
+  type(infileinfo),         intent(inout)           :: inputfileinfo_wm(:)   ! the name of structure that hold the infile information
+  integer(i4b),             intent(out)             :: ierr                  ! error code
+  character(*),             intent(out)             :: message               ! error message
+  ! local variables
   integer(i4b)                                      :: nt
-  integer(i4b)                                      :: nFile             ! number of nc files for the simulated runoff
-  integer(i4b)                                      :: nFile_wm          ! number of nc files for the water managent
-  integer(i4b)                                      :: iFile             ! for loop over the nc files
-  real(dp)                                          :: day_runoff_start  ! the Julian day that runoff starts
-  real(dp)                                          :: day_start_diff    ! conversion of the day to the local time
-  real(dp)                                          :: day_end_diff      ! conversion of the day to the local time
+  integer(i4b)                                      :: nFile                 ! number of nc files for the simulated runoff
+  integer(i4b)                                      :: nFile_wm              ! number of nc files for the water managent
+  integer(i4b)                                      :: iFile                 ! for loop over the nc files
+  real(dp)                                          :: day_runoff_start      ! the Julian day that runoff starts
+  real(dp)                                          :: day_start_diff        ! conversion of the day to the local time
+  real(dp)                                          :: day_end_diff          ! conversion of the day to the local time
 
-
-  ! initialize error control
   ierr=0; message='inFile_sync_time/'
 
   ! set the reference julday based on the first nc file of simulation
@@ -388,10 +371,8 @@ CONTAINS
   ! - begDatetime, endDatetime:   simulationg start and end datetime
   ! - restDatetime, dropDatetime
 
-  USE ascii_utils, ONLY : lower            ! convert string to lower case
-  ! derived datatype
+  USE ascii_utils, ONLY : lower                  ! convert string to lower case
   USE datetime_data, ONLY : datetime             ! datetime data
-  ! public data
   USE public_var, ONLY: time_units               ! time units (seconds, hours, or days)
   USE public_var, ONLY: simStart                 ! date string defining the start of the simulation
   USE public_var, ONLY: simEnd                   ! date string defining the end of the simulation
@@ -405,7 +386,6 @@ CONTAINS
   USE public_var, ONLY: restart_day              ! periodic restart day
   USE public_var, ONLY: restart_hour             ! periodic restart hr
   USE public_var, ONLY: maxTimeDiff              ! time difference tolerance for input checks
-  ! saved time variables
   USE globalData, ONLY: timeVar                  ! time variables (unit given by runoff data)
   USE globalData, ONLY: iTime                    ! time index at simulation time step
   USE globalData, ONLY: simDatetime              ! model time data (yyyy:mm:dd:hh:mm:ss)
@@ -421,10 +401,10 @@ CONTAINS
 
   implicit none
 
-  ! output: error control
+  ! Argument variables
   integer(i4b),              intent(out)   :: ierr                ! error code
   character(*),              intent(out)   :: message             ! error message
-  ! local variable
+  ! local variables
   integer(i4b)                             :: ix
   integer(i4b)                             :: counter
   integer(i4b)                             :: nTime
@@ -446,7 +426,6 @@ CONTAINS
   character(len=strLen)                    :: cmessage            ! error message of downwind routine
   character(len=50)                        :: fmt1='(a,I4,a,I2.2,a,I2.2,x,I2.2,a,I2.2,a,F5.2)'
 
-  ! initialize error control
   ierr=0; message='init_time/'
 
   ! Set time attributes for continuous time variables (saved in globalData to use for output)
@@ -654,15 +633,13 @@ CONTAINS
    USE globalData, ONLY: wm_data              ! abstraction injection data structure
 
    implicit none
-   ! input:
+   ! Argument variables
    integer(i4b),              intent(in)    :: pid              ! proc id
-   ! output: error control
    integer(i4b),              intent(out)   :: ierr             ! error code
    character(*),              intent(out)   :: message          ! error message
-   ! local:
+   ! local variables
    character(len=strLen)                    :: cmessage         ! error message of downwind routine
 
-   ! initialize error control
    ierr=0; message='init_runoff_data/'
 
    if (pid==0) then
@@ -721,12 +698,11 @@ CONTAINS
  USE read_remap,  ONLY: get_remap_data         ! read remap data
 
  implicit none
- ! data structures
+ ! Argument variables
  logical(lgt), intent(in)           :: remap_flag       ! logical whether or not runnoff needs to be mapped to river network HRU
  type(remap),  intent(out)          :: remap_data_in    ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
  type(runoff), intent(out)          :: runoff_data_in   ! runoff for one time step for all HRUs
  type(wm),     intent(out)          :: wm_data_in       ! abstraction/injection for one time step for all HRUs
- ! error control
  integer(i4b), intent(out)          :: ierr             ! error code
  character(*), intent(out)          :: message          ! error message
  ! local variables
@@ -734,7 +710,6 @@ CONTAINS
  integer(i4b), allocatable          :: unq_idx(:)
  character(len=strLen)              :: cmessage         ! error message from subroutine
 
- ! initialize error control
  ierr=0; message='init_runoff/'
 
  ! get runoff metadata for simulated runoff, evaporation and precipitation
@@ -864,7 +839,7 @@ CONTAINS
 
 
  ! *****
- ! private subroutine: get indices of mapping points within runoff file...
+ ! private subroutine: get indices of mapping points within runoff file... (To be removed since the same routine in nr_utils)
  ! ***********************************************************************
  SUBROUTINE get_qix(qid,qidMaster,qix,ierr,message)
 

--- a/route/build/src/standalone/read_runoff.f90
+++ b/route/build/src/standalone/read_runoff.f90
@@ -27,13 +27,11 @@ CONTAINS
  SUBROUTINE read_runoff_metadata(fname            , & ! input: filename including directory
                                  var_name         , & ! input: varibale name
                                  var_time_name    , & ! input: name of varibale time
-                                 dim_time_name    , & ! input: name of dimension time
                                  var_hru_name     , & ! input: name of varibale HRUs
                                  dim_hru_name     , & ! input: name of dimension HRUs
                                  dim_ylat_name    , & ! input: name of dimension lat in case of a 2D input varibale
                                  dim_xlon_name    , & ! input: name of dimension lon in case of a 2D input varibale
                                  nSpace           , & ! output: nSpace of the input in runoff or wm strcuture
-                                 nTime            , & ! output: nTime of the input in runoff or wm strcuture
                                  sim              , & ! output: 1D simulation
                                  sim2D            , & ! output: 2D simulation
                                  ID_array         , & ! output: ID of seg or hru in data
@@ -45,13 +43,11 @@ CONTAINS
  character(*),              intent(in)    :: fname           ! filename
  character(*),              intent(in)    :: var_name        ! name of the varibale for simulated runoff or abstraction/injection
  character(*),              intent(in)    :: var_time_name   ! name of the varibale time
- character(*),              intent(in)    :: dim_time_name   ! name of dimension for time
  character(*),              intent(in)    :: var_hru_name    ! name of the varibale hru
  character(*),              intent(in)    :: dim_hru_name    ! name of dimension for hydrological HRUs
  character(*),              intent(in)    :: dim_ylat_name   ! name of dimension along lat
  character(*),              intent(in)    :: dim_xlon_name   ! name of dimension along lon
  integer(i4b),              intent(out)   :: nSpace(1:2)     ! nSpace of the input in runoff or wm strcuture
- integer(i4b),              intent(out)   :: nTime           ! nTime of the input in runoff or wm strcuture
  real(dp),     allocatable, intent(out)   :: sim(:)          ! 1D simulation
  real(dp),     allocatable, intent(out)   :: sim2D(:,:)      ! 2D simulation
  integer(i4b), allocatable, intent(out)   :: ID_array(:)     ! ID of seg or hru in data
@@ -83,11 +79,9 @@ CONTAINS
  select case( nDims )
   case(2); call read_1D_runoff_metadata(fname,            & ! name of dile including its directory
                                         var_time_name,    & ! name of varibale time
-                                        dim_time_name,    & ! dimension of varibale time
                                         var_hru_name,     & ! name of varibale hrus
                                         dim_hru_name,     & ! dimension of varibales hrus
                                         nSpace,           & ! nSpace of the input in runoff or wm strcuture
-                                        nTime,            & ! nTime of the input in runoff or wm strcuture
                                         sim,              & ! 1D simulation
                                         ID_array,         & ! ID of seg or hru in data
                                         timeUnits,        &
@@ -95,11 +89,9 @@ CONTAINS
                                         ierr, cmessage)
   case(3); call read_2D_runoff_metadata(fname,            & ! name of file including its directory
                                         var_time_name,    & ! name of varibale time
-                                        dim_time_name,    & ! dimension of varibale time
                                         dim_ylat_name,    & ! dimesnion of lat
                                         dim_xlon_name,    & ! dimension of lon
                                         nSpace,           & ! nSpace of the input in runoff or wm strcuture
-                                        nTime,            & ! nTime of the input in runoff or wm strcuture
                                         sim2D,            & ! 2D simulation
                                         ID_array,         & ! ID of seg or hru in data
                                         timeUnits,        &
@@ -116,11 +108,9 @@ CONTAINS
  ! ******************************************
  SUBROUTINE read_1D_runoff_metadata(fname           , & ! input: filename
                                    var_time_name    , & ! input: name of varibale time
-                                   dim_time_name    , & ! input: name of dimension time
                                    var_hru_name     , & ! input: name of varibale HRUs
                                    dim_hru_name     , & ! input: name of dimension HRUs
                                    nSpace           , & ! output: nSpace of the input in runoff or wm strcuture
-                                   nTime            , & ! output: nTime of the input in runoff or wm strcuture
                                    sim              , & ! output: 1D simulation
                                    ID_array         , & ! output: ID of seg or hru in data
                                    timeUnits        , & ! output: time units
@@ -130,11 +120,9 @@ CONTAINS
  ! argument variables
  character(*),               intent(in)          :: fname           ! filename
  character(*),               intent(in)          :: var_time_name   ! name of the varibale time
- character(*),               intent(in)          :: dim_time_name   ! name of dimension for time
  character(*),               intent(in)          :: var_hru_name    ! name of the varibale hru
  character(*),               intent(in)          :: dim_hru_name    ! name of dimension for hydrological HRUs
  integer(i4b),               intent(out)         :: nSpace(1:2)     ! nSpace of the input in runoff or wm strcuture
- integer(i4b),               intent(out)         :: nTime           ! nTime of the input in runoff or wm strcuture
  real(dp),     allocatable,  intent(out)         :: sim(:)          ! 1D simulation
  integer(i4b), allocatable,  intent(out)         :: ID_array(:)     ! ID of seg or hru in data
  character(*),               intent(out)         :: timeUnits       ! time units
@@ -150,10 +138,6 @@ CONTAINS
 
  ! get the number of HRUs
  call get_nc_dim_len(fname, trim(dim_hru_name), nSpace(1), ierr, cmessage)
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
- ! get number of time steps from the runoff file
- call get_nc_dim_len(fname, trim(dim_time_name), nTime, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! get the time units
@@ -187,11 +171,9 @@ CONTAINS
  ! ******************************************
  SUBROUTINE read_2D_runoff_metadata(fname            , & ! input: filename
                                     var_time_name    , & ! input: name of varibale time
-                                    dim_time_name    , & ! input: name of dimension time
                                     dim_ylat_name    , & ! input: name of varibale HRUs
                                     dim_xlon_name    , & ! input: name of dimension HRUs
                                     nSpace           , & ! output: nSpace of the input in runoff or wm strcuture
-                                    nTime            , & ! output: nTime of the input in runoff or wm strcuture
                                     sim2D            , & ! output: 2D simulation
                                     ID_array         , & ! output: ID of seg or hru in data
                                     timeUnits        , & ! output: time units
@@ -201,11 +183,9 @@ CONTAINS
  ! argument variables
  character(*),                  intent(in)   :: fname           ! filename
  character(*),                  intent(in)   :: var_time_name   ! name of the varibale time
- character(*),                  intent(in)   :: dim_time_name   ! name of dimension for time
  character(*),                  intent(in)   :: dim_ylat_name   ! name of dimension along lat
  character(*),                  intent(in)   :: dim_xlon_name   ! name of dimension along lon
  integer(i4b),                  intent(out)  :: nSpace(1:2)     ! nSpace of the input in runoff or wm strcuture
- integer(i4b),                  intent(out)  :: nTime           ! nTime of the input in runoff or wm strcuture
  real(dp),     allocatable,     intent(out)  :: sim2D(:,:)      ! 2D simulation
  integer(i4b), allocatable,     intent(out)  :: ID_array(:)     ! ID of seg or hru in data
  character(*),                  intent(out)  :: timeUnits       ! time units
@@ -216,10 +196,6 @@ CONTAINS
  character(len=strLen)                       :: cmessage        ! error message from subroutine
 
  ierr=0; message='read_2D_runoff_metadata/'
-
- ! get number of time steps from the runoff file
- call get_nc_dim_len(fname, trim(dim_time_name), nTime, ierr, cmessage)
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! get the time units
  if (trim(timeUnits) == charMissing) then
@@ -401,7 +377,6 @@ CONTAINS
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! get the forcing data
- forc_data_in%sim2d(1:nSpace(2),1:nSpace(1)) = 0._dp
  do it = 1, nTime
    fname = trim(indir)//trim(inFileInfo_in(tmap_sim_forc_in%iFile(it))%infilename)
 
@@ -411,6 +386,7 @@ CONTAINS
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end do
 
+! move this outside reading routine
  ! get the _fill_values for forcing variable
  existFillVal = check_attr(fname, var_name, '_FillValue')
  if (existFillval) then
@@ -418,6 +394,7 @@ CONTAINS
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
 
+ forc_data_in%sim2d(1:nSpace(2),1:nSpace(1)) = 0._dp
  ! finalize
  if (nTime>1) then ! simulation time step includes multiple forcing time steps
    do ix2 = 1, nSpace(2)

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -190,24 +190,31 @@ MODULE var_lookup
   integer(i4b)     :: code            = integerMissing  ! 1. pfafstetter code
  endtype iLook_PFAF
  ! ***********************************************************************************************************
- ! ** define variables for segment fluxes/states variables
+ ! ** define history output fluxes/states variables
  ! ***********************************************************************************************************
- ! Reach fluxes
+ ! Reach/lake fluxes
  type, public  ::  iLook_RFLX
-  integer(i4b)     :: instRunoff        = integerMissing  ! 1. instantaneous runoff at reach outlet (m3/s)
-  integer(i4b)     :: dlayRunoff        = integerMissing  ! 2. delayed runoff at reach outlet (m3/s)
-  integer(i4b)     :: sumUpstreamRunoff = integerMissing  ! 3. sum of upstream runoff at reach outlet (m3/s)
-  integer(i4b)     :: KWTroutedRunoff   = integerMissing  ! 4. Lagrangian KWT routed runoff at reach outlet (m3/s)
-  integer(i4b)     :: KWroutedRunoff    = integerMissing  ! 5. KW routed runoff at reach outlet(m3/s)
-  integer(i4b)     :: MCroutedRunoff    = integerMissing  ! 6. muskingum-cunge routed runoff at reach outlet (m3/s)
-  integer(i4b)     :: DWroutedRunoff    = integerMissing  ! 7. diffusive wave routed runoff at reach outlet (m3/s)
-  integer(i4b)     :: IRFroutedRunoff   = integerMissing  ! 8. IRF routed runoff at reach outlet (m3/s)
-  integer(i4b)     :: volume            = integerMissing  ! 9. water volume in reach (m3)
+  integer(i4b)     :: instRunoff        = integerMissing  !  1. instantaneous runoff at reach outlet (m3/s)
+  integer(i4b)     :: dlayRunoff        = integerMissing  !  2. delayed runoff at reach outlet (m3/s)
+  integer(i4b)     :: sumUpstreamRunoff = integerMissing  !  3. sum of upstream runoff at reach outlet (m3/s)
+  integer(i4b)     :: IRFroutedRunoff   = integerMissing  !  4. IRF routed runoff at reach outlet (m3/s)
+  integer(i4b)     :: KWTroutedRunoff   = integerMissing  !  5. Lagrangian KWT routed runoff at reach outlet (m3/s)
+  integer(i4b)     :: KWroutedRunoff    = integerMissing  !  6. KW routed runoff at reach outlet(m3/s)
+  integer(i4b)     :: MCroutedRunoff    = integerMissing  !  7. muskingum-cunge routed runoff at reach outlet (m3/s)
+  integer(i4b)     :: DWroutedRunoff    = integerMissing  !  8. diffusive wave routed runoff at reach outlet (m3/s)
+  integer(i4b)     :: IRFvolume         = integerMissing  !  9. IRF water volume in reach/lake (m3)
+  integer(i4b)     :: KWTvolume         = integerMissing  ! 10. KWT water volume in reach/lake (m3)
+  integer(i4b)     :: KWvolume          = integerMissing  ! 11. KW water volume in reach/lake (m3)
+  integer(i4b)     :: MCvolume          = integerMissing  ! 12. MC water volume in reach/lake (m3)
+  integer(i4b)     :: DWvolume          = integerMissing  ! 13. DW water volume in reach/lake (m3)
  endtype iLook_RFLX
  ! HRU fluxes
  type, public  ::  iLook_HFLX
   integer(i4b)     :: basRunoff         = integerMissing  ! 1. basin runoff (m/s)
  endtype iLook_HFLX
+ ! ***********************************************************************************************************
+ ! ** define restart variables
+ ! ***********************************************************************************************************
  ! Reach inflow from basin
  type, public  ::  iLook_basinQ
   integer(i4b)     :: q              = integerMissing  ! 1. final discharge (m3/s)
@@ -265,7 +272,8 @@ MODULE var_lookup
                                                                          11,12,13,14,15,16,17,18,19,20, &
                                                                          21,22)
  type(iLook_PFAF)     ,public,parameter :: ixPFAF      = iLook_PFAF     ( 1)
- type(iLook_RFLX)     ,public,parameter :: ixRFLX      = iLook_RFLX     ( 1, 2, 3, 4, 5, 6, 7, 8, 9)
+ type(iLook_RFLX)     ,public,parameter :: ixRFLX      = iLook_RFLX     ( 1, 2, 3, 4, 5, 6, 7, 8, 9,10, &
+                                                                         11,12,13)
  type(iLook_HFLX)     ,public,parameter :: ixHFLX      = iLook_HFLX     ( 1)
  type(iLook_basinQ)   ,public,parameter :: ixBasinQ    = iLook_basinQ   ( 1)
  type(iLook_IRFbas)   ,public,parameter :: ixIRFbas    = iLook_IRFbas   ( 1)

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -228,6 +228,7 @@ MODULE var_lookup
   integer(i4b)     :: qwave          = integerMissing  ! 3. wave flow (m3/s)
   integer(i4b)     :: qwave_mod      = integerMissing  ! 4. wave flow after merged (m3/s)
   integer(i4b)     :: routed         = integerMissing  ! 5. Routed out of a segment or not (-)
+  integer(i4b)     :: vol            = integerMissing  ! 6. reach volume (m3)
  endtype iLook_KWT
  ! KW state/fluxes
  type, public  ::  iLook_KW
@@ -269,7 +270,7 @@ MODULE var_lookup
  type(iLook_basinQ)   ,public,parameter :: ixBasinQ    = iLook_basinQ   ( 1)
  type(iLook_IRFbas)   ,public,parameter :: ixIRFbas    = iLook_IRFbas   ( 1)
  type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      ( 1, 2)
- type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      ( 1, 2, 3, 4, 5)
+ type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      ( 1, 2, 3, 4, 5, 6)
  type(iLook_KW)       ,public,parameter :: ixKW        = iLook_KW       ( 1, 2)
  type(iLook_DW)       ,public,parameter :: ixDW        = iLook_DW       ( 1, 2)
  type(iLook_MC)       ,public,parameter :: ixMC        = iLook_MC       ( 1, 2)

--- a/route/build/src/water_balance.f90
+++ b/route/build/src/water_balance.f90
@@ -157,8 +157,8 @@ CONTAINS
         write(iulog,'(A,1PG15.7)') '  dVol [m3]         = ', wb_global(1)
         write(iulog,'(A,1PG15.7)') '  lateral flow [m3] = ', wb_global(2)
         write(iulog,'(A,1PG15.7)') '  precip [m3]       = ', wb_global(3)
-        write(iulog,'(A,1PG15.7)') '  abstraction [m3]  = ', wb_global(4)
-        write(iulog,'(A,1PG15.7)') '  evaporation [m3]  = ', wb_global(5)
+        write(iulog,'(A,1PG15.7)') '  evaporation [m3]  = ', wb_global(4)
+        write(iulog,'(A,1PG15.7)') '  abstraction [m3]  = ', wb_global(5)
         write(iulog,'(A,1PG15.7)') '  outflow [m3]      = ', wb_global(6)
         write(iulog,'(A,1PG15.7)') '  WBerr [m3]        = ', wb_error
       end if

--- a/route/build/src/water_balance.f90
+++ b/route/build/src/water_balance.f90
@@ -151,8 +151,8 @@ CONTAINS
 
     wb_error = wb_global(1)-sum(wb_global(2:6))
 
-    if (verbose) then
-      if (masterproc) then
+    if (masterproc) then
+      if (verbose) then
         write(iulog,'(A)') '  global water balance [m3] '
         write(iulog,'(A,1PG15.7)') '  dVol [m3]         = ', wb_global(1)
         write(iulog,'(A,1PG15.7)') '  lateral flow [m3] = ', wb_global(2)
@@ -162,11 +162,11 @@ CONTAINS
         write(iulog,'(A,1PG15.7)') '  outflow [m3]      = ', wb_global(6)
         write(iulog,'(A,1PG15.7)') '  WBerr [m3]        = ', wb_error
       end if
-    endif
 
-    if (abs(wb_error) > 1._dp) then ! tolerance is 1 [m3]
-      write(iulog,'(A,1PG15.7,1X,A)') ' WARNING: global WB error [m3] = ', wb_error, '> 1.0 [m3]'
-    end if
+      if (abs(wb_error) > 1._dp) then ! tolerance is 1 [m3]
+        write(iulog,'(A,1PG15.7,1X,A)') ' WARNING: global WB error [m3] = ', wb_error, '> 1.0 [m3]'
+      end if
+    endif
 
     CONTAINS
 

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -816,7 +816,6 @@ CONTAINS
  USE globalData, ONLY: nRch                ! number of reaches in network
  USE globalData, ONLY: TSEC                ! beginning/ending of simulation time step [sec]
  USE globalData, ONLY: timeVar             ! time variables (unit given by runoff data)
- USE globalData, ONLY: iTime               ! time index at simulation time step
 
  implicit none
 
@@ -880,7 +879,7 @@ CONTAINS
      ierr=20; message=trim(message)//'<time_units>= '//trim(time_units)//': <time_units> must be seconds, minutes, hours or days.'; return
  end select
 
- restartTimeVar = timeVar(iTime) + dt/secPerTime
+ restartTimeVar = timeVar + dt/secPerTime
 
  ! -- Write out to netCDF
 

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -154,7 +154,6 @@ CONTAINS
  SUBROUTINE output(ierr, message)
 
    USE public_var, ONLY: outputAtGage      ! ascii containing last restart and history files
-   USE globalData, ONLY: iTime
    USE globalData, ONLY: timeVar
    USE globalData, ONLY: rch_per_proc      ! number of reaches assigned to each proc (size = num of procs+1)
    USE globalData, ONLY: nRch_mainstem     ! number of mainstem reach
@@ -188,11 +187,11 @@ CONTAINS
      index_write_all = arth(1,1,nRch_local)
    end if
 
-   call hist_all_network%write_flux(timeVar(iTime), index_write_all, ierr, cmessage)
+   call hist_all_network%write_flux(timeVar, index_write_all, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    if (outputAtGage) then
-     call hist_gage%write_flux(timeVar(iTime), index_write_gage, ierr, cmessage)
+     call hist_gage%write_flux(timeVar, index_write_gage, ierr, cmessage)
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
    end if
 

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -283,7 +283,8 @@ CONTAINS
      reachID_local = NETOPO_trib(:)%REACHID
    endif
 
-   call reach_subset(reachID_local, gage_data, compdof=compdof_rch, index2=index_write_gage)
+   call reach_subset(reachID_local, gage_data, ierr, cmessage, compdof=compdof_rch, index2=index_write_gage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    ! Need to adjust tributary indices in root processor
    ! This is because RCHFLX has three components in the order: mainstem, halo, tributary

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -154,7 +154,8 @@ CONTAINS
  SUBROUTINE output(ierr, message)
 
    USE public_var, ONLY: outputAtGage      ! ascii containing last restart and history files
-   USE globalData, ONLY: timeVar
+   USE globalData, ONLY: timeVar           ! current simulation time variable
+   USE globalData, ONLY: RCHFLX_trib       ! reach flux data structure containing current flux variables
    USE globalData, ONLY: rch_per_proc      ! number of reaches assigned to each proc (size = num of procs+1)
    USE globalData, ONLY: nRch_mainstem     ! number of mainstem reach
    USE globalData, ONLY: nTribOutlet       ! number of
@@ -187,11 +188,12 @@ CONTAINS
      index_write_all = arth(1,1,nRch_local)
    end if
 
-   call hist_all_network%write_flux(timeVar, index_write_all, ierr, cmessage)
+   ! write out output variables in history files
+   call hist_all_network%write_flux(timeVar, RCHFLX_trib, index_write_all, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    if (outputAtGage) then
-     call hist_gage%write_flux(timeVar, index_write_gage, ierr, cmessage)
+     call hist_gage%write_flux(timeVar, RCHFLX_trib, index_write_gage, ierr, cmessage)
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
    end if
 

--- a/route/settings/SAMPLE.control
+++ b/route/settings/SAMPLE.control
@@ -12,77 +12,93 @@
 ! ****************************************************************************************************************************
 ! RUN CONTROL 
 ! --------------------------------------------
-<case_name>             CASE_NAME                  ! name of simulation
-<sim_start>             yyyy-mm-dd hh:mm:ss        ! time of simulation start. hh:mm:ss can be omitted
-<sim_end>               yyyy-mm-dd hh:mm:ss        ! time of simulation end. hh:mm:ss can be omitted 
-<route_opt>             1                          ! option for routing schemes 0->accum 1->IRF (default) 2->KWT 3->KW 4->MC 5->DW 
-<doesBasinRoute>        1                          ! basin routing options: 0-> no, 1->IRF, otherwise error
-<restart_write>         last                       ! restart write options: never, daily, monthly, annual, last, specified 
-<restart_date>          yyyy-mm-dd hh:mm:ss        ! restart date.  activated only if <restart_write> is "specified" 
-<fname_state_in>        INPUT_RESTART_NC           ! input restart netCDF name. remove for run without any particular initial channel states
-<newFileFrequency>      month                      ! output netcdf frequency: single, day, month, annual  
+<case_name>               CASE_NAME                  ! name of simulation
+<sim_start>               yyyy-mm-dd hh:mm:ss        ! time of simulation start. hh:mm:ss can be omitted
+<sim_end>                 yyyy-mm-dd hh:mm:ss        ! time of simulation end. hh:mm:ss can be omitted
+<route_opt>               1                          ! options for routing schemes (multiple options allowed): 1->IRF 2->KWT 3->KW 4->MC 5->DW
+<doesBasinRoute>          1                          ! basin routing options: 0-> no, 1->IRF, otherwise error
+<restart_write>           last                       ! restart write options: never, daily, monthly, yearly, last, specified
+<restart_date>            yyyy-mm-dd hh:mm:ss        ! restart date.  activated only if <restart_write> is "specified"
+<fname_state_in>          INPUT_RESTART_NC           ! input restart netCDF name. remove or 'coldstart' for run without any particular restart file
+<newFileFrequency>        month                      ! output netcdf frequency: single, daily, monthly, yearly
+<dt_qsim>                 86400                      ! time interval of the forcing [sec] e.g., 86400 sec for daily step
+! lake mode
+<is_lake_sim>             T                          ! switch on (T) or off (F) lake simulation
+<is_flux_wm>              T                          ! switch on (T) or off (F) abstraction from or injection to seg/lakes
+<is_vol_wm>               T                          ! switch on (T) or off (F) target volume
+<is_vol_wm_jumpstart>     T                          ! switch on (T) or off (F) for start for lakes with target volume
 ! ****************************************************************************************************************************
 ! DEFINE DIRECTORIES 
 ! --------------------------
-<ancil_dir>             ANCIL_DIR                  ! directory containing ancillary data (runoff mapping data, river network data)
-<input_dir>             INPUT_DIR                  ! directory containing input data (runoff data)
-<output_dir>            OUTPUT_DIR                 ! directory containing output data
+<ancil_dir>               ANCIL_DIR                  ! directory containing ancillary data (runoff mapping data, river network data)
+<input_dir>               INPUT_DIR                  ! directory containing input data (runoff data)
+<output_dir>              OUTPUT_DIR                 ! directory containing output data
 ! ****************************************************************************************************************************
 ! DEFINE FINE NAME AND DIMENSIONS
 ! ---------------------------------------
-<fname_ntopOld>         NTOPO_NC                   ! netCDF name for River Network
-<dname_sseg>            DIMNAME_SEG                ! dimension name of the stream segments
-<dname_nhru>            DIMNAME_HRU                ! dimension name of the HRUs
-! ****************************************************************************************************************************
-! DEFINE DESIRED VARIABLES FOR THE NETWORK TOPOLOGY
-! ---------------------------------------------------------
-<seg_outlet>            -9999                      ! seg_id of outlet streamflow segment. -9999 for all segments 
+<fname_ntopOld>           NTOPO_NC                   ! netCDF name for River Network
+<dname_sseg>              DIMNAME_SEG                ! dimension name of the stream segments
+<dname_nhru>              DIMNAME_HRU                ! dimension name of the HRUs
 ! ****************************************************************************************************************************
 ! DEFINE RUNOFF FILE
 ! ----------------------------------
-<fname_qsim>            RUNOFF_NC                  ! name of file containing the HRU runoff
-<vname_qsim>            VARNAME_RUNOFF             ! name of HRU runoff variable
-<vname_time>            VARNAME_TIME               ! name of time variable 
-<vname_hruid>           VARNAME_RO_HRU             ! name of runoff HRU id variable (if 1D runoff vector is input)
-<dname_xlon>            DIMNAME_XLON               ! name of x(j) dimension (if 2D runoff grid is input)
-<dname_ylat>            DIMNAME_YLAT               ! name of y(i) dimension (if 2D runoff grid is input)
-<dname_time>            DIMNAME_TIME               ! name of time dimension 
-<dname_hruid>           DIMNAME_RO_HRU             ! name of the HRU dimension (if 1D runoff vector is input) 
-<units_qsim>            mm/s                       ! units of runoff e.g., mm/s
-<dt_qsim>               86400                      ! time interval of the runoff [sec] e.g., 86400 sec for daily step
+<fname_qsim>              RUNOFF_NC                  ! name of text file listing forcing (runoff, precip, evapo) netcdf (chronologically ordered)
+<vname_qsim>              VARNAME_RUNOFF             ! name of runoff variable
+<vname_precip>            VARNAME_PRECIP             ! name of precipitation variable (used for only lake mode on)
+<vname_evapo>             VARNAME_EVAPO              ! name of evaporation variable (used for only lake mode on)
+<vname_time>              VARNAME_TIME               ! name of time variable
+<vname_hruid>             VARNAME_RO_HRU             ! name of forcing HRU id variable (if 1D vector is input)
+<dname_xlon>              DIMNAME_XLON               ! name of x(j) dimension (if 2D grid is input)
+<dname_ylat>              DIMNAME_YLAT               ! name of y(i) dimension (if 2D grid is input)
+<dname_time>              DIMNAME_TIME               ! name of time dimension
+<dname_hruid>             DIMNAME_RO_HRU             ! name of the HRU dimension (if 1D vector is input)
+<units_qsim>              mm/s                       ! units of runoff e.g., mm/s
+<dt_ro>                   86400                      ! time interval of the forcing [sec] e.g., 86400 sec for daily step
+! water-management option
+<fname_wm>                WM_NC_IN                   ! name of text file containing water-management netcdf (chronologically ordered)
+<vname_flux_wm>           VARNAME_WM_FLUX            ! name of varibale for abstraction/injection
+<vname_vol_wm>            VARNAME_WM_VOL             ! name of varibale for target volume for managed lakes
+<vname_time_wm>           VARNAME_WM_TIME            ! name of time variable
+<vname_segid_wm>          VARNAME_WM_SEG             ! name of the segment (or lake) ID varibale in netCDFs
+<dname_time_wm>           DIMNAME_WM_TIME            ! name of time dimension
+<dname_segid_wm>          DIMNAME_WM_SEG             ! name of segment/lake ID dimension
 ! ****************************************************************************************************************************
-! PART 6: DEFINE RUNOFF MAPPING FILE 
+! PART 6: DEFINE RUNOFF MAPPING FILE
 !  ----------------------------------
-<is_remap>              T                          ! logical whether or not runnoff needs to be mapped to river network HRU 
-<fname_remap>           MAPPING_NC                 ! name of runoff mapping netCDF 
-<vname_hruid_in_remap>  VARNAME_MAP_RN_HRU         ! name of variable for river network HRUs within each river network HRU 
-<vname_weight>          VARNAME_MAP_WEIGHT         ! name of variable for areal weights of runoff HRUs within each river network HRU
-<vname_qhruid>          VARNAME_MAP_RO_HRU         ! name of variable for runoff HRU ID (if 1D runoff vector is input)
-<vname_num_qhru>        VARNAME_MAP_NUM_RO_HRU     ! name of variable for a numbers of runoff HRUs within each river network HRU
-<dname_hru_remap>       DIMNAME_MAP_RN_HRU         ! name of hru dimension (if 1D runoff vector is input)
-<dname_data_remap>      DIMNAME_MAP_DATA           ! name of data dimension
-<vname_i_index>         DIMNAME_I_INDEX            ! name of ylat index dimension (if 2D runoff grid is input) 
-<vname_j_index>         DIMNAME_J_INDEX            ! name of xlon index dimension (if 2D runoff grid is input)
+<is_remap>                T                          ! logical whether or not runnoff needs to be mapped to river network HRU
+<fname_remap>             MAPPING_NC                 ! name of runoff mapping netCDF
+<vname_hruid_in_remap>    VARNAME_MAP_RN_HRU         ! name of variable for river network HRUs within each river network HRU
+<vname_weight>            VARNAME_MAP_WEIGHT         ! name of variable for areal weights of runoff HRUs within each river network HRU
+<vname_qhruid>            VARNAME_MAP_RO_HRU         ! name of variable for runoff HRU ID (if 1D runoff vector is input)
+<vname_num_qhru>          VARNAME_MAP_NUM_RO_HRU     ! name of variable for a numbers of runoff HRUs within each river network HRU
+<dname_hru_remap>         DIMNAME_MAP_RN_HRU         ! name of hru dimension (if 1D runoff vector is input)
+<dname_data_remap>        DIMNAME_MAP_DATA           ! name of data dimension
+<vname_i_index>           DIMNAME_I_INDEX            ! name of ylat index dimension (if 2D runoff grid is input)
+<vname_j_index>           DIMNAME_J_INDEX            ! name of xlon index dimension (if 2D runoff grid is input)
 ! ****************************************************************************************************************************
 ! Define options to include/skip calculations
 ! ----------------------------------------------------
-<hydGeometryOption>     1                          ! option for hydraulic geometry calculations (0=read from file, 1=compute)
-<topoNetworkOption>     1                          ! option for network topology calculations (0=read from file, 1=compute)
-<computeReachList>      1                          ! option to compute list of upstream reaches (0=do not compute, 1=compute)
+<hydGeometryOption>       1                          ! option for hydraulic geometry calculations (0=read from file, 1=compute)
+<topoNetworkOption>       1                          ! option for network topology calculations (0=read from file, 1=compute)
+<computeReachList>        1                          ! option to compute list of upstream reaches (0=do not compute, 1=compute)
 ! ****************************************************************************************************************************
-! Namelist file name 
+! Namelist file name
 ! ---------------------------
-<param_nml>             PARAMETER_NML              ! Namelist name containing routing parameter values 
+<param_nml>               PARAMETER_NML              ! Namelist name containing routing parameter values
 ! ****************************************************************************************************************************
 ! Dictionary to map variable names
 ! ---------------------------
-<varname_area>          Basin_Area                 ! name of variable holding hru area
-<varname_length>        Length                     ! name of variable holding segment length
-<varname_slope>         Slope                      ! name of variable holding segment slope
-<varname_HRUid>         hruid                      ! name of variable holding HRU id
-<varname_hruSegId>      seg_hru_id                 ! name of variable holding the stream segment below each HRU  
-<varname_segId>         seg_id                     ! name of variable holding the ID of each stream segment  
-<varname_downSegId>     tosegment                  ! name of variable holding the ID of the next downstream segment
+<varname_area>            Basin_Area                 ! name of variable holding hru area
+<varname_length>          Length                     ! name of variable holding segment length
+<varname_slope>           Slope                      ! name of variable holding segment slope
+<varname_HRUid>           hruid                      ! name of variable holding HRU id
+<varname_hruSegId>        seg_hru_id                 ! name of variable holding the stream segment below each HRU
+<varname_segId>           seg_id                     ! name of variable holding the ID of each stream segment
+<varname_downSegId>       tosegment                  ! name of variable holding the ID of the next downstream segment
+! if lake mode is on
+<varname_islake>          lake                       ! name of variable holding the islake flage (1=lake, 0=reach)
+<varname_lakeModelType>   lake_type                  ! name of variable holding the lake model type
+<varname_LakeTargVol>     target_vol                 ! name of varibale to identify the target volume flag
 ! ****************************************************************************************************************************
 ! ****************************************************************************************************************************
 ! ****************************************************************************************************************************
@@ -91,25 +107,26 @@
 ! See read_control.f90 for complete options
 !
 ! ****************************************************************************************************************************
-! Network augmentation
+! Network augmentation or subsetting
 ! ---------------------------
-<ntopAugmentMode>       F                          ! option for river network augmentation mode
-<fname_ntopNew>         AUGMENTED_NTOPO_NC         ! name of augmented river network netCDF
+<seg_outlet>              SEG_ID                     ! seg_id of outlet streamflow segment to subset for upstream basin.
+<ntopAugmentMode>         F                          ! option for river network augmentation mode
+<fname_ntopNew>           AUGMENTED_NTOPO_NC         ! name of augmented or subsetted river network netCDF
 ! ****************************************************************************************************************************
-! debugging  
+! debugging
 ! ---------------------------
-<debug>                 F                          ! print out detailed information throught the probram
-<desireId>              -9999                      ! turn off checks (-999) or speficy reach ID if necessary to print on screen
+<debug>                   F                          ! print out detailed information throught the probram
+<desireId>                -9999                      ! turn off checks (-999) or speficy reach ID if necessary to print on screen
 ! ****************************************************************************************************************************
 ! output options
 ! ---------------------------
-<basRunoff>             T                          ! HRU average runoff depth at HRU [L/T]
-<instRunoff>            T                          ! intantaneou runoff volume from Local HRUs at reach [L3/T]
-<dlayRunoff>            T                          ! delayed runoff voluem (discharge) from local HRUsi at reach [L3/T] 
-<sumUpstreamRunoff>     T                          ! accumulated total upstream discharge at reach [L3/T]
-<KWTroutedRunoff>       T                          ! kinematic wave tracking routed discharge at reach [L3/T]
-<IRFroutedRunoff>       T                          ! impulse response function routed discharge at reach [L3/T]
-<MCroutedRunoff>        T                          ! kinematic wave routed discharge at reach [L3/T]
-<KWroutedRunoff>        T                          ! muskingum-cunge routed discharge at reach [L3/T]
-<DWroutedRunoff>        T                          ! diffusive wave routed discharge at reach [L3/T]
-<volume>                F                          ! volume at the end of time step at reach [L3] - currently only IRF
+<basRunoff>               T                          ! HRU average runoff depth at HRU [L/T]
+<instRunoff>              T                          ! intantaneou runoff volume from Local HRUs at reach [L3/T]
+<dlayRunoff>              T                          ! delayed runoff voluem (discharge) from local HRUsi at reach [L3/T]
+<sumUpstreamRunoff>       T                          ! accumulated total upstream discharge at reach [L3/T]
+<KWTroutedRunoff>         T                          ! kinematic wave tracking routed discharge at reach [L3/T]
+<IRFroutedRunoff>         T                          ! impulse response function routed discharge at reach [L3/T]
+<MCroutedRunoff>          T                          ! kinematic wave routed discharge at reach [L3/T]
+<KWroutedRunoff>          T                          ! muskingum-cunge routed discharge at reach [L3/T]
+<DWroutedRunoff>          T                          ! diffusive wave routed discharge at reach [L3/T]
+<volume>                  F                          ! volume at the end of time step at reach [L3] - currently only IRF

--- a/route/settings/SAMPLE.control
+++ b/route/settings/SAMPLE.control
@@ -22,10 +22,10 @@
 <fname_state_in>          INPUT_RESTART_NC           ! input restart netCDF name. remove or 'coldstart' for run without any particular restart file
 <newFileFrequency>        month                      ! output netcdf frequency: single, daily, monthly, yearly
 <dt_qsim>                 86400                      ! time interval of the forcing [sec] e.g., 86400 sec for daily step
-! lake mode
+! lake and water management (wm) mode
 <is_lake_sim>             T                          ! switch on (T) or off (F) lake simulation
 <is_flux_wm>              T                          ! switch on (T) or off (F) abstraction from or injection to seg/lakes
-<is_vol_wm>               T                          ! switch on (T) or off (F) target volume
+<is_vol_wm>               T                          ! switch on (T) or off (F) target volume (threshold lake volume where water release is trigerred)
 <is_vol_wm_jumpstart>     T                          ! switch on (T) or off (F) for start for lakes with target volume
 ! ****************************************************************************************************************************
 ! DEFINE DIRECTORIES 


### PR DESCRIPTION
Allow user to specify simulation time step regardless of runoff and water-management input time steps.  Use new routine-timeMap_sim_forc to map time indices in runoff or/and water management data for each simulation time step. Allow sub-cycling (use the same forcing at multiple simulation time steps or aggregate forcing if simulation time step is larger than forcing time step).

Clean-ups:

- Removed duplicated routines (get_qix in standalone/model_setup.f90 and match_index in nr_util.f90)
- Removed un-used derived data-type (subbasin_omp_tmp)
- Removed or modify unnecessary components (in input_data, inFileInfo, runoff_data -> input_data and runoff and wm is extend from input_data)