### PR TITLE
reach/lake water balance error check and minor fix/cleanup in lake and irf routing

### DIFF
--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -212,16 +212,11 @@ CONTAINS
    write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_Q
  endif
 
- if(verbose) then
-   write(iulog,'(a)') ' -------------------------'
-   write(iulog,'(a)') ' -- water balance check --'
-   write(iulog,'(a)') ' -------------------------'
- endif
- call comp_reach_wb(idxDW, q_upstream, RCHFLX_out(iens,segIndex), verbose)
-
  if (RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_VOL(1) < 0) then
    write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE VOLUME = ', RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_VOL(1), 'at ', NETOPO_in(segIndex)%REACHID
  end if
+
+ call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxDW, q_upstream, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
 
  END SUBROUTINE dfw_rch
 

--- a/route/build/src/histVars_data.f90
+++ b/route/build/src/histVars_data.f90
@@ -141,11 +141,11 @@ MODULE histVars_data
       nHru_input = size(basRunoff_local)
       nRch_input = size(RCHFLX_local(1,:))
       if (nHru_input/=this%nHru) then
-        write(message,'(2A,I,A,I)') trim(message),'history buffer hru size:',this%nHru,'/= input data hru size:',nHru_input
+        write(message,'(2A,G0,A,G0)') trim(message),'history buffer hru size:',this%nHru,'/= input data hru size:',nHru_input
         ierr=81; return
       end if
       if (nRch_input/=this%nRch) then
-        write(message,'(2A,I,A,I)') trim(message),'history buffer reach size:',this%nRch,'/= input data reach size:',nRch_input
+        write(message,'(2A,G0,A,G0)') trim(message),'history buffer reach size:',this%nRch,'/= input data reach size:',nRch_input
         ierr=81; return
       end if
 
@@ -175,7 +175,7 @@ MODULE histVars_data
           case(muskingumCunge);        idxMethod=idxMC
           case(diffusiveWave);         idxMethod=idxDW
           case default
-            write(message,'(2A,X,I,X,A)') trim(message), 'routing method index:',routeMethods(iRoute), 'must be 0-5'
+            write(message,'(2A,X,G0,X,A)') trim(message), 'routing method index:',routeMethods(iRoute), 'must be 0-5'
             ierr=81; return
         end select
 

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -11,6 +11,7 @@ USE dataTypes, ONLY: subbasin_omp     ! mainstem+tributary data structures
 USE public_var, ONLY: iulog           ! i/o logical unit number
 USE public_var, ONLY: realMissing     ! missing value for real number
 USE public_var, ONLY: integerMissing  ! missing value for integer number
+USE public_var, ONLY: dt
 USE globalData, ONLY: idxIRF          ! index of IRF method
 ! external subroutines
 USE lake_route_module, ONLY: lake_route        ! lake route module
@@ -141,6 +142,8 @@ CONTAINS
  ! Local variables
  logical(lgt)                             :: verbose        ! check details of variables
  real(dp)                                 :: q_upstream     ! total discharge at top of the reach being processed
+ real(dp)                                 :: Qabs           ! maximum allowable water abstraction rate [m3/s]
+ real(dp)                                 :: Vmod           ! abstraction rate from storage [m3/s]
  integer(i4b)                             :: nUps           ! number of upstream segment
  integer(i4b)                             :: iUps           ! upstream reach index
  integer(i4b)                             :: iRch_ups       ! index of upstream reach in NETOPO
@@ -201,20 +204,27 @@ CONTAINS
   ! take out the water from the reach if the wm flag is true and the value are not missing
   ! here we should make sure the real missing is not injection (or negative abstration)
   if((RCHFLX_out(iens,segIndex)%REACH_WM_FLUX /= realMissing).and.(is_flux_wm)) then
-    ! abstraction or injection
     if (RCHFLX_out(iens,segIndex)%REACH_WM_FLUX <= 0) then ! negative/injection
+      RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
       RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
     else ! positive/abstraction
