### PR TITLE
Added mathematical temporal bias trend to adjust discharge at future time step

### DIFF
--- a/docs/source/Control_file.rst
+++ b/docs/source/Control_file.rst
@@ -65,7 +65,7 @@ The following variables (not pre-defined in the code) need to be defined in cont
 +--------+------------------------+--------------------------------------------------------------------------------------------------+
 | 1,2,3  | <units_qsim>           | units of input runoff. e.g., mm/s                                                                |
 +--------+------------------------+--------------------------------------------------------------------------------------------------+
-| 1,2,3  | <dt_qsim>              | time interval of input runoff in second. e.g., 86400 sec for daily step                          |
+| 1,2,3  | <dt_qsim>              | time interval of simulation time step in second. e.g., 86400 sec for daily step                  |
 +--------+------------------------+--------------------------------------------------------------------------------------------------+
 | 1,2,3  | <is_remap>             | Logical to indicate runoff needs to be remapped to RN_HRU. T or F                                |
 +--------+------------------------+--------------------------------------------------------------------------------------------------+
@@ -206,6 +206,48 @@ The output file name convension:  <case_name>.h.yyyy-mm-dd-sssss.nc
 
 
 3. routed runoff corresponding to the scheme is not ouput if users deactivate a particular routing scheme with <route_opt> tag.  
+
+
+Data assimilation options
+---------------------
+
+mizuRoute can read gauge observed discharge data (in netCDF) along with gauge meta ascii data. To read gauge observation and gauge metadata, the following control variables need to be specified. 
+
+
++---------------------+---------------------------------------------------------------------------------------------------------+
+| tag                 | Description                                                                                             |
++=====================+=========================================================================================================+
+| <gageMetaFile>      | gauge meta data (two column csv format): gauge_id (non-numeric ID is accepted), seg_id                  |
++---------------------+---------------------------------------------------------------------------------------------------------+
+| <fname_gageObs>     | gauge discharge data                                                                                    |
++---------------------+---------------------------------------------------------------------------------------------------------+
+| <vname_gageFlow>    | variable name for discharge [m3/s]                                                                      |
++---------------------+---------------------------------------------------------------------------------------------------------+
+| <vname_gageSite>    | variable name for gauge site name (character array)                                                     |
++---------------------+---------------------------------------------------------------------------------------------------------+
+| <vname_gageTime>    | variable name for time                                                                                  |
++---------------------+---------------------------------------------------------------------------------------------------------+
+| <dname_gageSite>    | dimension name for site                                                                                 |
++---------------------+---------------------------------------------------------------------------------------------------------+
+| <dname_gageTime>    | imension name for time                                                                                  |
++---------------------+---------------------------------------------------------------------------------------------------------+
+| <strlen_gageSite>   | maximum gauge name string length                                                                        | 
++---------------------+---------------------------------------------------------------------------------------------------------+
+
+
+Data assimilation is the direct insertion that is performed at a list of reaches in the metadata. Two parameters-<QerrTrend> and <ntsQmodStop> are needed. 
+<QerrTrend> tells how bias computed at observation time at each reach evolves in the subsequent future <ntsQmodStop> time steps.
+To activate data assimilation of observed discharge into simulated discharge, the following control variables need to be specified.
+
++---------------------+---------------------------------------------------------------------------------------------------------+
+| tag                 | Description                                                                                             |
++=====================+=========================================================================================================+
+| <qmodOption>        | activation of direct insertion. 0 -> do nothing, 1=> discharge direct insertion                         | 
++---------------------+---------------------------------------------------------------------------------------------------------+
+| <QerrTrend>         | temporal discharge error trend. 1->constant, 2->linear, 3->logistic, 4->exponential                     |
++---------------------+---------------------------------------------------------------------------------------------------------+
+| <ntsQmodStop>       | the number of time steps when flow correction stops                                                     | 
++---------------------+---------------------------------------------------------------------------------------------------------+
 
 
 Control file examples

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,8 @@ pygments_style = None
 # a list of builtin themes.
 #
 #html_theme = 'alabaster'
-html_theme = 'sphinxdoc'
+#html_theme = 'sphinxdoc'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -14,6 +14,7 @@ USE public_var,  ONLY: realMissing       ! missing value for real number
 USE public_var,  ONLY: integerMissing    ! missing value for integer number
 USE public_var,  ONLY: qmodOption        ! qmod option (use 1==direct insertion)
 USE public_var,  ONLY: ntsQmodStop       ! number of time steps for which direct insertion is performed
