### PR TITLE
move git variable (version, gitBranch, gitHash) to standalone f90 

### DIFF
--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -44,9 +44,6 @@ CONTAINS
   USE globalData, ONLY: multiProcs   ! mpi multi-procs logical (.true. -> use more than 1 processors)
   USE globalData, ONLY: pid          ! procs id (rank)
   USE globalData, ONLY: nThreads     ! number of OMP threads
-  USE globalData, ONLY: version      ! mizuRoute version
-  USE globalData, ONLY: gitBranch    ! git branch
-  USE globalData, ONLY: gitHash      ! git commit hash
   USE mpi_utils, ONLY: shr_mpi_commsize
   USE mpi_utils, ONLY: shr_mpi_commrank
 
@@ -58,17 +55,6 @@ CONTAINS
   integer(i4b)               :: omp_get_num_threads ! number of threads used for openMP
 
   message='get_mpi_omp/'
-
-  ! Get mizuRoute model information
-#if defined(VERSION)
-  version=VERSION
-#endif
-#if defined(HASH)
-  gitHash=HASH
-#endif
-#if defined(BRANCH)
-  gitBranch=BRANCH
-#endif
 
   ! Get the number of processes
   call shr_mpi_commsize(comm, nNodes, message)

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -146,7 +146,7 @@ MODULE public_var
   character(len=strLen),public    :: dname_hru_remap      = ''              ! dimension name for river network HRU
   character(len=strLen),public    :: dname_data_remap     = ''              ! dimension name for runoff HRU ID
   ! RESTART OPTION
-  character(len=strLen),public    :: restart_write        = 'never'         ! restart write option: N[n]ever-> never write, L[l]ast -> write at last time step, S[s]pecified, Monthly, Daily
+  character(len=strLen),public    :: restart_write        = 'never'         ! restart write option (case-insensitive): never, last, specified, yearly, monthly, daily
   character(len=strLen),public    :: restart_date         = charMissing     ! specifed restart date
   integer(i4b)         ,public    :: restart_month        = 1               ! restart periodic month. Default Jan (write every January of year)
   integer(i4b)         ,public    :: restart_day          = 1               ! restart periodic day.   Default 1st (write every 1st of month)

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -63,6 +63,9 @@ CONTAINS
    USE globalData,          ONLY: pio_stride
    USE globalData,          ONLY: pioSystem
    USE globalData,          ONLY: runMode
+   USE globalData,          ONLY: version             ! mizuRoute version
+   USE globalData,          ONLY: gitBranch           ! git branch
+   USE globalData,          ONLY: gitHash             ! git commit hash
    USE mpi_process,         ONLY: pass_global_data    ! mpi globaldata copy to slave proc
    USE init_model_data,     ONLY: init_ntopo_data
    USE init_model_data,     ONLY: init_state_data
@@ -79,6 +82,17 @@ CONTAINS
    character(len=strLen)                    :: cmessage         ! error message of downwind routine
 
    ierr=0; message='init_data/'
+
+  ! Get mizuRoute model information
+#if defined(VERSION)
+  version=VERSION
+#endif
+#if defined(HASH)
+  gitHash=HASH
+#endif
+#if defined(BRANCH)
+  gitBranch=BRANCH
+#endif
 
    ! pio initialization
    if (trim(runMode)=='standalone') then
@@ -618,7 +632,7 @@ CONTAINS
   ! "Monthly" option: use 2000-01 as template calendar yr/month
   ! "Daily" option:   use 2000-01-01 as template calendar yr/month/day
   select case(lower(trim(restart_write)))
-    case('annual')
+    case('yearly')
       dummyDatetime = datetime(2000, restart_month, 1, 0, 0, 0.0_dp)
       nDays = dummyDatetime%ndays_month(calendar, ierr, cmessage)
       if(ierr/=0) then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -628,9 +628,9 @@ CONTAINS
   ! Set restart calendar date/time and dropoff calendar date/time and
   ! -- For periodic restart options  ---------------------------------------------------------------------
   ! Ensure that user-input restart month, day are valid.
-  ! "Annual" option:  if user input day exceed number of days given user input month, set to last day
-  ! "Monthly" option: use 2000-01 as template calendar yr/month
-  ! "Daily" option:   use 2000-01-01 as template calendar yr/month/day
+  ! "yearly" option:  if user input day exceed number of days given user input month, set to last day
+  ! "monthly" option: use 2000-01 as template calendar yr/month
+  ! "daily" option:   use 2000-01-01 as template calendar yr/month/day
   select case(lower(trim(restart_write)))
     case('yearly')
       dummyDatetime = datetime(2000, restart_month, 1, 0, 0, 0.0_dp)


### PR DESCRIPTION
**issue**
fortran file extension used is f90, which causes a compilation problem in CESM build. Root cause of the problem is likely cpp preprocessing, which require fortran file extension to be F90 (see https://github.com/j3-fortran/fortran_proposals/issues/65, or https://gcc.gnu.org/onlinedocs/gfortran/Preprocessing-Options.html). For standalone compilation, f90 extension seems to be working. 

**How it is resolved for now**
Instead of changing extension for all the files (better for consistency, and could be better?), move git variable (version, gitBranch, gitHash) assignment section to model_setup.f90, which is located under standalone directory so they are visible only for standalone compilation. 