-      if (RCHFLX_out(iens,segIndex)%REACH_WM_FLUX <= RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q) then ! abstraction is smaller than water in the river
-        RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
-      else ! abstraction is larger than water in the river
-        RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q
-      endif
+      Qabs = min(RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1)/dt+RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q, &
+                 RCHFLX_out(iens,segIndex)%REACH_WM_FLUX)
+      Vmod = min(RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q-Qabs, 0._dp) ! is taken from storage and is <= 0
+
+      RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) + Vmod*dt
+      RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q      = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - (Qabs+Vmod)
+      RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = Qabs
+
+      !if (RCHFLX_out(iens,segIndex)%REACH_WM_FLUX <= RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q) then ! abstraction is smaller than water in the river
+      !  RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
+      !else ! abstraction is larger than water in the river
+      !  RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q
+      !endif
     endif
-    RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual
+    !RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual
   endif
 
-  ! check
   if(verbose)then
     ntdh = size(NETOPO_in(segIndex)%UH)
     write(fmt1,'(A,I5,A)') '(A, 1X',ntdh,'(1X,F20.7))'
@@ -227,12 +237,16 @@ CONTAINS
     write(*,'(a,x,F15.7)')     ' RCHFLX_out%REACH_Q =', RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q
   endif
 
-  if(verbose) then
-    write(iulog,'(a)') ' -------------------------'
-    write(iulog,'(a)') ' -- water balance check --'
-    write(iulog,'(a)') ' -------------------------'
-  endif
-  call comp_reach_wb(idxIRF, q_upstream, RCHFLX_out(iens,segIndex), verbose)
+  if (RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) < 0) then
+    write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE VOLUME [m3]= ', RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1), 'at ', NETOPO_in(segIndex)%REACHID
+!    RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) = 0._dp
+  end if
+  if (RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q < 0) then
+    write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE FLOW [m3/s] = ', RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q, 'at ', NETOPO_in(segIndex)%REACHID
+!    RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q = 0._dp
+  end if
+
+  call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxIRF, q_upstream, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
 
  END SUBROUTINE irf_rch
 
@@ -247,8 +261,6 @@ CONTAINS
  ! ----------------------------------------------------------------------------------------
  ! Details: Convolute runoff volume of upstream at one reach at one time step
  ! ----------------------------------------------------------------------------------------
-
- USE public_var, ONLY: dt
 
  implicit none
  ! Argument variables
@@ -273,6 +285,8 @@ CONTAINS
 
  ! compute volume in reach
  rflux%ROUTE(idxIRF)%REACH_VOL(0) = rflux%ROUTE(idxIRF)%REACH_VOL(1)
+! ! For very low flow condition, outflow - inflow > current storage, so limit outflow and adjust rflux%QFUTURE_IRF(1)
+! rflux%QFUTURE_IRF(1) = min(rflux%ROUTE(idxIRF)%REACH_VOL(0)/dt + q_upstream*0.999, rflux%QFUTURE_IRF(1))
  rflux%ROUTE(idxIRF)%REACH_VOL(1) = rflux%ROUTE(idxIRF)%REACH_VOL(0) - (rflux%QFUTURE_IRF(1) - q_upstream)*dt
 
  ! Add local routed flow at the bottom of reach

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -204,25 +204,17 @@ CONTAINS
   ! take out the water from the reach if the wm flag is true and the value are not missing
   ! here we should make sure the real missing is not injection (or negative abstration)
   if((RCHFLX_out(iens,segIndex)%REACH_WM_FLUX /= realMissing).and.(is_flux_wm)) then
+    ! abstraction or injection
     if (RCHFLX_out(iens,segIndex)%REACH_WM_FLUX <= 0) then ! negative/injection
-      RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
       RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
     else ! positive/abstraction
