### PR TITLE
reading aggregated history variables from restart netcdf

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -147,6 +147,7 @@ DATATYPES = \
     nrtype.f90 \
     public_var.f90 \
     nr_utils.f90 \
+    ncio_utils.f90 \
     pio_utils.f90 \
     ascii_utils.f90 \
     dataTypes.f90 \
@@ -161,7 +162,6 @@ DATATYPES = \
     allocation.f90
 # define utilities
 UTILS = \
-    ncio_utils.f90 \
     mpi_utils.f90 \
     model_utils.f90 \
     gamma_func.f90

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -117,6 +117,7 @@ MODULE globalData
   character(300),                  public :: hfileout=charMissing        ! history output file name
   character(300),                  public :: hfileout_gage=charMissing   ! gage-only history output file name
   character(300),                  public :: rfileout=charMissing        ! restart output file name
+  logical(lgt),                    public :: initHvars=.false.           ! status of history variable data initialization
 
   ! ---------- MPI/OMP/PIO variables ----------------------------------------------------------------
 

--- a/route/build/src/histVars_data.f90
+++ b/route/build/src/histVars_data.f90
@@ -50,12 +50,12 @@ MODULE histVars_data
     integer(i4b)             :: nHru               ! number of
     integer(i4b)             :: nRch               ! number of
     real(dp)                 :: timeVar            ! time variable [unit] at nt = 1
-    real(sp), allocatable    :: basRunoff(:)       ! catchment average runoff [m/s] [nHru]
-    real(sp), allocatable    :: instRunoff(:)      ! instantaneous lateral inflow into each river/lake [m3/s]  [nRch]
-    real(sp), allocatable    :: dlayRunoff(:)      ! lateral inflow into river or lake [m3/s] for each reach [nRch]
-    real(sp), allocatable    :: discharge(:,:)     ! river/lake discharge [m3/s] for each reach/lake and routing method [nRch,nMethod]
-    real(sp), allocatable    :: elev(:,:)          ! river/lake surface water elevation [m] for each reach/lake and routing method [nRch,nMethod]
-    real(sp), allocatable    :: volume(:,:)        ! river/lake volume [m3] for each reach/lake and routing method [nRch,nMethod]
+    real(dp), allocatable    :: basRunoff(:)       ! catchment average runoff [m/s] [nHru]
+    real(dp), allocatable    :: instRunoff(:)      ! instantaneous lateral inflow into each river/lake [m3/s]  [nRch]
+    real(dp), allocatable    :: dlayRunoff(:)      ! lateral inflow into river or lake [m3/s] for each reach [nRch]
+    real(dp), allocatable    :: discharge(:,:)     ! river/lake discharge [m3/s] for each reach/lake and routing method [nRch,nMethod]
+    real(dp), allocatable    :: elev(:,:)          ! river/lake surface water elevation [m] for each reach/lake and routing method [nRch,nMethod]
+    real(dp), allocatable    :: volume(:,:)        ! river/lake volume [m3] for each reach/lake and routing method [nRch,nMethod]
 
     CONTAINS
 
