### PR TITLE
detect maximum unit-hydrograph size for restart writing

### DIFF
--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -161,6 +161,7 @@ MODULE globalData
 
   ! miscellaneous
   integer(i4b)                   , public :: ixPrint=integerMissing     ! index of desired reach to be on-screen print
+  integer(i4b)                   , public :: maxtdh                     ! maximum unit-hydrograph future time steps
   type(cMolecule)                , public :: nMolecule                  ! number of computational molecule (used for KW, MC, DW)
 
 END MODULE globalData

--- a/route/build/src/write_restart.f90
+++ b/route/build/src/write_restart.f90
@@ -327,6 +327,7 @@ CONTAINS
    USE globalData,   ONLY: meta_stateDims  ! states dimension meta
    USE globalData,   ONLY: nRch
    USE globalData,   ONLY: nMolecule
+   USE globalData,   ONLY: maxtdh          ! maximum unit-hydrogrph future time
    USE public_var,   ONLY: MAXQPAR
    USE globalData,   ONLY: FRAC_FUTURE     ! To get size of q future for basin IRF
 
@@ -347,7 +348,7 @@ CONTAINS
      case(ixStateDims%ens);     meta_stateDims(ixStateDims%ens)%dimLength     = 1
      case(ixStateDims%tbound);  meta_stateDims(ixStateDims%tbound)%dimLength  = 2
      case(ixStateDims%tdh);     meta_stateDims(ixStateDims%tdh)%dimLength     = size(FRAC_FUTURE)
-     case(ixStateDims%tdh_irf); meta_stateDims(ixStateDims%tdh_irf)%dimLength = 50   !just temporarily
+     case(ixStateDims%tdh_irf); meta_stateDims(ixStateDims%tdh_irf)%dimLength = maxtdh
      case(ixStateDims%wave);    meta_stateDims(ixStateDims%wave)%dimLength    = MAXQPAR
      case(ixStateDims%mol_kw);  meta_stateDims(ixStateDims%mol_kw)%dimLength  = nMolecule%KW_ROUTE
      case(ixStateDims%mol_mc);  meta_stateDims(ixStateDims%mol_mc)%dimLength  = nMolecule%MC_ROUTE


### PR DESCRIPTION
IRF (unit-hydrograph) future time size depend on various thing (time step, reach length, slope etc).  Currently temporal dimension size - 50 was used for writing future discharge from unit-hydrograph in restart file.  This change identify maximum unit-hydrograph size and use this as the dimension size in the restart file 