-      Qabs = min(RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1)/dt+RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q, &
-                 RCHFLX_out(iens,segIndex)%REACH_WM_FLUX)
-      Vmod = min(RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q-Qabs, 0._dp) ! is taken from storage and is <= 0
-
-      RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) + Vmod*dt
-      RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q      = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - (Qabs+Vmod)
-      RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = Qabs
-
-      !if (RCHFLX_out(iens,segIndex)%REACH_WM_FLUX <= RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q) then ! abstraction is smaller than water in the river
-      !  RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
-      !else ! abstraction is larger than water in the river
-      !  RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q
-      !endif
+      if (RCHFLX_out(iens,segIndex)%REACH_WM_FLUX <= RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q) then ! abstraction is smaller than water in the river
+        RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
+      else ! abstraction is larger than water in the river
+        RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q
+      endif
     endif
-    !RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual
+    RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual
   endif
 
   if(verbose)then

--- a/route/build/src/kwe_route.f90
+++ b/route/build/src/kwe_route.f90
@@ -215,16 +215,11 @@ CONTAINS
    write(iulog,'(A,X,G15.4)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_Q
  endif
 
- if(verbose) then
-   write(iulog,'(a)') ' -------------------------'
-   write(iulog,'(a)') ' -- water balance check --'
-   write(iulog,'(a)') ' -------------------------'
- endif
- call comp_reach_wb(idxKW, q_upstream, RCHFLX_out(iens,segIndex), verbose)
-
  if (RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1) < 0) then
    write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE VOLUME = ', RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1), 'at ', NETOPO_in(segIndex)%REACHID
  end if
+
+ call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxKW, q_upstream, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
 
  END SUBROUTINE kw_rch
 

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -213,16 +213,11 @@ CONTAINS
    write(iulog,'(A,X,G12.5)') ' RCHFLX_out(iens,segIndex)%REACH_Q=', RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_Q
  endif
 
- if(verbose) then
-   write(iulog,'(a)') ' -------------------------'
-   write(iulog,'(a)') ' -- water balance check --'
-   write(iulog,'(a)') ' -------------------------'
- endif
- call comp_reach_wb(idxMC, q_upstream, RCHFLX_out(iens,segIndex), verbose)
-
  if (RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_VOL(1) < 0) then
    write(iulog,'(A,X,G12.5,X,A,X,I9)') ' ---- NEGATIVE VOLUME = ', RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_VOL(1), 'at ', NETOPO_in(segIndex)%REACHID
  end if
+
+ call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxMC, q_upstream, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
 
  END SUBROUTINE mc_rch
 

--- a/route/build/src/water_balance.f90
+++ b/route/build/src/water_balance.f90
@@ -19,10 +19,13 @@ CONTAINS
   ! *********************************************************************
   ! public subroutine: compute reach water balance
   ! *********************************************************************
-  SUBROUTINE comp_reach_wb(ixRoute,    &     ! input: index of routing method
+  SUBROUTINE comp_reach_wb(seg_id,     &     ! input: reach/lake id
+                           ixRoute,    &     ! input: index of routing method
                            Qupstream,  &     ! input: inflow from upstream
                            RCHFLX_in,  &     ! inout: reach flux data structure
-                           verbose)
+                           verbose,    &     !
+                           lakeFlag,   &     !
+                           tolerance)
 
   ! Descriptions
   ! Compute water balance per simulation time step and reach/lake
@@ -35,47 +38,73 @@ CONTAINS
 
   implicit none
   ! Argument variables:
+  integer(i4b), intent(in)                 :: seg_id         ! input: routing method index
   integer(i4b), intent(in)                 :: ixRoute        ! input: routing method index
   real(dp),     intent(in)                 :: Qupstream      ! input: total inflow from upstream reaches
   type(STRFLX), intent(inout)              :: RCHFLX_in      ! inout: Reach fluxes data structure
+  logical(lgt), intent(in)                 :: lakeFlag       ! input: reach index to be examined
   logical(lgt), intent(in)                 :: verbose        ! input: reach index to be examined
+  real(dp),     optional, intent(in)       :: tolerance      ! input: wb error tolerance trigering print out
   ! Local variables:
+  real(dp)                                 :: wb_tol         !
   real(dp)                                 :: dVol           !
   real(dp)                                 :: Qin            !
   real(dp)                                 :: Qlateral       !
   real(dp)                                 :: Qout           !
   real(dp)                                 :: precip         !
   real(dp)                                 :: evapo          !
