### PR TITLE
bugfixes in init and run routines for ctsm-coupling

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -79,29 +79,36 @@ ifeq "$(isOpenMP)" "yes"
 endif
 
 #========================================================================
+# generate a Git version string
+#========================================================================
+VERSION = $(shell git describe --tag)
+GITBRCH = $(shell git describe --long --all --always | sed -e's/heads\///')
+GITHASH = $(shell git rev-parse HEAD)
+
+#========================================================================
 # Define flags
 #========================================================================
 ifeq "$(FC)" "gnu"
   ifeq "$(MODE)" "fast"
-    FLAGS = -O3 -fmax-errors=0 -ffree-line-length-none $(FLAGS_OMP)
+    FLAGS = -O3 -fmax-errors=0 -ffree-line-length-none $(FLAGS_OMP) -cpp -DVERSION=\"$(VERSION)\" -DBRANCH=\"$(GITBRCH)\" -DHASH=\"$(GITHASH)\"
   endif
   ifeq "$(MODE)" "debug"
-    FLAGS = -g -Wall -fmax-errors=0 -fbacktrace -fcheck=all -ffpe-trap=zero -ffree-line-length-none $(FLAGS_OMP)
+    FLAGS = -g -Wall -fmax-errors=0 -fbacktrace -fcheck=all -ffpe-trap=zero -ffree-line-length-none $(FLAGS_OMP) -cpp -DVERSION=\"$(VERSION)\" -DBRANCH=\"$(GITBRCH)\" -DHASH=\"$(GITHASH)\"
   endif
   ifeq "$(MODE)" "profile"
-    FLAGS = -p -g -Wall -fmax-errors=0 -fbacktrace -fbounds-check -ffpe-trap=zero -ffree-line-length-none $(FLAGS_OMP)
+    FLAGS = -p -g -Wall -fmax-errors=0 -fbacktrace -fbounds-check -ffpe-trap=zero -ffree-line-length-none $(FLAGS_OMP) -cpp -DVERSION=\"$(VERSION)\" -DBRANCH=\"$(GITBRCH)\" -DHASH=\"$(GITHASH)\"
   endif
 endif
 
 ifeq "$(FC)" "intel"
   ifeq "$(MODE)" "fast"
-    FLAGS = -O3 -FR -auto -fltconsistency -fpe0 $(FLAGS_OMP)
+    FLAGS = -O3 -FR -auto -fltconsistency -fpe0 $(FLAGS_OMP) -cpp -DVERSION=\"$(VERSION)\" -DBRANCH=\"$(GITBRCH)\" -DHASH=\"$(GITHASH)\"
   endif
   ifeq "$(MODE)" "debug"
-    FLAGS = -g -debug all -warn all -check all -FR -O0 -auto -WB -fpe0 -traceback -fltconsistency $(FLAGS_OMP)
+    FLAGS = -g -debug all -warn all -check all -FR -O0 -auto -WB -fpe0 -traceback -fltconsistency $(FLAGS_OMP) -cpp -DVERSION=\"$(VERSION)\" -DBRANCH=\"$(GITBRCH)\" -DHASH=\"$(GITHASH)\"
   endif
   ifeq "$(MODE)" "profile"
-    FLAGS = -p -g -debug -warn all -check all -noerror_limit -FR -O0 -auto -WB -fpe0 -traceback -fltconsistency $(FLAGS_OMP)
+    FLAGS = -p -g -debug -warn all -check all -noerror_limit -FR -O0 -auto -WB -fpe0 -traceback -fltconsistency $(FLAGS_OMP) -cpp -DVERSION=\"$(VERSION)\" -DBRANCH=\"$(GITBRCH)\" -DHASH=\"$(GITHASH)\"
   endif
 endif
 

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -274,19 +274,22 @@ CONTAINS
 
       SUBROUTINE get_hru_area(NETOPO_in, RPARAM_in, offset, verbose)
 
-        ! Descriptions: Compute HRU areas
-        ! Note: mizuRoute holds contributory area [m2]-BASAREA, which CAN consists of multiple HRUs
+        ! Descriptions: Get HRU areas in rtmCTL from mizuRoute NETOPO/RPARAM data structure
+        ! Note: 1) mizuRoute holds contributory area [m2]-BASAREA, which CAN consists of multiple HRUs
         !       To get HRU area associated with each reach, need to compute based on areal weight
