### PR TITLE
Separate runoff input time step and simulation time step

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -146,7 +146,15 @@ end type subdomain
    integer(i4b)             , allocatable  :: qhru_ix(:)   ! Index of hrus associated with runoff simulation (="qhru")
  end type remap
 
- ! simulated runoff data
+ ! mapping time step between two time series e.g., simulation time step vs runoff time step
+ type, public :: map_time
+   integer(i4b), allocatable :: iTime(:)
+   real(dp),     allocatable :: frac(:)
+ end type map_time
+
+ ! ---------- forcing data  ----------------------------------------------------------------------
+
+ ! input runoff data
  type, public :: runoff
    integer(i4b)                            :: nTime         ! number of time steps
    integer(i4b)                            :: nSpace(1:2)   ! number of spatial dimension

--- a/route/build/src/get_basin_runoff.f90
+++ b/route/build/src/get_basin_runoff.f90
@@ -16,6 +16,7 @@ CONTAINS
 
  ! populate runoff_data with runoff values at LSM domain and at simulation time step
 
+  USE dataTypes,   ONLY: map_time                ! data type for time-step mapping between two time series
   USE public_var,  ONLY: input_dir               ! directory containing input data
   USE public_var,  ONLY: fname_qsim              ! simulated runoff netCDF name
   USE public_var,  ONLY: is_remap                ! logical whether or not runnoff needs to be mapped to river network HRU
@@ -25,11 +26,12 @@ CONTAINS
   USE globalData,  ONLY: runoff_data             ! data structure to hru runoff data
   USE globalData,  ONLY: remap_data              ! data structure to remap data
   USE globalData,  ONLY: iTime                   !
-  USE globalData,  ONLY: modTime                 !
-  USE globalData,  ONLY: gage_obs_data
-  USE globalData,  ONLY: rch_qtake_data
-  USE globalData,  ONLY: RCHFLX
-  USE globalData,  ONLY: tmap_sim_ro             !
+  USE globalData,  ONLY: simDatetime             ! current model time data (yyyy:mm:dd:hh:mm:sec)
+  USE globalData,  ONLY: begDatetime             ! forcing data start datetime data (yyyy:mm:dd:hh:mm:sec)
+  USE globalData,  ONLY: roBegDatetime           ! forcing data start datetime data (yyyy:mm:dd:hh:mm:sec)
+  USE globalData,  ONLY: gage_obs_data           !
+  USE globalData,  ONLY: rch_qtake_data          !
+  USE globalData,  ONLY: RCHFLX                  !
   USE read_runoff, ONLY: read_runoff_data        ! read runoff value into runoff_data data strucuture
   USE remapping,   ONLY: remap_runoff            ! mapping HM runoff to river network HRU runoff (HM_HRU /= RN_HRU)
   USE remapping,   ONLY: sort_runoff             ! mapping HM runoff to river network HRU runoff (HM_HRU == RN_HRU)
@@ -39,6 +41,7 @@ CONTAINS
   integer(i4b), intent(out)     :: ierr               ! error code
   character(*), intent(out)     :: message            ! error message
   ! local variables
+  type(map_time)                :: tmap_sim_ro        ! time-steps mapping data
   character(len=strLen)         :: cmessage           ! error message from subroutine
   integer(i4b)                  :: iens=1
   integer(i4b)                  :: ix, jx
@@ -54,10 +57,19 @@ CONTAINS
 
 !  call system_clock(count_rate=cr)
 
+  ! time step mapping from runoff time step to simulation time step
+  call timeMap_sim_forc(tmap_sim_ro,        &
+                        begDatetime,        &
+                        roBegDatetime,      &
+                        runoff_data%nTime,  &
+                        iTime,              &
+                        ierr, cmessage)
+  if(ierr/=0) then; message=trim(message)//trim(cmessage); return; endif
+
 !  call system_clock(startTime)
   ! get the simulated runoff for the current time step - runoff_data%qsim(:) or %qsim2D(:,:)
   call read_runoff_data(trim(input_dir)//trim(fname_qsim), & ! input: filename
-                        tmap_sim_ro(iTime),                & ! input: ro-sim time mapping at current simulation step
+                        tmap_sim_ro,                       & ! input: ro-sim time mapping at current simulation step
                         runoff_data,                       & ! inout: runoff data structure
                         ierr, cmessage)                      ! output: error control
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -83,7 +95,7 @@ CONTAINS
     case(direct_insert)
       RCHFLX(:,:)%QOBS = 0.0_dp
       ! read gage observation [m3/s] at current time