-  real(dp)                                 :: Qtake          !
+  real(dp)                                 :: Qtake_demand   !
+  real(dp)                                 :: Qtake_actual   !
+
+  if (present(tolerance)) then
+    wb_tol=tolerance
+  else
+    wb_tol=2.e-5_dp
+  end if
 
   ! volume change
   dVol     = RCHFLX_in%ROUTE(ixRoute)%REACH_VOL(1)-RCHFLX_in%ROUTE(ixRoute)%REACH_VOL(0)
   ! in flux
   Qin      = Qupstream *dt
   Qlateral = RCHFLX_in%BASIN_QR(1) *dt
-  precip   = RCHFLX_in%basinprecip *dt
+  if (lakeFlag) then
+    precip   = RCHFLX_in%basinprecip *dt
+  else
+    precip   = 0._dp
+  end if
   ! out flux
-  Qout     = -1._dp *RCHFLX_in%ROUTE(ixRoute)%REACH_Q *dt
-  Qtake    = -1._dp *RCHFLX_in%REACH_WM_FLUX *dt
-  evapo    = -1._dp *RCHFLX_in%basinevapo *dt
+  Qout         = -1._dp *RCHFLX_in%ROUTE(ixRoute)%REACH_Q *dt
+  Qtake_demand = -1._dp *RCHFLX_in%REACH_WM_FLUX *dt
+  Qtake_actual = -1._dp *RCHFLX_in%REACH_WM_FLUX_actual *dt
+  if (lakeFlag) then
+    evapo    = -1._dp *RCHFLX_in%basinevapo *dt
+  else
+    evapo   = 0._dp
+  end if
 
-  ! RCHFLX_in%ROUTE(ixRoute)%WB = dVol - (Qin + Qlateral + precip + Qout + Qtake + evapo)
-  RCHFLX_in%ROUTE(ixRoute)%WB = dVol - (Qin + Qlateral + Qout + Qtake)
+  RCHFLX_in%ROUTE(ixRoute)%WB = dVol - (Qin+ Qlateral+ precip+ Qtake_actual+ Qout+ evapo)
 
-  if (verbose) then
-    write(iulog,'(A,1PG15.7)') '  WBerr [m3]        = ', RCHFLX_in%ROUTE(ixRoute)%WB
-    write(iulog,'(A,1PG15.7)') '  Vol at t0 [m3]    = ', RCHFLX_in%ROUTE(ixRoute)%REACH_VOL(0)
-    write(iulog,'(A,1PG15.7)') '  Vol at t1 [m3]    = ', RCHFLX_in%ROUTE(ixRoute)%REACH_VOL(1)
-    write(iulog,'(A,1PG15.7)') '  dVol [m3]         = ', dVol
-    write(iulog,'(A,1PG15.7)') '  inflow [m3]       = ', Qin
-    write(iulog,'(A,1PG15.7)') '  lateral flow [m3] = ', Qlateral
-    write(iulog,'(A,1PG15.7)') '  precip [m3]       = ', precip
-    write(iulog,'(A,1PG15.7)') '  outflow [m3]      = ', Qout
-    write(iulog,'(A,1PG15.7)') '  abstraction [m3]  = ', Qtake
-    write(iulog,'(A,1PG15.7)') '  evaporation [m3]  = ', evapo
+  if (verbose .or. abs(RCHFLX_in%ROUTE(ixRoute)%WB) > wb_tol) then
+    write(iulog,'(A)')         ' -------------------------------'
+    write(iulog,'(A)')         ' -- reach water balance check --'
+    write(iulog,'(A)')         ' -------------------------------'
+    write(iulog,'(A,1PG15.7)') '  id                  = ', seg_id
+    write(iulog,'(A,1PG15.7)') '  lake                = ', lakeFlag
+    write(iulog,'(A)')         '  1 = 5-(6+7+8+9+10+12)'
+    write(iulog,'(A,1PG15.7)') '  1 WBerr [m3]        = ', RCHFLX_in%ROUTE(ixRoute)%WB
+    write(iulog,'(A,1PG15.7)') '  3 Vol at t0 [m3]    = ', RCHFLX_in%ROUTE(ixRoute)%REACH_VOL(0)
+    write(iulog,'(A,1PG15.7)') '  4 Vol at t1 [m3]    = ', RCHFLX_in%ROUTE(ixRoute)%REACH_VOL(1)
+    write(iulog,'(A,1PG15.7)') '  5 dVol [m3]         = ', dVol
+    write(iulog,'(A,1PG15.7)') '  6 inflow [m3]       = ', Qin
+    write(iulog,'(A,1PG15.7)') '  7 lateral flow [m3] = ', Qlateral
+    write(iulog,'(A,1PG15.7)') '  8 precip [m3]       = ', precip
+    write(iulog,'(A,1PG15.7)') '  9 outflow [m3]      = ', Qout
+    write(iulog,'(A,1PG15.7)') ' 10 take-actual [m3]  = ', Qtake_actual
+    write(iulog,'(A,1PG15.7)') ' 11 take-demand [m3]  = ', Qtake_demand
+    write(iulog,'(A,1PG15.7)') ' 12 evaporation [m3]  = ', evapo
   endif
