### PR TITLE
Ensuring river volume is always positive or zero

### DIFF
--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -233,6 +233,10 @@ CONTAINS
     write(*,'(a,x,G15.4)')     ' WB error   =', WB_error
   endif
 
+  if (RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) < 0) then
+    write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE VOLUME [m3]= ', RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1), 'at ', NETOPO_in(segIndex)%REACHID
+!    RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) = 0._dp
+  end if
  END SUBROUTINE irf_rch
 
 
@@ -282,6 +286,8 @@ CONTAINS
 
  ! compute volume in reach
  rflux%ROUTE(idxIRF)%REACH_VOL(0) = rflux%ROUTE(idxIRF)%REACH_VOL(1)
+ ! For very low flow condition, outflow - inflow > current storage, so limit outflow and adjust rflux%QFUTURE_IRF(1)
+ rflux%QFUTURE_IRF(1) = min(rflux%ROUTE(idxIRF)%REACH_VOL(0)/dt + QupMod*0.999, rflux%QFUTURE_IRF(1))
  rflux%ROUTE(idxIRF)%REACH_VOL(1) = rflux%ROUTE(idxIRF)%REACH_VOL(0) + (QupMod - rflux%QFUTURE_IRF(1))*dt
 
  ! Add local routed flow at the bottom of reach

--- a/route/build/src/kw_route.f90
+++ b/route/build/src/kw_route.f90
@@ -221,6 +221,14 @@ CONTAINS
    write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_Q
  endif
 
+ if (RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_Q < 0) then
+   write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE FLOW (Kinematic Wave)= ', RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_Q, 'at ', NETOPO_in(segIndex)%REACHID
+ end if
+ if (RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1) < 0) then
+   write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE VOLUME (Kinematic Wave)= ', RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1), 'at ', NETOPO_in(segIndex)%REACHID
+ end if
+
+
  END SUBROUTINE kw_rch
 
 
@@ -374,7 +382,7 @@ CONTAINS
  ! compute volume
  rflux%ROUTE(idxKW)%REACH_VOL(0) = rflux%ROUTE(idxKW)%REACH_VOL(1)
  ! For very low flow condition, outflow - inflow > current storage, so limit outflow and adjust Q(1,1)
- !Q(1,1) = min(rflux%ROUTE(idxKW)%REACH_VOL(0)/dt + Q(1,0)*0.999, Q(1,1))
+ Q(1,1) = min(rflux%ROUTE(idxKW)%REACH_VOL(0)/dt + Q(1,0)*0.999, Q(1,1))
  rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dt
 
  ! add catchment flow

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -219,6 +219,14 @@ CONTAINS
    write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_Q
  endif
 
+ if (RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_Q < 0) then
+   write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE FLOW (Muskingum-Cunge)= ', RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_Q, 'at ', NETOPO_in(segIndex)%REACHID
+ end if
+ if (RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_VOL(1) < 0) then
+   write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE VOLUME (Muskingum-Cunge)= ', RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_VOL(1), 'at ', NETOPO_in(segIndex)%REACHID
+ end if
+
+
  END SUBROUTINE mc_rch
 
  ! *********************************************************************
@@ -392,7 +400,7 @@ CONTAINS
  ! compute volume
  rflux%ROUTE(idxMC)%REACH_VOL(0) = rflux%ROUTE(idxMC)%REACH_VOL(1)
  ! For very low flow condition, outflow - inflow > current storage, so limit outflow and adjust Q(1,1)
- ! Q(1,1) = min(rflux%ROUTE(idxMC)%REACH_VOL(0)/dt + Q(1,0)*0.999, Q(1,1))
+ Q(1,1) = min(rflux%ROUTE(idxMC)%REACH_VOL(0)/dt + Q(1,0)*0.999, Q(1,1))
  rflux%ROUTE(idxMC)%REACH_VOL(1) = rflux%ROUTE(idxMC)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dt
 
  ! add catchment flow

--- a/route/build/src/model_setup.f90
+++ b/route/build/src/model_setup.f90
@@ -307,7 +307,7 @@ CONTAINS
           RCHSTA(iens,ix)%MC_ROUTE%molecule%Q(:) = 0._dp
         end do
       else if (routeMethods(iRoute)==diffusiveWave) then
-        nMolecule%DW_ROUTE = 5
+        nMolecule%DW_ROUTE = 20
         do ix = 1, size(RCHSTA(1,:))
           RCHFLX(iens,ix)%ROUTE(iRoute)%REACH_VOL(0:1) = 0._dp
           RCHFLX(iens,ix)%ROUTE(iRoute)%Qerror = 0._dp


### PR DESCRIPTION
**Issue:** Often current routing methods (irf, kw, mc, and df) cause negative volume (most of such cases seen so far is small negative values.

**Solution:** Made a small adjustment outflow computed by each routing method if the volume becomes below zero, such that Volume(t0) + inflow\*dt >= outflow\*dt  where t0 is time at beginning of the simulation period dt [sec].  Outflow excludes lateral flow since lateral flow is poured into the bottom of the reach (or the top of its downstream reach).  

**Scientific impact:** This flow adjustment produces slight different discharge values but not visible in hydrograph (as seen in the comparison with diffusive wave routing (w/ adjustment and w/o adjustment) over the entire Pacific Northwest simulation but seen in numeric comparison using a command like `nccmp`. 

![Screen Shot 2023-02-25 at 12 07 14 PM](https://user-images.githubusercontent.com/5290615/221375212-0d45fa8b-e8c1-4b69-8291-119edddf4060.png)