+        !       2) offset (optional input): in main processor, index for rtmCTL variable is based on 1 through nHRU_mainstem+nHRU_trib
+        !       (combining mainstem and tributary hru in the order). Therefore, hru index based NETOPO for tributary in main processor
+        !       need to be added by number of nHRU_mainstem. offset can be used for this.
 
         USE dataTypes, ONLY: RCHTOPO   ! data structure - Network topology
         USE dataTypes, ONLY: RCHPRP    ! data structure - Reach/hru physical parameters
 
         implicit none
         ! Arguments:
-        type(RCHTOPO),     intent(in) :: NETOPO_in(:)
-        type(RCHPRP),      intent(in) :: RPARAM_in(:)
-        integer, optional, intent(in) :: offset
-        logical, optional, intent(in) :: verbose
+        type(RCHTOPO),     intent(in) :: NETOPO_in(:) ! network topology data structure
+        type(RCHPRP),      intent(in) :: RPARAM_in(:) ! reach parameter data structure
+        integer, optional, intent(in) :: offset       ! index offset to point correct location in rtmCTL
+        logical, optional, intent(in) :: verbose      ! verbose option
         ! Local variables:
         logical                   :: verb
         integer                   :: ix
@@ -714,6 +717,9 @@ CONTAINS
         ! Descriptions: get exporting variables
         !  - discharge [m3/s],
         !  - water volume per HUC area [m]
+        !  NOTE 1) offset (optional input): in main processor, index for rtmCTL variable is based on 1 through nHRU_mainstem+nHRU_trib
+        !       (combining mainstem and tributary hru in the order). Therefore, hru index based NETOPO for tributary in main processor
+        !       need to be added by number of nHRU_mainstem. offset can be used for this.
 
         USE globalData, ONLY: idxIRF   ! routing method index
         USE dataTypes, ONLY: RCHTOPO   ! data structure - Network topology
@@ -721,9 +727,9 @@ CONTAINS
 
         implicit none
         ! Arguments:
-        type(RCHTOPO), intent(in)     :: NETOPO_in(:)
-        type(STRFLX),  intent(in)     :: RCHFLX_in(:,:)
-        integer, optional, intent(in) :: offset
+        type(RCHTOPO), intent(in)     :: NETOPO_in(:)   ! mizuRoute network topology data structure
+        type(STRFLX),  intent(in)     :: RCHFLX_in(:,:) ! mizuRoute reach flux data structure
+        integer, optional, intent(in) :: offset         ! index offset to point correct location in rtmCTL
         ! Local variables:
         integer                   :: ix
         integer                   :: iens=1

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -61,6 +61,12 @@ MODULE globalData
 
   save
 
+  ! ---------- mizuRoute version -------------------------------------------------------------------
+
+  character(len=strLen)          , public :: version='undefined'        ! mizuRoute version
+  character(len=strLen)          , public :: gitBranch='undefined'      ! github branch
+  character(len=strLen)          , public :: gitHash='undefined'        ! github commit hash
+
   ! ---------- Catchment and reach IDs  -------------------------------------------------------------------------
 
   integer(i4b),                    public :: nHRU                 ! number of HRUs in the whole river network

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -44,6 +44,9 @@ CONTAINS
   USE globalData, ONLY: multiProcs   ! mpi multi-procs logical (.true. -> use more than 1 processors)
   USE globalData, ONLY: pid          ! procs id (rank)
   USE globalData, ONLY: nThreads     ! number of OMP threads
+  USE globalData, ONLY: version      ! mizuRoute version
+  USE globalData, ONLY: gitBranch    ! git branch
+  USE globalData, ONLY: gitHash      ! git commit hash
   USE mpi_utils, ONLY: shr_mpi_commsize
   USE mpi_utils, ONLY: shr_mpi_commrank
 
@@ -55,6 +58,17 @@ CONTAINS
   integer(i4b)               :: omp_get_num_threads ! number of threads used for openMP
 
   message='get_mpi_omp/'
+
+  ! Get mizuRoute model information
+#if defined(VERSION)
+  version=VERSION
+#endif
+#if defined(HASH)
+  gitHash=HASH
+#endif
+#if defined(BRANCH)
+  gitBranch=BRANCH
+#endif
 
   ! Get the number of processes
   call shr_mpi_commsize(comm, nNodes, message)

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -9,9 +9,6 @@ MODULE public_var
 
   save
 