-  if (abs(RCHFLX_in%ROUTE(ixRoute)%WB) > 1.e-5_dp) then
-    write(iulog,'(A,1PG15.7,1X,A)') ' WARNING: WB error [m3] = ', RCHFLX_in%ROUTE(ixRoute)%WB, '> 1.e-5 [m3]'
+  if (abs(RCHFLX_in%ROUTE(ixRoute)%WB) > wb_tol) then
+    write(iulog,'(A,1PG15.7,1X,A,1X,1PG15.7)') ' WARNING: abs. WB error [m3] = ', abs(RCHFLX_in%ROUTE(ixRoute)%WB), '>',wb_tol
   end if
 
   END SUBROUTINE comp_reach_wb
@@ -113,10 +142,10 @@ CONTAINS
     character(strLen), intent(out)    :: message        ! error message
     ! Local variables:
     integer(i4b)                      :: lwr,upr        ! loop index
-    real(dp)                          :: wb_local(6)
-    real(dp)                          :: wb_global(6)
-    real(dp)                          :: wb_mainstem(6)
-    real(dp)                          :: wb_trib(6)
+    real(dp)                          :: wb_local(7)
+    real(dp)                          :: wb_global(7)
+    real(dp)                          :: wb_mainstem(7)
+    real(dp)                          :: wb_trib(7)
     real(dp)                          :: wb_error
     character(strLen)                 :: cmessage       ! error message from subroutine
 
@@ -152,22 +181,26 @@ CONTAINS
 
     wb_error = wb_global(1)-sum(wb_global(2:6))
 
-    if (masterproc) then
-      if (verbose) then
-        write(iulog,'(A)') '  global water balance [m3] '
-        write(iulog,'(A,1PG15.7)') '  dVol [m3]         = ', wb_global(1)
-        write(iulog,'(A,1PG15.7)') '  lateral flow [m3] = ', wb_global(2)
-        write(iulog,'(A,1PG15.7)') '  precip [m3]       = ', wb_global(3)
-        write(iulog,'(A,1PG15.7)') '  evaporation [m3]  = ', wb_global(4)
-        write(iulog,'(A,1PG15.7)') '  abstraction [m3]  = ', wb_global(5)
-        write(iulog,'(A,1PG15.7)') '  outflow [m3]      = ', wb_global(6)
-        write(iulog,'(A,1PG15.7)') '  WBerr [m3]        = ', wb_error
-      end if
-
-      if (abs(wb_error) > 1._dp) then ! tolerance is 1 [m3]
-        write(iulog,'(A,1PG15.7,1X,A)') ' WARNING: global WB error [m3] = ', wb_error, '> 1.0 [m3]'
+    if (verbose) then
+      if (masterproc) then
+        write(iulog,'(A)')         ' ---------------------------'
+        write(iulog,'(A)')         ' -- global water balance  --'
+        write(iulog,'(A)')         ' ---------------------------'
+        write(iulog,'(A)')         ' 8=1-(2+3+4+5+6)'
+        write(iulog,'(A,1PG15.7)') ' 1 dVol [m3]              = ', wb_global(1)
+        write(iulog,'(A,1PG15.7)') ' 2 lateral flow [m3]      = ', wb_global(2)
+        write(iulog,'(A,1PG15.7)') ' 3 precip [m3]            = ', wb_global(3)
+        write(iulog,'(A,1PG15.7)') ' 4 waterTake-actual [m3]  = ', wb_global(4)
+        write(iulog,'(A,1PG15.7)') ' 5 evaporation [m3]       = ', wb_global(5)
+        write(iulog,'(A,1PG15.7)') ' 6 outflow [m3]           = ', wb_global(6)
+        write(iulog,'(A,1PG15.7)') ' 7 waterTake-demand [m3]  = ', wb_global(7)
+        write(iulog,'(A,1PG15.7)') ' 8 WBerr [m3]             = ', wb_error
       end if
     endif