@@ -97,29 +97,29 @@ MODULE histVars_data
       if (meta_hflx(ixHFLX%basRunoff)%varFile) then
         allocate(instHistVar%basRunoff(nHRU_local), stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [instHistVar%basRunoff]'; return; endif
-        instHistVar%basRunoff(1:nHRU_local) = 0._sp
+        instHistVar%basRunoff(1:nHRU_local) = 0._dp
       end if
 
       if (meta_rflx(ixRFLX%instRunoff)%varFile) then
         allocate(instHistVar%instRunoff(nRch_local), stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [instHistVar%instRunoff]'; return; endif
-        instHistVar%instRunoff(1:nRch_local) = 0._sp
+        instHistVar%instRunoff(1:nRch_local) = 0._dp
       end if
 
       if (meta_rflx(ixRFLX%dlayRunoff)%varFile) then
         allocate(instHistVar%dlayRunoff(nRch_local), stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [instHistVar%instRunoff]'; return; endif
-        instHistVar%dlayRunoff(1:nRch_local) = 0._sp
+        instHistVar%dlayRunoff(1:nRch_local) = 0._dp
       end if
 
       if (nRoutes>0) then ! this should be number of methods that ouput
         allocate(instHistVar%discharge(nRch_local, nRoutes), stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [instHistVar%discharge]'; return; endif
-        instHistVar%discharge(1:nRch_local, 1:nRoutes) = 0._sp
+        instHistVar%discharge(1:nRch_local, 1:nRoutes) = 0._dp
 
         allocate(instHistVar%volume(nRch_local, nRoutes), stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [instHistVar%volume]'; return; endif
-        instHistVar%volume(1:nRch_local, 1:nRoutes) = 0._sp
+        instHistVar%volume(1:nRch_local, 1:nRoutes) = 0._dp
       end if
 
     END FUNCTION constructor
@@ -219,27 +219,27 @@ MODULE histVars_data
       ! ---- aggregate
       ! 1. basin runoff
       if (allocated(this%basRunoff)) then
-        this%basRunoff = this%basRunoff/real(this%nt, kind=sp)
+        this%basRunoff = this%basRunoff/real(this%nt, kind=dp)
       end if
 
       ! 2. instantaneous runoff into reach
       if (allocated(this%instRunoff)) then
-        this%instRunoff = this%instRunoff/real(this%nt, kind=sp)
+        this%instRunoff = this%instRunoff/real(this%nt, kind=dp)
       end if
 
       ! 3. delayed runoff into reach
       if (allocated(this%dlayRunoff)) then
-        this%dlayRunoff = this%dlayRunoff/real(this%nt, kind=sp)
+        this%dlayRunoff = this%dlayRunoff/real(this%nt, kind=dp)
       end if
 
       ! 4. discharge
       if (allocated(this%discharge)) then
-        this%discharge = this%discharge/real(this%nt, kind=sp)
+        this%discharge = this%discharge/real(this%nt, kind=dp)
       end if
 
       ! 5. volume
       if (allocated(this%volume)) then
-        this%volume    = this%volume/real(this%nt, kind=sp)
+        this%volume    = this%volume/real(this%nt, kind=dp)
       end if
 
     END SUBROUTINE finalize
@@ -255,11 +255,11 @@ MODULE histVars_data
 
       this%nt = 0
 
-      if (allocated(this%basRunoff))  this%basRunoff = 0._sp
-      if (allocated(this%instRunoff)) this%instRunoff = 0._sp
-      if (allocated(this%dlayRunoff)) this%dlayRunoff = 0._sp
-      if (allocated(this%discharge))  this%discharge = 0._sp
-      if (allocated(this%volume))     this%volume = 0._sp
+      if (allocated(this%basRunoff))  this%basRunoff = 0._dp
+      if (allocated(this%instRunoff)) this%instRunoff = 0._dp
+      if (allocated(this%dlayRunoff)) this%dlayRunoff = 0._dp
+      if (allocated(this%discharge))  this%discharge = 0._dp
+      if (allocated(this%volume))     this%volume = 0._dp
 
     END SUBROUTINE refresh
 
@@ -293,7 +293,7 @@ MODULE histVars_data
       character(len=strLen),intent(out)  :: message               ! error message
       ! local variable
       character(len=strLen)              :: cmessage              ! error message from subroutines
-      real(sp), allocatable              :: array_tmp(:)          ! temp array
+      real(dp), allocatable              :: array_tmp(:)          ! temp array
       integer(i4b)                       :: ixRoute, ix1, ix2     ! loop index
       integer(i4b)                       :: ixFlow, ixVol         ! temporal method index
       logical(lgt)                       :: FileStatus            ! file open or close
@@ -351,13 +351,13 @@ MODULE histVars_data
 
       ! initialze ioDesc
       call pio_decomp(pioSystem,         & ! input: pio system descriptor
-                      ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      ncd_double,        & ! input: data type (pio_int, pio_real, pio_double, pio_char)
                       [nRch],            & ! input: dimension length == global array size
                       compdof_rch,       & ! input: local->global mapping
                       ioDescRchHist)
 
       call pio_decomp(pioSystem,         & ! input: pio system descriptor
-                      ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      ncd_double,        & ! input: data type (pio_int, pio_real, pio_double, pio_char)
                       [nHRU],            & ! input: dimension length == global array size
                       compdof_hru,       & ! input: local->global mapping
                       ioDescHruHist)
@@ -412,8 +412,8 @@ MODULE histVars_data
         allocate(this%volume(this%nRch, nRoutes), stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [hVars%discharge]'; return; endif
 
-        this%discharge = 0._sp
-        this%volume    = 0._sp
+        this%discharge = 0._dp
+        this%volume    = 0._dp
 
         do ixRoute=1,nRoutes
           select case(routeMethods(ixRoute))

--- a/route/build/src/histVars_data.f90
+++ b/route/build/src/histVars_data.f90
@@ -145,7 +145,7 @@ MODULE histVars_data
       integer(i4b)                       :: nHRU_input
       integer(i4b)                       :: nRch_input
       integer(i4b)                       :: ix, iRoute          ! loop indices
-      integer(i4b)                       :: idxMethod             ! temporal method index
+      integer(i4b)                       :: idxMethod           ! temporal method index
 
       ierr=0; message='aggregate/'
 

--- a/route/build/src/historyFile.f90
+++ b/route/build/src/historyFile.f90
@@ -133,7 +133,7 @@ MODULE historyFile
                       this%ioDescRchFlux)
 
       call pio_decomp(this%pioSystem,    & ! input: pio system descriptor
-                      ncd_float,        & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
                       [nHRU_in],         & ! input: dimension length == global array size
                       compdof_hru,       & ! input: local->global mapping
                       this%ioDescHruFlux)

--- a/route/build/src/historyFile.f90
+++ b/route/build/src/historyFile.f90
@@ -34,7 +34,7 @@ MODULE historyFile
     integer(i4b)          :: iTime=0             ! time step in output netCDF
     logical(lgt)          :: fileStatus=.false.  ! flag to indicate history output netcdf is open
     logical(lgt)          :: gageOutput=.false.  ! flag to indicate this is at-gage-only output (== output subset of reaches)
-    type(iosystem_desc_t) :: pioSystem           ! PIO system (this does not have to be initialize for each history file?)
+    type(iosystem_desc_t) :: pioSys              ! PIO system (this does not have to be initialize for each history file?)
     type(file_desc_t)     :: pioFileDesc         ! PIO data identifying the file
     type(io_desc_t)       :: ioDescRchFlux       ! PIO domain decomposition data for reach flux [nRch]
     type(io_desc_t)       :: ioDescHruFlux       ! PIO domain decomposition data for hru runoff [nHRU]
@@ -86,13 +86,13 @@ MODULE historyFile
 
       ! pio initialization - pioSystem
       if (present(pioSys)) then
-          instHistFile%pioSystem=pioSys
+          instHistFile%pioSys=pioSys
       else
         pio_numiotasks = nNodes/pio_stride
         call pio_sys_init(pid, mpicom_route,          & ! input: MPI related parameters
                           pio_stride, pio_numiotasks, & ! input: PIO related parameters
                           pio_rearranger, pio_root,   & ! input: PIO related parameters
-                          instHistFile%pioSystem)       ! output: PIO system descriptors
+                          instHistFile%pioSys)       ! output: PIO system descriptors
       end if
 
     END FUNCTION constructor
@@ -108,7 +108,7 @@ MODULE historyFile
       integer(i4b),             intent(in)     :: nRch_in          ! total number of reaches
 
       ! initialze iodescRchFlux
-      call pio_decomp(this%pioSystem,    & ! input: pio system descriptor
+      call pio_decomp(this%pioSys,       & ! input: pio system descriptor
                       ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
                       [nRch_in],         & ! input: dimension length == global array size
                       compdof_rch,       & ! input: local->global mapping
@@ -129,13 +129,13 @@ MODULE historyFile
       integer(i4b),             intent(in)     :: nRch_in          ! total number of reaches
 
       ! initialze iodescRchFlux and ioDescHruFlux
-      call pio_decomp(this%pioSystem,    & ! input: pio system descriptor
+      call pio_decomp(this%pioSys,       & ! input: pio system descriptor
                       ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
                       [nRch_in],         & ! input: dimension length == global array size
                       compdof_rch,       & ! input: local->global mapping
                       this%ioDescRchFlux)
 
-      call pio_decomp(this%pioSystem,    & ! input: pio system descriptor
+      call pio_decomp(this%pioSys,       & ! input: pio system descriptor
                       ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
                       [nHRU_in],         & ! input: dimension length == global array size
                       compdof_hru,       & ! input: local->global mapping
@@ -167,7 +167,7 @@ MODULE historyFile
       ierr=0; message='createNC_rch/'
 
       ! 1. Create new netCDF - initialize pioFileDesc under pioSystem
-      call createFile(this%pioSystem, trim(this%fname), pio_typename, pio_netcdf_format, this%pioFileDesc, ierr, cmessage)
+      call createFile(this%pioSys, trim(this%fname), pio_typename, pio_netcdf_format, this%pioFileDesc, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! 2. Define dimension
@@ -250,7 +250,7 @@ MODULE historyFile
       ierr=0; message='createNC_rch_hru/'
 
       ! 1. Create new netCDF
-      call createFile(this%pioSystem, trim(this%fname), pio_typename, pio_netcdf_format, this%pioFileDesc, ierr, cmessage)
+      call createFile(this%pioSys, trim(this%fname), pio_typename, pio_netcdf_format, this%pioFileDesc, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! 2. Define dimension
@@ -350,7 +350,7 @@ MODULE historyFile
 
       ierr=0; message='openNC/'
 
-      call openFile(this%pioSystem, this%pioFileDesc, trim(this%fname), pio_typename, ncd_write, this%FileStatus, ierr, cmessage)
+      call openFile(this%pioSys, this%pioFileDesc, trim(this%fname), pio_typename, ncd_write, this%FileStatus, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       call inq_dim_len(this%pioFileDesc, 'time', this%iTime)

--- a/route/build/src/historyFile.f90
+++ b/route/build/src/historyFile.f90
@@ -519,12 +519,16 @@ MODULE historyFile
       integer(i4b),              intent(out)   :: ierr             ! error code
       character(*),              intent(out)   :: message          ! error message
       ! local variables
+      real(sp),    allocatable                 :: array_temp(:)
       character(len=strLen)                    :: cmessage         ! error message of downwind routine
 
       ierr=0; message='write_flux_hru/'
 
       if (meta_hflx(ixHFLX%basRunoff)%varFile) then
-        call write_pnetcdf_recdim(this%pioFileDesc, 'basRunoff', hVars_local%basRunoff, this%ioDescHruFlux, this%iTime, ierr, cmessage)
+        allocate(array_temp(hVars_local%nHru), stat=ierr, errmsg=cmessage)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [array_temp]'; return; endif
+        array_temp = hVars_local%basRunoff
+        call write_pnetcdf_recdim(this%pioFileDesc, 'basRunoff', array_temp, this%ioDescHruFlux, this%iTime, ierr, cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       endif
 

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -376,6 +376,8 @@ CONTAINS
   USE globalData, ONLY: RCHSTA                 ! global Reach state data structures
   USE globalData, ONLY: nMolecule              ! computational molecule
   USE globalData, ONLY: TSEC                   ! begining/ending of simulation time step [sec]
+  USE globalData, ONLY: initHvars              ! status of history variabiable data initialization
+  USE write_simoutput_pio, ONLY: hVars         ! history variable data
 
   implicit none
   ! Argument variables:
@@ -511,6 +513,11 @@ CONTAINS
       allocate(RCHSTA(1,1),RCHFLX(1,1), stat=ierr, errmsg=cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA,RCHFLX]'; return; endif
     end if
+
+    call hVars%read_restart(trim(restart_dir)//trim(fname_state_in), ierr, cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage);return; endif
+
+    initHvars = .true.
 
     call mpi_restart(pid, nNodes, comm, iens, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/ncio_utils.f90
+++ b/route/build/src/ncio_utils.f90
@@ -25,8 +25,10 @@ INTERFACE get_nc
   module procedure get_iscalar
   module procedure get_dscalar
   module procedure get_ivec
+  module procedure get_svec
   module procedure get_dvec
   module procedure get_2d_iarray
+  module procedure get_2d_sarray
   module procedure get_2d_darray
   module procedure get_3d_iarray
   module procedure get_3d_darray
@@ -443,6 +445,49 @@ CONTAINS
  ! *********************************************************************
  ! subroutine: read a double precision vector
  ! *********************************************************************
+ subroutine get_svec(fname,           &  ! input: filename
+                     vname,           &  ! input: variable name
+                     array,           &  ! output: variable data
+                     iStart,          &  ! input: start index
+                     iCount,          &  ! input: length of vector
+                     ierr, message)      ! output: error control
+  implicit none
+  ! input variables
+  character(*), intent(in)        :: fname     ! filename
+  character(*), intent(in)        :: vname     ! variable name
+  integer(i4b), intent(in)        :: iStart    ! start index
+  integer(i4b), intent(in)        :: iCount    ! length of vector to be read in
+  ! output variables
+  real(sp), intent(out)           :: array(:)  ! output variable data
+  integer(i4b), intent(out)       :: ierr      ! error code
+  character(*), intent(out)       :: message   ! error message
+  ! local variables
+  integer(i4b)                    :: ncid      ! NetCDF file ID
+  integer(i4b)                    :: iVarID    ! NetCDF variable ID
+
+  ierr=0; message='get_svec/'
+
+  ! open NetCDF file
+  ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+  ! get variable ID
+  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+  ! get the data
+  ierr = nf90_get_var(ncid, iVarID, array, start=(/iStart/), count=(/iCount/))
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+  ! close output file
+  ierr = nf90_close(ncid)
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+ end subroutine
+
+ ! *********************************************************************
+ ! subroutine: read a double precision vector
+ ! *********************************************************************
  subroutine get_dvec(fname,           &  ! input: filename
                      vname,           &  ! input: variable name
                      array,           &  ! output: variable data
@@ -595,6 +640,49 @@ CONTAINS
   integer(i4b)                    :: iVarId       ! NetCDF variable ID
   ! initialize error control
   ierr=0; message='get_4d_iarray/'
+
+  ! open NetCDF file
+  ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+  ! get variable ID
+  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+  ! read data
+  ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+  ! close output file
+  ierr = nf90_close(ncid)
+  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
+
+ end subroutine
+
+ ! *********************************************************************
+ ! subroutine: read a single precision 2D array
+ ! *********************************************************************
+ subroutine get_2d_sarray(fname,          &  ! input: filename
+                          vname,          &  ! input: variable name
+                          array,          &  ! output: variable data
+                          iStart,         &  ! input: start index
+                          iCount,         &  ! input: length of vector
+                          ierr, message)     ! output: error control
+  implicit none
+  ! input variables
+  character(*), intent(in)        :: fname        ! filename
+  character(*), intent(in)        :: vname        ! variable name
+  integer(i4b), intent(in)        :: iStart(1:2)  ! start indices
+  integer(i4b), intent(in)        :: iCount(1:2)  ! length of vector
+  ! output variables
+  real(sp), intent(out)           :: array(:,:)   ! variable data
+  integer(i4b), intent(out)       :: ierr         ! error code
+  character(*), intent(out)       :: message      ! error message
+  ! local variables
+  integer(i4b)                    :: ncid         ! NetCDF file ID
+  integer(i4b)                    :: iVarId       ! NetCDF variable ID
+
+  ierr=0; message='get_2d_sarray/'
 
   ! open NetCDF file
   ierr = nf90_open(trim(fname),nf90_nowrite,ncid)

--- a/route/build/src/pio_utils.f90
+++ b/route/build/src/pio_utils.f90
@@ -7,7 +7,8 @@ MODULE pio_utils
   implicit none
 
   private
-  public::pio_sys_init             ! Define pio system descriptor (iosystem_desc_t)
+  public::pio_sys_init             ! Create new pio system descriptor (iosystem_desc_t)
+  public::pio_sys_finalize         ! Shut down pio system descriptor (iosystem_desc_t)
   public::pio_decomp               ! Define decomposition (io_desc_t)
   public::createFile               ! Create netcdf
   public::def_dim                  ! Define dimension
@@ -19,6 +20,7 @@ MODULE pio_utils
   public::closeFile                ! close netcdf (if it's open) and clean file_desc_t
   public::finalizeSystem           ! free pio system descriptor (iosystem_desc_t)
   public::sync_file                ! Write out data into disk
+  public::read_pnetcdf             ! read distributed data
   public::write_scalar_netcdf      ! write non-distributed data
   public::write_netcdf             ! write non-distributed data
   public::write_pnetcdf            ! write distributed data without record dimension
@@ -42,6 +44,11 @@ MODULE pio_utils
   public file_desc_t
   public var_desc_t
   public io_desc_t
+
+  INTERFACE read_pnetcdf
+    module procedure read_darray1D
+    module procedure read_darray2D
+  END INTERFACE
 
   INTERFACE write_scalar_netcdf
     module procedure write_int_scalar
@@ -114,6 +121,23 @@ CONTAINS
                   base=idxBase)       ! base (optional argument)
 
   END SUBROUTINE pio_sys_init
+
+  ! *********************************************************************
+  ! subroutine: initialize ParallelIO system
+  ! *********************************************************************
+  SUBROUTINE pio_sys_finalize(pioIOsystem, ierr, message)
+    implicit none
+    ! ARGUMENTS:
+    type(iosystem_desc_t), intent(inout) :: pioIoSystem  ! pio system descriptor
+    integer(i4b),          intent(out)   :: ierr         ! error code
+    character(*),          intent(out)   :: message      ! error message
+
+    ierr=0; message='pio_sys_finalize/'
+
+    call PIO_finalize(pioIoSystem, ierr)
+    if(ierr/=0)then; message=trim(message)//'ERR: pio IO system not shut down properly'; return; endif
+
+  END SUBROUTINE pio_sys_finalize
 
   ! *********************************************************************
   ! subroutine: PIO domain decomposition data
@@ -498,6 +522,84 @@ CONTAINS
   end if
 
   END SUBROUTINE def_var
+
+  ! -----------------------------
+  ! Reading routine
+  ! -----------------------------
+
+  ! ---------------------------------------------------------------
+  ! read distributed a vector into 1D data
+  SUBROUTINE read_darray1D(pioFileDesc,     &
+                           vname,           &  ! input: variable name
+                           array,           &  ! input: variable data
+                           iodesc,          &  ! input: ??? it is from initdecomp routine
+                           ierr, message)      ! output: error control
+  implicit none
+  ! Argument variables:
+  type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
+  character(*),          intent(in)    :: vname        ! variable name
+  class(*),              intent(out)   :: array(:)     ! variable data
+  type(io_desc_t),       intent(inout) :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
+  integer(i4b), intent(out)            :: ierr         ! error code
+  character(*), intent(out)            :: message      ! error message
+  ! local variables
+  type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
+
+  ierr=0; message='read_darray1D/'
+
+  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
+  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
+
+   select type (array)
+      type is (integer(i4b))
+        call pio_read_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+      type is (real(sp))
+        call pio_read_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+      type is (real(dp))
+        call pio_read_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+      class default
+        ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+    end select
+    if(ierr/=pio_noerr)then; message=trim(message)//'ERROR: reading data'; return; endif
+
+  END SUBROUTINE read_darray1D
+
+  ! ---------------------------------------------------------------
+  ! read distributed a vector into 1D data
+  SUBROUTINE read_darray2D(pioFileDesc,     &
+                           vname,           &  ! input: variable name
+                           array,           &  ! input: variable data
+                           iodesc,          &  ! input: ??? it is from initdecomp routine
+                           ierr, message)      ! output: error control
+  implicit none
+  ! Argument variables:
+  type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
+  character(*),          intent(in)    :: vname        ! variable name
+  class(*),              intent(out)   :: array(:,:)   ! variable data
+  type(io_desc_t),       intent(inout) :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
+  integer(i4b), intent(out)            :: ierr         ! error code
+  character(*), intent(out)            :: message      ! error message
+  ! local variables
+  type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
+
+  ierr=0; message='read_darray2D/'
+
+  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
+  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
+
+   select type (array)
+      type is (integer(i4b))
+        call pio_read_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+      type is (real(sp))
+        call pio_read_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+      type is (real(dp))
+        call pio_read_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+      class default
+        ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+    end select
+    if(ierr/=pio_noerr)then; message=trim(message)//'ERROR: reading data'; return; endif
+
+  END SUBROUTINE read_darray2D
 
   ! -----------------------------
   ! Writing routine

--- a/route/build/src/pio_utils.f90
+++ b/route/build/src/pio_utils.f90
@@ -20,7 +20,7 @@ MODULE pio_utils
   public::closeFile                ! close netcdf (if it's open) and clean file_desc_t
   public::finalizeSystem           ! free pio system descriptor (iosystem_desc_t)
   public::sync_file                ! Write out data into disk
-  public::read_pnetcdf             ! read distributed data
+  public::read_dist_array          ! read distributed data
   public::put_attr                 ! write attribute
   public::write_scalar_netcdf      ! write non-distributed data
   public::write_netcdf             ! write non-distributed data
@@ -46,7 +46,7 @@ MODULE pio_utils
   public var_desc_t
   public io_desc_t
 
-  INTERFACE read_pnetcdf
+  INTERFACE read_dist_array
     module procedure read_darray1D
     module procedure read_darray2D
   END INTERFACE

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -10,6 +10,7 @@ USE nr_utils,          ONLY: match_index
 USE nr_utils,          ONLY: arth
 USE nr_utils,          ONLY: unique         ! get unique element array
 USE nr_utils,          ONLY: indexx         ! get rank of data value
+USE pio_utils
 
 implicit none
 
@@ -55,6 +56,13 @@ CONTAINS
                       ierr, message)   ! output: error control
 
    USE public_var,          ONLY: continue_run        ! T-> append output in existing history files. F-> write output in new history file
+   USE globalData,          ONLY: mpicom_route
+   USE globalData,          ONLY: pio_numiotasks
+   USE globalData,          ONLY: pio_rearranger
+   USE globalData,          ONLY: pio_root
+   USE globalData,          ONLY: pio_stride
+   USE globalData,          ONLY: pioSystem
+   USE globalData,          ONLY: runMode
    USE mpi_process,         ONLY: pass_global_data    ! mpi globaldata copy to slave proc
    USE init_model_data,     ONLY: init_ntopo_data
    USE init_model_data,     ONLY: init_state_data
@@ -71,6 +79,15 @@ CONTAINS
    character(len=strLen)                    :: cmessage         ! error message of downwind routine
 
    ierr=0; message='init_data/'
+
+   ! pio initialization
+   if (trim(runMode)=='standalone') then
+     pio_numiotasks = nNodes/pio_stride
+     call pio_sys_init(pid, mpicom_route,          & ! input: MPI related parameters
+                       pio_stride, pio_numiotasks, & ! input: PIO related parameters
+                       pio_rearranger, pio_root,   & ! input: PIO related parameters
+                       pioSystem)                    ! output: PIO system descriptors
+   end if
 
    ! runoff input files initialization
    call init_inFile_pop(ierr, cmessage)

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -317,10 +317,10 @@ CONTAINS
  call def_var(pioFileDescState, 'reachID', ncd_int, ierr, cmessage, pioDimId=[dim_seg], vdesc='reach ID',  vunit='-' )
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call def_var(pioFileDescState, 'restart_time', ncd_float, ierr, cmessage, vdesc='resatart time', vunit=trim(time_units), vcal=calendar)
+ call def_var(pioFileDescState, 'restart_time', ncd_double, ierr, cmessage, vdesc='resatart time', vunit=trim(time_units), vcal=calendar)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call def_var(pioFileDescState, 'history_time', ncd_float, ierr, cmessage, vdesc='history time', vunit=trim(time_units), vcal=calendar)
+ call def_var(pioFileDescState, 'history_time', ncd_double, ierr, cmessage, vdesc='history time', vunit=trim(time_units), vcal=calendar)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  call def_var(pioFileDescState, 'time_bound', ncd_float, ierr, cmessage, pioDimId=[dim_tbound], vdesc='time bound at last time step', vunit='sec')

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -57,8 +57,8 @@ implicit none
 type(file_desc_t)    :: pioFileDescState     ! contains data identifying the file
 type(io_desc_t)      :: iodesc_rch_int
 type(io_desc_t)      :: iodesc_rch_double
-type(io_desc_t)      :: ioDesc_rch_float
-type(io_desc_t)      :: ioDesc_hru_float
+type(io_desc_t)      :: iodesc_hist_rch_double
+type(io_desc_t)      :: iodesc_hist_hru_double
 type(io_desc_t)      :: iodesc_wave_int
 type(io_desc_t)      :: iodesc_wave_double
 type(io_desc_t)      :: iodesc_mesh_kw_double
@@ -398,24 +398,24 @@ CONTAINS
                  compdof_rch,            & ! input:
                  iodesc_rch_int)
 
- ! type: single precision float  dim: [dim_seg, dim_ens]  --
+ ! type: single precision float  dim: [dim_seg]  --
  call pio_decomp(pioSystem,              & ! input: pio system descriptor
-                 ncd_float,              & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                 ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
                  [nSeg],                 & ! input: dimension length == global array size
                  compdof_rch,            & ! input:
-                 ioDesc_rch_float)
+                 iodesc_hist_rch_double)
 
  if (meta_hflx(ixHFLX%basRunoff)%varFile) then
-   ! type: single precision float  dim: [dim_hru, dim_ens]  --
+   ! type: single precision float  dim: [dim_hru]  --
    call pio_decomp(pioSystem,              & ! input: pio system descriptor
-                   ncd_float,              & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                   ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
                    [nHru],                 & ! input: dimension length == global array size
                    compdof_hru,            & ! input:
-                   ioDesc_hru_float)
+                   iodesc_hist_hru_double)
  end if
 
  if (doesBasinRoute==1) then
-   ! type: float dim: [dim_seg, dim_tdh_irf, dim_ens]
+   ! type: float dim: [dim_seg, dim_tdh_irf]
    call pio_decomp(pioSystem,              & ! input: pio system descriptor
                    ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
                    [nSeg,ntdh,nEns],       & ! input: dimension length == global array size
@@ -811,7 +811,7 @@ CONTAINS
    do iVar=1,nVarsRFLX
      if (.not. meta_rflx(iVar)%varFile) cycle
      dim_set(1) = meta_stateDims(ixStateDims%seg)%dimId ! this should be seg dimension
-     call def_var(pioFileDescState, meta_rflx(iVar)%varName, meta_rflx(iVar)%varType, ierr, cmessage, &
+     call def_var(pioFileDescState, meta_rflx(iVar)%varName, ncd_double, ierr, cmessage, &
                   pioDimId=dim_set, vdesc=meta_rflx(iVar)%varDesc, vunit=meta_rflx(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
@@ -819,7 +819,7 @@ CONTAINS
    do iVar=1,nVarsHFLX
      if (.not. meta_hflx(iVar)%varFile) cycle
      dim_set(1) = meta_stateDims(ixStateDims%hru)%dimId ! this should be hru dimension
-     call def_var(pioFileDescState, meta_hflx(iVar)%varName, meta_hflx(iVar)%varType, ierr, cmessage, &
+     call def_var(pioFileDescState, meta_hflx(iVar)%varName, ncd_double, ierr, cmessage, &
                   pioDimId=dim_set, vdesc=meta_hflx(iVar)%varDesc, vunit=meta_hflx(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
@@ -976,9 +976,9 @@ CONTAINS
  ! clean decomposition data
  call freeDecomp(pioFileDescState, iodesc_rch_double)
  call freeDecomp(pioFileDescState, iodesc_rch_int)
- call freeDecomp(pioFileDescState, iodesc_rch_float)
+ call freeDecomp(pioFileDescState, iodesc_hist_rch_double)
  if (meta_hflx(ixHFLX%basRunoff)%varFile) then
-   call freeDecomp(pioFileDescState, iodesc_hru_float)
+   call freeDecomp(pioFileDescState, iodesc_hist_hru_double)
  end if
  if (doesBasinRoute==1) then
    call freeDecomp(pioFileDescState, iodesc_irf_bas_double)
@@ -1399,7 +1399,7 @@ CONTAINS
     ! local variables
     integer(i4b)               :: nRch_local         ! number of reaches per processors
     integer(i4b), allocatable  :: index_write(:)  ! indices in hVar to be written in netcdf
-    real(sp),     allocatable  :: array_sp(:)
+    real(dp),     allocatable  :: array_dp(:)
 
     ierr=0; message1='write_history_state/'
 
@@ -1417,7 +1417,7 @@ CONTAINS
       index_write = arth(1,1,nRch_local)
     end if
 
-    allocate(array_sp(nRch_local),stat=ierr, errmsg=cmessage)
+    allocate(array_dp(nRch_local),stat=ierr, errmsg=cmessage)
 
     call write_scalar_netcdf(pioFileDescState, 'nt', hVars%nt, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -1426,61 +1426,61 @@ CONTAINS
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     if (meta_hflx(ixHFLX%basRunoff)%varFile) then
-      call write_pnetcdf(pioFileDescState, 'basRunoff', hVars%basRunoff, ioDesc_hru_float, ierr, cmessage)
+      call write_pnetcdf(pioFileDescState, 'basRunoff', hVars%basRunoff, iodesc_hist_hru_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     end if
 
     if (meta_rflx(ixRFLX%instRunoff)%varFile) then
-      array_sp(1:nRch_local) = hVars%instRunoff(index_write)
-      call write_pnetcdf(pioFileDescState, 'instRunoff', array_sp, ioDesc_rch_float, ierr, cmessage)
+      array_dp(1:nRch_local) = hVars%instRunoff(index_write)
+      call write_pnetcdf(pioFileDescState, 'instRunoff', array_dp, iodesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%dlayRunoff)%varFile) then
-      array_sp(1:nRch_local) = hVars%dlayRunoff(index_write)
-      call write_pnetcdf(pioFileDescState, 'dlayRunoff', array_sp, ioDesc_rch_float, ierr, cmessage)
+      array_dp(1:nRch_local) = hVars%dlayRunoff(index_write)
+      call write_pnetcdf(pioFileDescState, 'dlayRunoff', array_dp, iodesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile) then
-      array_sp = hVars%discharge(index_write, idxSUM)
-      call write_pnetcdf(pioFileDescState, 'sumUpstreamRunoff', array_sp, ioDesc_rch_float, ierr, cmessage)
+      array_dp = hVars%discharge(index_write, idxSUM)
+      call write_pnetcdf(pioFileDescState, 'sumUpstreamRunoff', array_dp, iodesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%KWTroutedRunoff)%varFile) then
-      array_sp = hVars%discharge(index_write, idxKWT)
-      call write_pnetcdf(pioFileDescState, 'KWTroutedRunoff', array_sp, ioDesc_rch_float, ierr, cmessage)
+      array_dp = hVars%discharge(index_write, idxKWT)
+      call write_pnetcdf(pioFileDescState, 'KWTroutedRunoff', array_dp, iodesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%IRFroutedRunoff)%varFile) then
-      array_sp = hVars%discharge(index_write, idxIRF)
-      call write_pnetcdf(pioFileDescState, 'IRFroutedRunoff', array_sp, ioDesc_rch_float, ierr, cmessage)
+      array_dp = hVars%discharge(index_write, idxIRF)
+      call write_pnetcdf(pioFileDescState, 'IRFroutedRunoff', array_dp, iodesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%KWroutedRunoff)%varFile) then
-      array_sp = hVars%discharge(index_write, idxKW)
-      call write_pnetcdf(pioFileDescState, 'KWroutedRunoff', array_sp, ioDesc_rch_float, ierr, cmessage)
+      array_dp = hVars%discharge(index_write, idxKW)
+      call write_pnetcdf(pioFileDescState, 'KWroutedRunoff', array_dp, iodesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%MCroutedRunoff)%varFile) then
-      array_sp = hVars%discharge(index_write, idxMC)
-      call write_pnetcdf(pioFileDescState, 'MCroutedRunoff', array_sp, ioDesc_rch_float, ierr, cmessage)
+      array_dp = hVars%discharge(index_write, idxMC)
+      call write_pnetcdf(pioFileDescState, 'MCroutedRunoff', array_dp, iodesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%DWroutedRunoff)%varFile) then
-      array_sp = hVars%discharge(index_write, idxDW)
-      call write_pnetcdf(pioFileDescState, 'DWroutedRunoff', array_sp, ioDesc_rch_float, ierr, cmessage)
+      array_dp = hVars%discharge(index_write, idxDW)
+      call write_pnetcdf(pioFileDescState, 'DWroutedRunoff', array_dp, iodesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%IRFvolume)%varFile) then
-      array_sp = hVars%volume(index_write, idxIRF)
-      call write_pnetcdf(pioFileDescState, 'IRFvolume', array_sp, ioDesc_rch_float, ierr, cmessage)
+      array_dp = hVars%volume(index_write, idxIRF)
+      call write_pnetcdf(pioFileDescState, 'IRFvolume', array_dp, iodesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -72,11 +72,7 @@ CONTAINS
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! initialize and create history netcdfs
-      select case(trim(runMode))
-        case('standalone');    hist_all_network = histFile(hfileout)
-        case('cesm-coupling'); hist_all_network = histFile(hfileout, pioSys=pioSystem)
-        case default; ierr=20; message=trim(message)//'rumMode: '//trim(runMode)//': must be standalone or cesm-coupling'; return
-      end select
+      hist_all_network = histFile(hfileout, pioSys=pioSystem)
 
       call get_compdof_all_network(compdof_rch, compdof_hru)
 
@@ -93,12 +89,7 @@ CONTAINS
 
       if (outputAtGage) then
 
-        ! initialize and create history netcdfs
-        select case(trim(runMode))
-          case('standalone');    hist_gage = histFile(hfileout_gage, gageOutput=.true.)
-          case('cesm-coupling'); hist_gage = histFile(hfileout_gage, pioSys=pioSystem, gageOutput=.true.)
-          case default; ierr=20; message=trim(message)//'rumMode: '//trim(runMode)//': must be standalone or cesm-coupling'; return
-        end select
+        hist_gage = histFile(hfileout_gage, pioSys=pioSystem, gageOutput=.true.)
 
         call get_compdof_gage(compdof_rch_gage, ierr, cmessage)
 
@@ -497,11 +488,7 @@ CONTAINS
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    ! initialize and create history netcdfs
-   select case(trim(runMode))
-     case('standalone');    hist_all_network = histFile(hfileout)
-     case('cesm-coupling'); hist_all_network = histFile(hfileout, pioSys=pioSystem)
-     case default; ierr=20; message=trim(message)//'rumMode: '//trim(runMode)//': must be standalone or cesm-coupling'; return
-   end select
+   hist_all_network = histFile(hfileout, pioSys=pioSystem)
 
    call hist_all_network%openNc(ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -511,11 +498,7 @@ CONTAINS
    call hist_all_network%set_compdof(compdof_rch, compdof_hru, nRch, nHRU)
 
    if (outputAtGage) then
-     select case(trim(runMode))
-       case('standalone');    hist_gage = histFile(hfileout_gage, gageOutput=.true.)
-       case('cesm-coupling'); hist_gage = histFile(hfileout_gage, pioSys=pioSystem, gageOutput=.true.)
-       case default; ierr=20; message=trim(message)//'rumMode: '//trim(runMode)//': must be standalone or cesm-coupling'; return
-     end select
+     hist_gage = histFile(hfileout_gage, pioSys=pioSystem, gageOutput=.true.)
 
      call hist_gage%openNC(ierr, message)
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -11,6 +11,7 @@ USE globalData,     ONLY: runMode           ! 'standalone' or 'cesm-coupling'
 USE globalData,     ONLY: pid, nNodes
 USE globalData,     ONLY: masterproc
 USE globalData,     ONLY: hfileout, hfileout_gage, rfileout
+USE globalData,     ONLY: initHvars
 USE historyFile,    ONLY: histFile
 USE histVars_data,  ONLY: histVars
 USE io_rpointfile,  ONLY: io_rpfile
@@ -18,7 +19,6 @@ USE ascii_utils,    ONLY: lower
 USE pio_utils
 
 implicit none
-logical(lgt),   save            :: initHvars=.false.     !
 type(histVars), save            :: hVars                 !
 type(histFile), save            :: hist_all_network      !
 type(histFile), save            :: hist_gage             !


### PR DESCRIPTION
This completes temporal aggregated history output capability.  This PR implements reading history variable restart so mizuRoute can restart properly (if the previous simulation ends before aggregated history variable is output)

- New type-bound procedure to read aggregated history variables from restart netcdf (in histVar_data.f90)
- Enable restarting capability for temporal aggregated history outputs.
- Fixed an error in writing aggregated history variables to restart file.
- Pio system initialization for standalone use (avoid creating separate pioSystem for each restart output, history output, reading)