-  ! ---------- mizuRoute version -------------------------------------------------------------------
-  character(len=strLen), parameter, public    :: mizuRouteVersion='v2.0'
-
   ! ---------- common constants ---------------------------------------------------------------------
 
   ! physical constants

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -414,7 +414,7 @@ CONTAINS
    case default
      read(outputFrequency,'(I5)',iostat=err) nOutFreq
      if (err/=0) then
-       message=trim(message)//'problem with numeric convertin - <outputFrequency>'; return
+       message=trim(message)//'<outputFrequency> is invalid: must be "daily", "monthly", "yearly" or positive integer (number of time steps)'; return
      end if
      if (nOutFreq<0) then
        message=trim(message)//'<outputFrequency> is invalid: must be positive integer'; return

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -403,40 +403,40 @@ CONTAINS
  ! ---------- simulation time step, output frequency, file frequency -------
  if (masterproc) then
    write(iulog,'(2a)') new_line('a'), '---- output/simulation time steps --- '
-   write(iulog,'(A,F10.1)') '  simulation frequency:     ', dt
-   write(iulog,'(2A)')      '  history file freqeuncy:   ', trim(newFileFrequency)
-   write(iulog,'(2A)')      '  history output freqeuncy: ', trim(outputFrequency)
+   write(iulog,'(A,F10.1)') '  simulation time step <dt_qsim>:             ', dt
+   write(iulog,'(2A)')      '  history file freqeuncy <newFileFrequency>:  ', trim(newFileFrequency)
+   write(iulog,'(2A)')      '  history output freqeuncy <outputFrequency>: ', trim(outputFrequency)
  end if
 
  ! 1. Process history output frequency
  select case(trim(outputFrequency))
    case('daily', 'monthly', 'yearly') ! do nothing
    case default
-     read(outputFrequency,'(5I)',iostat=err) nOutFreq
+     read(outputFrequency,'(I5)',iostat=err) nOutFreq
      if (err/=0) then
-       message=trim(message)//'<outputFrequency> is invalid: must be daily, monthly, yearly or integer (number of time steps)'; return
+       message=trim(message)//'problem with numeric convertin - <outputFrequency>'; return
      end if
      if (nOutFreq<0) then
-       message=trim(message)//'<outputFrequency> is invalid: must be positive integer AND outputFrequency x simulation step [sec] must be 86400 [sec] (one day)'; return
+       message=trim(message)//'<outputFrequency> is invalid: must be positive integer'; return
      end if
  end select
 
  ! 2. Check simulation time step
  ! 2.1 must be less than one day
  if (dt>86400._dp) then
-   write(message, '(2A)') trim(message), 'simulation frequency must be less than one-day (86400 sec)'
+   write(message, '(2A)') trim(message), '<dt_qsim> must be less than one-day (86400 sec)'
    err=81; return
  end if
  ! 2.2. multiple of simulation time step must be one day
  if (mod(86400._dp, dt)>0._dp) then
-   write(message, '(2A)') trim(message), 'multiple of simulation step [sec] must end up in one-day (86400 sec)'
+   write(message, '(2A)') trim(message), 'multiple of <dt_qsim> [sec] must be 86400 [sec] (one day)'
    err=81; return
  end if
 
  ! 3. Check output frequency against simulation time step if outputFrequency is numeric
  if (nOutFreq/=integerMissing) then
    if (mod(86400._dp, real(nOutFreq,kind=dp)*dt)>0._dp) then
-     write(message, '(2A)') trim(message), 'outputFrequency x simulation step [sec] must be 86400 [sec] (one day)'
+     write(message, '(2A)') trim(message), 'multiple of <outputFrequency> x <dt_qsim> [sec] must be 86400 [sec] (one day)'
      err=81; return
    end if
  end if


### PR DESCRIPTION
Fixing the following bug fixes

- Fixed unit conversion factor
- Fixed populating rtmCTL - area array 
- Fixed populating rtmCTL - volr array (water volume for exporting)

**These bugs caused incorrect values for one rtmCTL variable (rtmCTL%area), exporting variable (rtmCTL%volr), and many irrigation related variables, affecting water extraction from river via irrigation demand.**

Minor comments update on error handling simulation time step (<dt_qsim>), history file frequency (<newFileFrequeycn.), and history write frequency (<outputFrequency>)

Added variables for git information in globalData 