+USE public_var,  ONLY: QerrTrend         ! temporal discharge error trend: 1->constant,2->linear, 3->logistic
 USE globalData,  ONLY: idxDW
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
@@ -155,7 +156,15 @@ CONTAINS
  integer(i4b)                              :: iUps              ! upstream reach index
  integer(i4b)                              :: iRch_ups          ! index of upstream reach in NETOPO
  real(dp)                                  :: q_upstream        ! total discharge at top of the reach being processed
+ real(dp)                                  :: Qcorrect          ! Discharge correction (when qmodOption=1) [m3/s]
+ real(dp)                                  :: k                 ! the logistic decay rate or steepness of the curve.
+ real(dp)                                  :: y0                !
+ real(dp)                                  :: x0                !
  character(len=strLen)                     :: cmessage          ! error message from subroutine
+ integer(i4b),parameter                    :: const=1           ! error reduction type: step function
+ integer(i4b),parameter                    :: linear=2          ! error reduction type: linear function
+ integer(i4b),parameter                    :: logistic=3        ! error reduction type: logistic function
+ integer(i4b),parameter                    :: exponential=4     ! error reduction type: exponential function
 
  ierr=0; message='dfw_rch/'
 
@@ -181,8 +190,31 @@ CONTAINS
        if (RCHFLX_out(iens,iRch_ups)%Qelapsed > ntsQmodStop) then
          RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%Qerror=0._dp
        end if
-       RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror, 0._dp)
+       if (RCHFLX_out(iens,iRch_ups)%Qelapsed <= ntsQmodStop) then
+          select case(QerrTrend)
+            case(const)
+              Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror
+            case(linear)
+              Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror*(1._dp - real(RCHFLX_out(iens,iRch_ups)%Qelapsed,dp)/real(ntsQmodStop, dp))
+            case(logistic)
+              x0 =0.25; y0 =0.90
+              k = log(1._dp/y0-1._dp)/(ntsQmodStop/2._dp-ntsQmodStop*x0)
+              Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror/(1._dp + exp(-k*(1._dp*RCHFLX_out(iens,iRch_ups)%Qelapsed-ntsQmodStop/2._dp)))
+            case(exponential)
+              if (RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror/=0._dp) then
+                k = log(0.1_dp/abs(RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror))/(1._dp*ntsQmodStop)
+                Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxDW)%Qerror*exp(k*RCHFLX_out(iens,iRch_ups)%Qelapsed)
+              else
+                Qcorrect = 0._dp
+              end if
+            case default; message=trim(message)//'discharge error trend model must be 1(const),2(liear), or 3(logistic)'; ierr=81; return
+          end select
+       else
+         Qcorrect=0._dp
+       end if
+       RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = max(RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q-Qcorrect, 0._dp)
      end if
+
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
    end do
  endif

--- a/route/build/src/get_basin_runoff.f90
+++ b/route/build/src/get_basin_runoff.f90
@@ -176,7 +176,6 @@ CONTAINS
    real(dp)                                   :: juldaySim        ! starting julian day in simulation time step [day]
    integer(i4b)                               :: ctr              ! counter
    integer(i4b)                               :: nRoSub           !
-   integer(i4b)                               :: iFile            ! loop index of input file
    integer(i4b)                               :: iRo              ! loop index of runoff time step
    integer(i4b)                               :: idxFront         ! index of r of which top is within ith model layer (i=1..nLyr)
    integer(i4b)                               :: idxEnd           ! index of the lowest soil layer of which bottom is within ith model layer (i=1..nLyr)
@@ -217,7 +216,7 @@ CONTAINS
    nRoSub = idxEnd-idxFront + 1
 
    allocate(tmap_sim_forc%iTime(nRoSub), stat=ierr, errmsg=cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage)//'tmap_sim_forc%iTime or iFile'; return; endif
+   if(ierr/=0)then; message=trim(message)//trim(cmessage)//'tmap_sim_forc%iTime'; return; endif
 
    if (idxFront == idxEnd)then ! if simulation period is completely within runoff period - one runoff time period per simulation period
      tmap_sim_forc%iTime(ctr) = idxFront

--- a/route/build/src/kw_route.f90
+++ b/route/build/src/kw_route.f90
@@ -16,6 +16,7 @@ USE public_var, ONLY: realMissing       ! missing value for real number
 USE public_var, ONLY: integerMissing    ! missing value for integer number
 USE public_var, ONLY: qmodOption        ! qmod option (use 1==direct insertion)
 USE public_var, ONLY: ntsQmodStop       ! number of time steps for which direct insertion is performed