+    if (abs(wb_error) > 1._dp) then ! tolerance is 1 [m3]
+      write(iulog,'(A,1PG15.7,1X,A)') ' WARNING: global WB error [m3] = ', wb_error, '> 1.0 [m3]'
+    end if
+    flush(iulog)
 
     CONTAINS
 
@@ -180,7 +213,7 @@ CONTAINS
       ! Arguments:
       type(RCHTOPO),     intent(in)  :: NETOPO_in(:)
       type(STRFLX),      intent(in)  :: RCHFLX_in(:)
-      real(dp),          intent(out) :: water_budget(6)
+      real(dp),          intent(out) :: water_budget(7)
       integer(i4b),      intent(out) :: ierr
       character(strLen), intent(out) :: message           ! error message
       ! Local variables:
@@ -199,14 +232,19 @@ CONTAINS
         water_budget(1) = water_budget(1) + (RCHFLX_in(ix)%ROUTE(ixRoute)%REACH_VOL(1)-RCHFLX_in(ix)%ROUTE(ixRoute)%REACH_VOL(0))
         ! in flux
         water_budget(2) = water_budget(2) + RCHFLX_in(ix)%BASIN_QR(1) *dt
-        water_budget(3) = water_budget(3) + RCHFLX_in(ix)%basinprecip *dt
+        if (NETOPO_in(ix)%isLake) then
+          water_budget(3) = water_budget(3) + RCHFLX_in(ix)%basinprecip *dt
+        end if
         ! out flux
-        water_budget(4) = water_budget(4) - RCHFLX_in(ix)%basinevapo *dt
-        water_budget(5) = water_budget(5) - RCHFLX_in(ix)%REACH_WM_FLUX *dt
-
+        water_budget(4) = water_budget(4) - RCHFLX_in(ix)%REACH_WM_FLUX_actual *dt
+        if (NETOPO_in(ix)%isLake) then
+          water_budget(5) = water_budget(5) - RCHFLX_in(ix)%basinevapo *dt
+        end if
         if (NETOPO_in(ix)%DREACHI==-1 .and. NETOPO_in(ix)%DREACHK<=0) then ! to-do: better way to detect outlet segments
           water_budget(6) = water_budget(6) - RCHFLX_in(ix)%ROUTE(ixRoute)%REACH_Q *dt
         end if
+        ! misc. flux information
+        water_budget(7) = water_budget(7) - RCHFLX_in(ix)%REACH_WM_FLUX *dt
       end do
     END SUBROUTINE accum_water_balance
 


### PR DESCRIPTION
- use shared water balance error check routine for individual river reaches and lakes for any routing methods.

- lake routine
  - clean up (removing temporal print out etc.)
  - set outflow from an endorheic lake to zero (so not getting random values)
  - ensure lake volume at previous time step (REACH_VOL(0)) as well as updated at current time step (REACH_VOL(1)) is kept when exit from the lake routine.