-      jx = gage_obs_data%time_ix(modTime(1))
+      jx = gage_obs_data%time_ix(simDatetime(1))
 
       if (jx/=integerMissing) then ! there is observation at this time step
         call gage_obs_data%read_obs(ierr, cmessage, index_time=jx)
@@ -111,7 +123,7 @@ CONTAINS
   RCHFLX(:,:)%TAKE = 0.0_dp
   if (takeWater) then
     ! read reach water take [m3/s] at current time
-    jx = rch_qtake_data%time_ix(modTime(1))
+    jx = rch_qtake_data%time_ix(simDatetime(1))
 
     if (jx/=integerMissing) then
       call rch_qtake_data%read_obs(ierr, cmessage, index_time=jx)
@@ -127,5 +139,106 @@ CONTAINS
   end if
 
  END SUBROUTINE get_hru_runoff
+
+ ! *********************************************************************
+ ! private subroutine: initialize simulation time
+ ! *********************************************************************
+ SUBROUTINE timeMap_sim_forc(tmap_sim_forc,     & ! inout: time-steps mapping data
+                             startSim, startRo, & ! input: starting datetime for simulation and input
+                             nRo,               & ! input: numbers of runoff time steps
+                             ixTime,            & ! input: simulation time index
+                             ierr, message)
+
+   USE nr_utility_module, ONLY: arth
+   USE datetime_data,     ONLY: datetime       ! time data type
+   USE dataTypes,         ONLY: map_time       ! data type for time-step mapping between two time series
+   USE public_var,        ONLY: verySmall      ! smallest real values
+   USE public_var,        ONLY: secprday       ! day to second conversion factor
+   USE public_var,        ONLY: calendar       ! calender
+   USE public_var,        ONLY: dt             ! simulation time step
+   USE public_var,        ONLY: dt_ro          ! input time step
+
+   implicit none
+   ! Argument variables
+   type(map_time),              intent(out)   :: tmap_sim_forc    ! time-steps mapping data
+   type(datetime),              intent(in)    :: startSim         ! simulation start datetime
+   type(datetime),              intent(in)    :: startRo          ! runoff data start datetime
+   integer(i4b),                intent(in)    :: nRo              ! number of runoff data time steps
+   integer(i4b),                intent(in)    :: ixTime           ! number of simulation time steps
+   integer(i4b),                intent(out)   :: ierr             ! error code
+   character(*),                intent(out)   :: message          ! error message
+   ! Local variables
+   character(len=strLen)                      :: cmessage         ! error message from subroutine
+   real(dp)                                   :: frcLapse(nRo+1)  !
+   real(dp)                                   :: simLapse(2)      !
+   real(dp)                                   :: startRoSec       ! starting runoff time relative to starting simulation time [sec]
+   real(dp)                                   :: juldayRo         ! starting julian day in runoff time step [day]
+   real(dp)                                   :: juldaySim        ! starting julian day in simulation time step [day]
+   integer(i4b)                               :: ctr              ! counter
+   integer(i4b)                               :: nRoSub           !
+   integer(i4b)                               :: iFile            ! loop index of input file
+   integer(i4b)                               :: iRo              ! loop index of runoff time step
+   integer(i4b)                               :: idxFront         ! index of r of which top is within ith model layer (i=1..nLyr)
+   integer(i4b)                               :: idxEnd           ! index of the lowest soil layer of which bottom is within ith model layer (i=1..nLyr)
+
+   ierr=0; message='timeMap_sim_forc/'
+
+   call startRo%julianday(calendar, juldayRo, ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   call startSim%julianday(calendar,juldaySim,  ierr, cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+   startRoSec = (juldaySim - juldayRo)*secprday ! day->sec
+
+   simLapse(1) = startRoSec+dt*(ixTime-1)
+   simLapse(2) = simLapse(1) + dt
+   frcLapse    = arth(0._dp,      dt_ro, nRo+1)
+
+   !-- Find index of runoff time period of which end is within simulation period
+   ! condition: from beginning to end of runoff time, first index of time period whose end exceeds the beginning of simulation time step
+   do iRo = 1,nRo
+     if (simLapse(1)<frcLapse(iRo+1)) then
+       idxFront = iRo; exit
+     end if
+   end do
+   !-- Find index of runoff time period of which beginning is within simulation period
+   ! condition: from beginning to end of runoff time, first index of time period whose end exceeds the beginning of simulation time step
+   do iRo = 1,nRo
+     if ( simLapse(2)<frcLapse(iRo+1) .or. abs(simLapse(2)-frcLapse(iRo+1))<verySmall ) then
+       idxEnd = iRo; exit
+     end if
+   end do
+
+   ! Error check
+   if (idxFront-idxEnd>0)then;ierr=30;message=trim(message)//'index of idxFront lower than idxEnd';return;endif
+
+   !-- Compute weight of soil layer contributing to each model layer and populate lyrmap variable
+   ctr = 1
+   nRoSub = idxEnd-idxFront + 1
+
+   allocate(tmap_sim_forc%iTime(nRoSub), stat=ierr, errmsg=cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage)//'tmap_sim_forc%iTime or iFile'; return; endif
+
+   if (idxFront == idxEnd)then ! if simulation period is completely within runoff period - one runoff time period per simulation period
+     tmap_sim_forc%iTime(ctr) = idxFront
+   else
+     allocate(tmap_sim_forc%frac(nRoSub), stat=ierr, errmsg=cmessage)
+     if(ierr/=0)then; message=trim(message)//trim(cmessage)//'tmap_sim_forc%frac'; return; endif
+
+     ! loop frm the ealiest runoff time index to the latest, and compute fraction
+     do iRo=idxFront, idxEnd
+       tmap_sim_forc%iTime(ctr) = iRo
+       if (iRo == idxFront)then        ! front side of simulation time step
+         tmap_sim_forc%frac(ctr)   = (frcLapse(iRo+1) - simLapse(1))/dt
+       else if ( iRo == idxEnd ) then  ! end side of simulation time step
+         tmap_sim_forc%frac(ctr)   = (simLapse(2)-frcLapse(iRo))/dt
+       else                            ! simulation time step is completely with forcing time step
+         tmap_sim_forc%frac(ctr)   = (frcLapse(iRo+1)-frcLapse(iRo))/dt
+       endif
+       ctr = ctr+1
+     end do
+   end if
+
+ END SUBROUTINE timeMap_sim_forc
 
 END MODULE get_runoff

--- a/route/build/src/get_basin_runoff.f90
+++ b/route/build/src/get_basin_runoff.f90
@@ -14,7 +14,7 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE get_hru_runoff(ierr, message)
 
- ! populate runoff_data with runoff values at LSM domain and at iTime step
+ ! populate runoff_data with runoff values at LSM domain and at simulation time step
 
   USE public_var,  ONLY: input_dir               ! directory containing input data
   USE public_var,  ONLY: fname_qsim              ! simulated runoff netCDF name
@@ -22,13 +22,14 @@ CONTAINS
   USE public_var,  ONLY: qmodOption              ! options for streamflow modification (DA)
   USE public_var,  ONLY: takeWater               ! switch for water abstraction/injection
   USE public_var,  ONLY: integerMissing          !
-  USE globalData,  ONLY: iTime
   USE globalData,  ONLY: runoff_data             ! data structure to hru runoff data
   USE globalData,  ONLY: remap_data              ! data structure to remap data
-  USE globalData,  ONLY: modTime
+  USE globalData,  ONLY: iTime                   !
+  USE globalData,  ONLY: modTime                 !
   USE globalData,  ONLY: gage_obs_data
   USE globalData,  ONLY: rch_qtake_data
   USE globalData,  ONLY: RCHFLX
+  USE globalData,  ONLY: tmap_sim_ro             !
   USE read_runoff, ONLY: read_runoff_data        ! read runoff value into runoff_data data strucuture
   USE remapping,   ONLY: remap_runoff            ! mapping HM runoff to river network HRU runoff (HM_HRU /= RN_HRU)
   USE remapping,   ONLY: sort_runoff             ! mapping HM runoff to river network HRU runoff (HM_HRU == RN_HRU)
@@ -56,7 +57,7 @@ CONTAINS
 !  call system_clock(startTime)
   ! get the simulated runoff for the current time step - runoff_data%qsim(:) or %qsim2D(:,:)
   call read_runoff_data(trim(input_dir)//trim(fname_qsim), & ! input: filename
-                        iTime,                             & ! input: time index
+                        tmap_sim_ro(iTime),                & ! input: ro-sim time mapping at current simulation step
                         runoff_data,                       & ! inout: runoff data structure
                         ierr, cmessage)                      ! output: error control
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -120,10 +120,12 @@ MODULE globalData
   integer(i4b)                   , public :: iTime                      ! time index at simulation time step
   real(dp)                       , public :: timeVar                    ! time variables (unit given by time variable)
   real(dp)                       , public :: TSEC(0:1)                  ! begning and end of time step (sec)
-  type(datetime)                 , public :: modTime(0:1)               ! previous and current model time (yyyy:mm:dd:hh:mm:ss)
-  type(datetime)                 , public :: endCal                     ! simulation end date/time (yyyy:mm:dd:hh:mm:ss)
-  type(datetime)                 , public :: restCal                    ! desired restart date/time (yyyy:mm:dd:hh:mm:ss)
-  type(datetime)                 , public :: dropCal                    ! restart dropoff date/time (yyyy:mm:dd:hh:mm:ss)
+  type(datetime),                  public :: simDatetime(0:1)           ! previous and current simulation time (yyyy:mm:dd:hh:mm:ss)
+  type(datetime)                 , public :: begDatetime                ! simulation begining date/time (yyyy:mm:dd:hh:mm:ss)
+  type(datetime)                 , public :: endDatetime                ! simulation end date/time (yyyy:mm:dd:hh:mm:ss)
+  type(datetime),                  public :: restDatetime               ! desired restart date/time (yyyy:mm:dd:hh:mm:ss)
+  type(datetime),                  public :: dropDatetime               ! restart dropoff date/time (yyyy:mm:dd:hh:mm:ss)
+  type(datetime),                  public :: roBegDatetime              ! forcing data start date/time (yyyy:mm:dd:hh:mm:ss)
   logical(lgt)                   , public :: restartAlarm               ! alarm to triger restart file writing
 
   ! obs data - gage data, watertake etc.
@@ -153,7 +155,6 @@ MODULE globalData
   ! mapping structures
   type(remap)                    , public :: remap_data                 ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
   type(runoff)                   , public :: runoff_data                ! runoff data for one time step for LSM HRUs and River network HRUs
-  type(map_time), allocatable    , public :: tmap_sim_ro(:)             ! mapping between simulation time step and runoff time step
 
   ! domain data
   type(subbasin_omp), allocatable, public :: river_basin(:)             ! openMP domain decomposition

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -25,6 +25,8 @@ MODULE globalData
   USE dataTypes,  ONLY: LKFLX         ! lake fluxes
   ! remapping structures
   USE dataTypes,  ONLY: remap         ! remapping data type
+  USE dataTypes,  ONLY: map_time      ! time step mapping
+  ! runoff forcing structures
   USE dataTypes,  ONLY: runoff        ! runoff data type
   ! basin data structure
   USE dataTypes,  ONLY: subbasin_omp  ! mainstem+tributary data structures
@@ -116,7 +118,7 @@ MODULE globalData
 
   ! DataTime data/variables
   integer(i4b)                   , public :: iTime                      ! time index at simulation time step
-  real(dp)        , allocatable  , public :: timeVar(:)                 ! time variables (unit given by time variable)
+  real(dp)                       , public :: timeVar                    ! time variables (unit given by time variable)
   real(dp)                       , public :: TSEC(0:1)                  ! begning and end of time step (sec)
   type(datetime)                 , public :: modTime(0:1)               ! previous and current model time (yyyy:mm:dd:hh:mm:ss)
   type(datetime)                 , public :: endCal                     ! simulation end date/time (yyyy:mm:dd:hh:mm:ss)
@@ -151,6 +153,7 @@ MODULE globalData
   ! mapping structures
   type(remap)                    , public :: remap_data                 ! data structure to remap data from a polygon (e.g., grid) to another polygon (e.g., basin)
   type(runoff)                   , public :: runoff_data                ! runoff data for one time step for LSM HRUs and River network HRUs
+  type(map_time), allocatable    , public :: tmap_sim_ro(:)             ! mapping between simulation time step and runoff time step
 
   ! domain data
   type(subbasin_omp), allocatable, public :: river_basin(:)             ! openMP domain decomposition

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -96,7 +96,7 @@ MODULE public_var
   character(len=strLen),public    :: dname_xlon           = ''              ! dimension name for x (j, longitude) dimension
   character(len=strLen),public    :: dname_ylat           = ''              ! dimension name for y (i, latitude) dimension
   character(len=strLen),public    :: units_qsim           = ''              ! units of simulated runoff data
-  real(dp)             ,public    :: dt                   = realMissing     ! time step (seconds)
+  real(dp)             ,public    :: dt_ro                = realMissing     ! runoff time step (seconds)
   real(dp)             ,public    :: ro_fillvalue         = realMissing     ! fillvalue used for runoff depth variable
   logical(lgt)         ,public    :: userRunoffFillvalue  = .false.         ! true -> runoff depth fillvalue used in netcdf is specified here, otherwise -> false
   ! RUNOFF REMAPPING
@@ -117,6 +117,7 @@ MODULE public_var
   character(len=10)    ,public    :: routOpt              = '0'             ! routing scheme options  0: accum runoff, 1:IRF, 2:KWT, 3:KW, 4:MC, 5:DW
   integer(i4b)         ,public    :: doesBasinRoute       = 1               ! basin routing options   0-> no, 1->IRF, otherwise error
   character(len=strLen),public    :: newFileFrequency     = 'yearly'        ! frequency for new output files (daily, monthly, yearly, single)
+  real(dp)             ,public    :: dt                   = realMissing     ! simulation time step (seconds)
   ! STATES
   character(len=strLen),public    :: restart_write        = 'never'         ! restart write option: never-> never write, last -> write at last time step, specified, yearly, monthly, daily
   character(len=strLen),public    :: restart_date         = charMissing     ! specifed restart date

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -117,7 +117,7 @@ CONTAINS
    case('<dname_xlon>');           dname_xlon   = trim(cData)                      ! name of x (j,lon) dimension
    case('<dname_ylat>');           dname_ylat   = trim(cData)                      ! name of y (i,lat) dimension
    case('<units_qsim>');           units_qsim   = trim(cData)                      ! units of runoff
-   case('<dt_qsim>');              read(cData,*,iostat=io_error) dt                ! time interval of the gridded runoff
+   case('<dt_ro>');                read(cData,*,iostat=io_error) dt_ro             ! time interval of the runoff input with unit of units_qsim
    case('<ro_fillvalue>')
                                    read(cData,*,iostat=io_error) ro_fillvalue      ! fillvalue used for runoff depth variable
                                    userRunoffFillvalue = .true.                    ! true -> runoff depth fillvalue used in netcdf is specified here, otherwise -> false
@@ -139,6 +139,7 @@ CONTAINS
    case('<route_opt>');            routOpt     = trim(cData)                       ! routing scheme options  0-> accumRunoff, 1->IRF, 2->KWT, 3-> KW, 4->MC, 5->DW
    case('<doesBasinRoute>');       read(cData,*,iostat=io_error) doesBasinRoute    ! basin routing options   0-> no, 1->IRF, otherwise error
    case('<newFileFrequency>');     newFileFrequency     = trim(cData)              ! frequency for new output options (case-insensitive): daily, monthly, yearly, or single
+   case('<dt_qsim>');              read(cData,*,iostat=io_error) dt                ! time interval of the simulation (To-do: change dt to dt_sim)
    ! RESTART
    case('<restart_write>');        restart_write        = trim(cData)              ! restart write option (case-insensitive): never, last, specified, yearly, monthly, or daily
    case('<restart_date>');         restart_date         = trim(cData)              ! specified restart date, yyyy-mm-dd (hh:mm:ss) for Specified option

--- a/route/build/src/write_simoutput.f90
+++ b/route/build/src/write_simoutput.f90
@@ -149,7 +149,7 @@ CONTAINS
  USE public_var,          only : time_units        ! time units (seconds, hours, or days)
  ! saved global data
  USE globalData,          only : basinID,reachID   ! HRU and reach ID in network
- USE globalData,          only : modTime           ! previous and current model time
+ USE globalData,          only : simDatetime       ! previous and current model time
  USE globalData,          only : nEns, nHRU, nRch  ! number of ensembles, HRUs and river reaches
 
  implicit none
@@ -167,14 +167,14 @@ CONTAINS
  ierr=0; message='prep_output/'
 
  ! print progress
- write(iulog,'(a,I4,4(x,I4))') new_line('a'), modTime(1)%year(), modTime(1)%month(), modTime(1)%day(), modTime(1)%hour(), modTime(1)%minute()
+ write(iulog,'(a,I4,4(x,I4))') new_line('a'), simDatetime(1)%year(), simDatetime(1)%month(), simDatetime(1)%day(), simDatetime(1)%hour(), simDatetime(1)%minute()
 
  ! check need for the new file
  select case(lower(trim(newFileFrequency)))
-   case('single'); defNewOutputFile=(modTime(0)%year() ==integerMissing)
-   case('yearly'); defNewOutputFile=(modTime(1)%year() /=modTime(0)%year())
-   case('monthly');  defNewOutputFile=(modTime(1)%month()/=modTime(0)%month())
-   case('daily');    defNewOutputFile=(modTime(1)%day()  /=modTime(0)%day())
+   case('single'); defNewOutputFile=(simDatetime(0)%year() ==integerMissing)
+   case('yearly'); defNewOutputFile=(simDatetime(1)%year() /=simDatetime(0)%year())
+   case('monthly');  defNewOutputFile=(simDatetime(1)%month()/=simDatetime(0)%month())
+   case('daily');    defNewOutputFile=(simDatetime(1)%day()  /=simDatetime(0)%day())
    case default; ierr=20; message=trim(message)//'Accepted <newFileFrequency> options (case-insensitive): single yearly, monthly, or daily '; return
  end select
 
@@ -193,9 +193,9 @@ CONTAINS
    jTime=1
 
    ! update filename
-   sec_in_day = modTime(1)%hour()*60*60+modTime(1)%minute()*60+nint(modTime(1)%sec())
+   sec_in_day = simDatetime(1)%hour()*60*60+simDatetime(1)%minute()*60+nint(simDatetime(1)%sec())
    write(simout_nc%ncname, fmtYMDS) trim(output_dir)//trim(case_name)//'.h.', &
-                                     modTime(1)%year(), '-', modTime(1)%month(), '-', modTime(1)%day(), '-',sec_in_day,'.nc'
+                                     simDatetime(1)%year(), '-', simDatetime(1)%month(), '-', simDatetime(1)%day(), '-',sec_in_day,'.nc'
 
    call defineFile(simout_nc%ncname,                      &  ! input: file name
                    nEns,                                  &  ! input: number of ensembles

--- a/route/build/src/write_simoutput.f90
+++ b/route/build/src/write_simoutput.f90
@@ -40,6 +40,7 @@ CONTAINS
   USE globalData, ONLY: nHRU, nRch          ! number of ensembles, HRUs and river reaches
   USE globalData, ONLY: RCHFLX              ! Reach fluxes (ensembles, space [reaches])
   USE globalData, ONLY: runoff_data         ! runoff data for one time step for LSM HRUs and River network HRUs
+  USE globalData, ONLY: timeVar             ! time variable at current model time step
 
   implicit none
 
@@ -62,7 +63,7 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [array_temp]'; return; endif
 
   ! write time -- note time is just carried across from the input
-  call write_nc(simout_nc%ncid, 'time', (/runoff_data%time/), (/jTime/), (/1/), ierr, cmessage)
+  call write_nc(simout_nc%ncid, 'time', (/timeVar/), (/jTime/), (/1/), ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   if (meta_rflx(ixRFLX%basRunoff)%varFile) then


### PR DESCRIPTION
Currently simulation time step is identical to runoff input time step.

This pull request makes the simulation time step flexible by setting `dt_qsim` (simulation time step) and `dt_ro` (runoff time step) in control file.  

 If `dt_qsim` is shorter than `dt_ro`,  the same runoff value at one runoff time step is used for multiple simulation time step.  If `dt_qsim` is  greater than `dt_ro`, runoff values from multiple time steps are aggregated into the corresponding simulation time step.

Other minor changes:  saved datetime variables are renamed. 