+USE public_var, ONLY: QerrTrend         ! temporal discharge error trend: 1->constant,2->linear, 3->logistic
 USE globalData, ONLY: idxKW             ! index of kw routing
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
@@ -159,7 +160,15 @@ CONTAINS
  integer(i4b)                              :: iUps              ! upstream reach index
  integer(i4b)                              :: iRch_ups          ! index of upstream reach in NETOPO
  real(dp)                                  :: q_upstream        ! total discharge at top of the reach being processed
+ real(dp)                                  :: Qcorrect          ! Discharge correction (when qmodOption=1) [m3/s]
+ real(dp)                                  :: k                 ! the logistic decay rate or steepness of the curve.
+ real(dp)                                  :: y0                !
+ real(dp)                                  :: x0                !
  character(len=strLen)                     :: cmessage          ! error message from subroutine
+ integer(i4b),parameter                    :: const=1           ! error reduction type: step function
+ integer(i4b),parameter                    :: linear=2          ! error reduction type: linear function
+ integer(i4b),parameter                    :: logistic=3        ! error reduction type: logistic function
+ integer(i4b),parameter                    :: exponential=4     ! error reduction type: exponential function
 
  ierr=0; message='kw_rch/'
 
@@ -185,8 +194,31 @@ CONTAINS
        if (RCHFLX_out(iens,iRch_ups)%Qelapsed > ntsQmodStop) then
          RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror=0._dp
        end if
-       RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%REACH_Q = max(RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror, 0._dp)
+       if (RCHFLX_out(iens,iRch_ups)%Qelapsed <= ntsQmodStop) then
+          select case(QerrTrend)
+            case(const)
+              Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror
+            case(linear)
+              Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror*(1._dp - real(RCHFLX_out(iens,iRch_ups)%Qelapsed,dp)/real(ntsQmodStop, dp))
+            case(logistic)
+              x0 =0.25; y0 =0.90
+              k = log(1._dp/y0-1._dp)/(ntsQmodStop/2._dp-ntsQmodStop*x0)
+              Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror/(1._dp + exp(-k*(1._dp*RCHFLX_out(iens,iRch_ups)%Qelapsed-ntsQmodStop/2._dp)))
+            case(exponential)
+              if (RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror/=0._dp) then
+                k = log(0.1_dp/abs(RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror))/(1._dp*ntsQmodStop)
+                Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%Qerror*exp(k*RCHFLX_out(iens,iRch_ups)%Qelapsed)
+              else
+                Qcorrect = 0._dp
+              end if
+            case default; message=trim(message)//'discharge error trend model must be 1(const),2(liear), or 3(logistic)'; ierr=81; return
+          end select
+       else
+         Qcorrect=0._dp
+       end if
+       RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%REACH_Q = max(RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%REACH_Q-Qcorrect, 0._dp)
      end if
+
      q_upstream = q_upstream + RCHFLX_out(iens,iRch_ups)%ROUTE(idxKW)%REACH_Q
    end do
  endif

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -16,6 +16,7 @@ USE public_var,  ONLY: realMissing       ! missing value for real number
 USE public_var,  ONLY: integerMissing    ! missing value for integer number
 USE public_var,  ONLY: qmodOption        ! qmod option (use 1==direct insertion)
 USE public_var,  ONLY: ntsQmodStop       ! number of time steps for which direct insertion is performed
+USE public_var,  ONLY: QerrTrend         ! temporal discharge error trend: 1->constant,2->linear, 3->logistic
 USE globalData,  ONLY: idxMC             ! index of IRF method
 ! subroutines: general
 USE model_finalize, ONLY : handle_err
@@ -157,7 +158,15 @@ CONTAINS
  integer(i4b)                              :: iUps              ! upstream reach index
  integer(i4b)                              :: iRch_ups          ! index of upstream reach in NETOPO
  real(dp)                                  :: q_upstream        ! total discharge at top of the reach being processed
+ real(dp)                                  :: Qcorrect          ! Discharge correction (when qmodOption=1) [m3/s]
+ real(dp)                                  :: k                 ! the logistic decay rate or steepness of the curve.
+ real(dp)                                  :: y0                !
+ real(dp)                                  :: x0                !
  character(len=strLen)                     :: cmessage          ! error message from subroutine
+ integer(i4b),parameter                    :: const=1           ! error reduction type: step function
+ integer(i4b),parameter                    :: linear=2          ! error reduction type: linear function
+ integer(i4b),parameter                    :: logistic=3        ! error reduction type: logistic function
+ integer(i4b),parameter                    :: exponential=4     ! error reduction type: exponential function
 
  ierr=0; message='mc_rch/'
 
@@ -183,8 +192,31 @@ CONTAINS
        if (RCHFLX_out(iens,iRch_ups)%Qelapsed > ntsQmodStop) then
          RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror=0._dp
        end if
-       RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%REACH_Q = max(RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%REACH_Q-RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror, 0._dp)
+       if (RCHFLX_out(iens,iRch_ups)%Qelapsed <= ntsQmodStop) then
+          select case(QerrTrend)
+            case(const)
+              Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror
+            case(linear)
+              Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror*(1._dp - real(RCHFLX_out(iens,iRch_ups)%Qelapsed,dp)/real(ntsQmodStop, dp))
+            case(logistic)
+              x0 =0.25; y0 =0.90
+              k = log(1._dp/y0-1._dp)/(ntsQmodStop/2._dp-ntsQmodStop*x0)
+              Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror/(1._dp + exp(-k*(1._dp*RCHFLX_out(iens,iRch_ups)%Qelapsed-ntsQmodStop/2._dp)))
+            case(exponential)
+              if (RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror/=0._dp) then
+                k = log(0.1_dp/abs(RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror))/(1._dp*ntsQmodStop)
+                Qcorrect = RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%Qerror*exp(k*RCHFLX_out(iens,iRch_ups)%Qelapsed)
+              else
+                Qcorrect = 0._dp
+              end if
+            case default; message=trim(message)//'discharge error trend model must be 1(const),2(liear), or 3(logistic)'; ierr=81; return
+          end select
+       else
+         Qcorrect=0._dp
+       end if
+       RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%REACH_Q = max(RCHFLX_out(iens,iRch_ups)%ROUTE(idxMC)%REACH_Q-Qcorrect, 0._dp)
      end if
+
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
    end do
  endif

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -143,6 +143,7 @@ MODULE public_var
   character(len=strLen),public    :: dname_wtTime         = ''              ! dimension name for time
   ! USER OPTIONS
   integer(i4b)         ,public    :: qmodOption           = 0               ! options for streamflow modification (DA): 0-> no DA, 1->direct insertion
+  integer(i4b)         ,public    :: QerrTrend            = 1               ! temporal discharge error decreasing trend: 1->constant, 2->linear, 3->logistic, 4->exponential
   integer(i4b)         ,public    :: ntsQmodStop          = 10              ! number of time steps for which streamflow modification is performed
   logical(lgt)         ,public    :: takeWater            = .false.         ! switch for water abstraction and injection
   integer(i4b)         ,public    :: hydGeometryOption    = compute         ! option for hydraulic geometry calculations (0=read from file, 1=compute)

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -152,6 +152,7 @@ CONTAINS
    ! USER OPTIONS: Define options to include/skip calculations
    case('<qmodOption>');           read(cData,*,iostat=io_error) qmodOption        ! option for streamflow modification (DA): 0->no DA, 1->direct insertion
    case('<ntsQmodStop>');          read(cData,*,iostat=io_error) ntsQmodStop       ! number of time steps for which streamflow modification is performed
+   case('<QerrTrend>');            read(cData,*,iostat=io_error) QerrTrend         ! temporal dischargge error decreasing trend. 1->constant, 2->linear, 3->logistic, 4->exponential
    case('<takeWater>');            read(cData,*,iostat=io_error) takeWater         ! switch for abstraction/injection
    case('<hydGeometryOption>');    read(cData,*,iostat=io_error) hydGeometryOption ! option for hydraulic geometry calculations (0=read from file, 1=compute)
    case('<topoNetworkOption>');    read(cData,*,iostat=io_error) topoNetworkOption ! option for network topology calculations (0=read from file, 1=compute)


### PR DESCRIPTION
This PR is about direct-insertion.

Before this change, simulated discharge was corrected at gauge reach based on the error computed at observation time at extended future time steps. This is called "const"

The following mathematical models are added and `QerrTrend`(integer) is used to switch the methods in a control variable:
linear (2), logistic(3), and exponential(4). const is 1.


TO-DO (future): 
Explore the possibility of moving the direct-insertion routine out of each routing routine and put it new module/subroutine to avoid repetition of the code.

Need to write RCHFLX_out%Qelapsed in restart file to properly restart during the error correction period.