### PR TITLE
use select type to compact the generic routine

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,9 +74,8 @@ pygments_style = None
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
-#html_theme = 'alabaster'
-#html_theme = 'sphinxdoc'
+# some themes: 'alabaster'(default), 'sphinxdoc', 'sphinx_rtd_theme'
+# see https://sphinx-themes.org/ (last accessed on May 4th 2023) for more themes
 html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,7 @@ pygments_style = None
 # a list of builtin themes.
 #
 #html_theme = 'alabaster'
-html_theme = 'sphinxdoc'
+#html_theme = 'sphinxdoc'
 html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,9 +72,9 @@ pygments_style = None
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-# some themes: 'alabaster'(default), 'sphinxdoc', 'sphinx_rtd_theme'
+# The theme to use for HTML and HTML Help pages.
+# Theme can be changed freely based on personal preference.
+# some themes used before: 'alabaster'(default), 'sphinxdoc'
 # see https://sphinx-themes.org/ (last accessed on May 4th 2023) for more themes
 html_theme = 'sphinx_rtd_theme'
 

--- a/route/build/src/ncio_utils.f90
+++ b/route/build/src/ncio_utils.f90
@@ -22,33 +22,17 @@ public::open_nc
 public::close_nc
 
 INTERFACE get_nc
-  module procedure get_iscalar
-  module procedure get_dscalar
-  module procedure get_ivec
-  module procedure get_svec
-  module procedure get_dvec
-  module procedure get_2d_iarray
-  module procedure get_2d_sarray
-  module procedure get_2d_darray
-  module procedure get_3d_iarray
-  module procedure get_3d_darray
-  module procedure get_4d_iarray
-  module procedure get_4d_darray
+  module procedure get_scalar
+  module procedure get_vec
+  module procedure get_2d_array
+  module procedure get_3d_array
+  module procedure get_4d_array
 END INTERFACE
 
 INTERFACE write_nc
-  module procedure write_ivec
-  module procedure write_dvec
-  module procedure write_charvec
-  module procedure write_2d_iarray
-  module procedure write_2d_darray
-  module procedure write_3d_iarray
-  module procedure write_3d_darray
-END INTERFACE
-
-INTERFACE get_var_attr
-  module procedure get_var_attr_char
-  module procedure get_var_attr_real
+  module procedure write_vec
+  module procedure write_2d_array
+  module procedure write_3d_array
 END INTERFACE
 
 ! public netCDF parameter
@@ -247,26 +231,25 @@ CONTAINS
  ! *********************************************************************
  ! subroutine: get attribute values for a variable
  ! *********************************************************************
- subroutine get_var_attr_char(fname,           &  ! input: filename
-                              vname,           &  ! input: variable name
-                              attr_name,       &  ! inpu: attribute name
-                              attr_value,      &  ! output: attribute value
-                              ierr, message)      ! output: error control
+ subroutine get_var_attr(fname,           &  ! input: filename
+                         vname,           &  ! input: variable name
+                         attr_name,       &  ! inpu: attribute name
+                         attr_value,      &  ! output: attribute value
+                         ierr, message)      ! output: error control
  implicit none
  ! input variables
  character(*), intent(in)        :: fname        ! filename
  character(*), intent(in)        :: vname        ! variable name
  character(*), intent(in)        :: attr_name    ! attribute name
  ! output variables
- character(*), intent(out)       :: attr_value   ! attribute value
+ class(*),     intent(out)       :: attr_value   ! attribute value
  integer(i4b), intent(out)       :: ierr         ! error code
  character(*), intent(out)       :: message      ! error message
  ! local variables
- integer(i4b)                    :: var_type     ! attribute variable type
  integer(i4b)                    :: ncid         ! NetCDF file ID
  integer(i4b)                    :: iVarID       ! variable ID
- ! initialize error control
- ierr=0; message='get_var_attr_char/'
+
+ ierr=0; message='get_var_attr/'
 
  ! open file for reading
  ierr = nf90_open(fname, nf90_nowrite, ncid)
@@ -276,137 +259,84 @@ CONTAINS
  ierr = nf90_inq_varid(ncid, trim(vname), ivarID)
  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
- ! Inquire attribute type, NF90_CHAR(=2)
- ierr = nf90_inquire_attribute(ncid, ivarID, attr_name, xtype=var_type)
- if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr))//'; nc='//trim(fname)//'; attr='//trim(attr_name); return; endif
-
- if (var_type /= nf90_char)then; ierr=20; message=trim(message)//'attribute type must be character'; return; endif
-
  ! get the attribute value
- ierr = nf90_get_att(ncid, ivarID, attr_name, attr_value)
+ select type (attr_value)
+   type is (integer(i4b))
+     ierr = nf90_get_att(ncid, ivarID, attr_name, attr_value)
+   type is (integer(i8b))
+     ierr = nf90_get_att(ncid, ivarID, attr_name, attr_value)
+   type is (real(sp))
+     ierr = nf90_get_att(ncid, ivarID, attr_name, attr_value)
+   type is (real(dp))
+     ierr = nf90_get_att(ncid, ivarID, attr_name, attr_value)
+   type is (character(len=*))
+     ierr = nf90_get_att(ncid, ivarID, attr_name, attr_value)
+   class default
+     ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+ end select
  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
  ! close the NetCDF file
  ierr = nf90_close(ncid)
  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
- end subroutine get_var_attr_char
+ end subroutine get_var_attr
 
- ! *********************************************************************
- ! subroutine: get attribute values for a real variable
- ! *********************************************************************
- subroutine get_var_attr_real(fname,           &  ! input: filename
-                              vname,           &  ! input: variable name
-                              attr_name,       &  ! inpu: attribute name
-                              attr_value,      &  ! output: attribute value in real
-                              ierr, message)      ! output: error control
- implicit none
- ! input variables
- character(*), intent(in)        :: fname        ! filename
- character(*), intent(in)        :: vname        ! variable name
- character(*), intent(in)        :: attr_name    ! attribute name
- ! output variables
- real(dp), intent(out)           :: attr_value   ! attribute value in real
- integer(i4b), intent(out)       :: ierr         ! error code
- character(*), intent(out)       :: message      ! error message
- ! local variables
- integer(i4b)                    :: var_type     ! attribute variable type
- integer(i4b)                    :: ncid         ! NetCDF file ID
- integer(i4b)                    :: iVarID       ! variable ID
- ! initialize error control
- ierr=0; message='get_var_attr_real/'
-
- ! open file for reading
- ierr = nf90_open(fname, nf90_nowrite, ncid)
- if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr))//'; name='//trim(fname); return; endif
-
- ! get the ID of the variable
- ierr = nf90_inq_varid(ncid, trim(vname), ivarID)
- if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
- ! Inquire attribute type, NF90_CHAR(=2)
- ierr = nf90_inquire_attribute(ncid, ivarID, attr_name, xtype=var_type)
- if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr))//'; nc='//trim(fname)//'; attr='//trim(attr_name); return; endif
-
- if (var_type /= nf90_float .and. var_type /= nf90_double)then; ierr=20; message=trim(message)//'attribute type must be real'; return; endif
-
- ! get the attribute value
- ierr = nf90_get_att(ncid, ivarID, attr_name, attr_value)
- if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
- ! close the NetCDF file
- ierr = nf90_close(ncid)
- if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
- end subroutine get_var_attr_real
-
-
- ! *********************************************************************
- ! subroutine: get integer scalar value from netCDF
- ! *********************************************************************
- subroutine get_iscalar(fname,           &  ! input:  filename
-                        vname,           &  ! input:  variable name
-                        array,           &  ! output: variable data
-                        iStart,          &  ! input:  start index
-                        ierr, message)      ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname     ! filename
-  character(*), intent(in)        :: vname     ! variable name
-  integer(i4b), intent(in)        :: iStart    ! start index
-  ! output variables
-  integer(i4b), intent(out)       :: array     ! output variable data
-  integer(i4b), intent(out)       :: ierr      ! error code
-  character(*), intent(out)       :: message   ! error message
-  ! local variables
-  character(len=strLen)           :: cmessage     ! error message of downwind routine
-  integer(i4b)                    :: array_vec(1) ! output variable data
-
- ierr=0; message='get_iscalar/'
-
- call get_ivec(fname, vname, array_vec, iStart, 1, ierr, cmessage)
- array = array_vec(1)
-
- end subroutine
 
  ! *********************************************************************
  ! subroutine: double precision scalar value from netCDF
  ! *********************************************************************
- subroutine get_dscalar(fname,           &  ! input:  filename
-                        vname,           &  ! input:  variable name
-                        array,           &  ! output: variable data
-                        iStart,          &  ! input:  start index
-                        ierr, message)      ! output: error control
+ subroutine get_scalar(fname,           &  ! input:  filename
+                       vname,           &  ! input:  variable name
+                       array,           &  ! output: variable data
+                       iStart,          &  ! input:  start index
+                       ierr, message)      ! output: error control
   implicit none
   ! input variables
   character(*), intent(in)        :: fname     ! filename
   character(*), intent(in)        :: vname     ! variable name
   integer(i4b), intent(in)        :: iStart    ! start index
   ! output variables
-  real(dp), intent(out)           :: array     ! output variable data
+  class(*),     intent(out)       :: array     ! output variable data
   integer(i4b), intent(out)       :: ierr      ! error code
   character(*), intent(out)       :: message   ! error message
   ! local variables
-  character(len=strLen)           :: cmessage     ! error message of downwind routine
-  real(dp)                        :: array_vec(1) ! output variable data
+  character(len=strLen)           :: cmessage   ! error message of downwind routine
+  integer(i4b)                    :: vec_14b(1) ! 32bit int variable data
+  integer(i8b)                    :: vec_18b(1) ! 64bit int variable data
+  real(sp)                        :: vec_sp(1)  ! double precision float variable data
+  real(dp)                        :: vec_dp(1)  ! single precision float variable data
 
- ! initialize error control
- ierr=0; message='get_dscalar/'
+ ierr=0; message='get_scalar/'
 
- call get_dvec(fname, vname, array_vec, iStart, 1, ierr, cmessage)
- array = array_vec(1)
+ select type (array)
+   type is (integer(i4b))
+     call get_vec(fname, vname, vec_14b, iStart, 1, ierr, cmessage)
+     array = vec_14b(1)
+   type is (integer(i8b))
+     call get_vec(fname, vname, vec_18b, iStart, 1, ierr, cmessage)
+     array = vec_18b(1)
+   type is (real(sp))
+     call get_vec(fname, vname, vec_sp, iStart, 1, ierr, cmessage)
+     array = vec_sp(1)
+   type is (real(dp))
+     call get_vec(fname, vname, vec_dp, iStart, 1, ierr, cmessage)
+     array = vec_dp(1)
+   class default
+     ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+ end select
 
- end subroutine
+ end subroutine get_scalar
 
  ! *********************************************************************
- ! subroutine: get integer vector value from netCDF
+ ! subroutine: get vector (1D aray) value from netCDF
  ! *********************************************************************
- subroutine get_ivec(fname,           &  ! input:  filename
-                     vname,           &  ! input:  variable name
-                     array,           &  ! output: variable data
-                     iStart,          &  ! input:  start index
-                     iCount,          &  ! input:  length of vector
-                     ierr, message)      ! output: error control
+ subroutine get_vec(fname,           &  ! input:  filename
+                    vname,           &  ! input:  variable name
+                    array,           &  ! output: variable data
+                    iStart,          &  ! input:  start index
+                    iCount,          &  ! input:  length of vector
+                    ierr, message)      ! output: error control
   implicit none
   ! input variables
   character(*), intent(in)        :: fname     ! filename
@@ -414,17 +344,15 @@ CONTAINS
   integer(i4b), intent(in)        :: iStart    ! start index
   integer(i4b), intent(in)        :: iCount    ! length of vector to be read in
   ! output variables
-  integer(i4b), intent(out)       :: array(:)  ! output variable data
+  class(*),     intent(out)       :: array(:)  ! output variable data
   integer(i4b), intent(out)       :: ierr      ! error code
   character(*), intent(out)       :: message   ! error message
   ! local variables
   integer(i4b)                    :: ncid      ! NetCDF file ID
   integer(i4b)                    :: iVarID    ! NetCDF variable ID
 
- ! initialize error control
- ierr=0; message='get_ivec/'
+ ierr=0; message='get_vec/'
 
- ! open NetCDF file
  ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
@@ -433,111 +361,34 @@ CONTAINS
  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
  ! get the data
- ierr = nf90_get_var(ncid, iVarID, array, start=(/iStart/), count=(/iCount/))
+ select type (array)
+   type is (integer(i4b))
+    ierr = nf90_get_var(ncid, iVarID, array, start=(/iStart/), count=(/iCount/))
+   type is (integer(i8b))
+    ierr = nf90_get_var(ncid, iVarID, array, start=(/iStart/), count=(/iCount/))
+   type is (real(sp))
+     ierr = nf90_get_var(ncid, iVarID, array, start=(/iStart/), count=(/iCount/))
+   type is (real(dp))
+     ierr = nf90_get_var(ncid, iVarID, array, start=(/iStart/), count=(/iCount/))
+   class default
+     ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+ end select
  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
- ! close output file
  ierr = nf90_close(ncid)
  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
- end subroutine
-
- ! *********************************************************************
- ! subroutine: read a double precision vector
- ! *********************************************************************
- subroutine get_svec(fname,           &  ! input: filename
-                     vname,           &  ! input: variable name
-                     array,           &  ! output: variable data
-                     iStart,          &  ! input: start index
-                     iCount,          &  ! input: length of vector
-                     ierr, message)      ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname     ! filename
-  character(*), intent(in)        :: vname     ! variable name
-  integer(i4b), intent(in)        :: iStart    ! start index
-  integer(i4b), intent(in)        :: iCount    ! length of vector to be read in
-  ! output variables
-  real(sp), intent(out)           :: array(:)  ! output variable data
-  integer(i4b), intent(out)       :: ierr      ! error code
-  character(*), intent(out)       :: message   ! error message
-  ! local variables
-  integer(i4b)                    :: ncid      ! NetCDF file ID
-  integer(i4b)                    :: iVarID    ! NetCDF variable ID
-
-  ierr=0; message='get_svec/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get the data
-  ierr = nf90_get_var(ncid, iVarID, array, start=(/iStart/), count=(/iCount/))
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
- end subroutine
-
- ! *********************************************************************
- ! subroutine: read a double precision vector
- ! *********************************************************************
- subroutine get_dvec(fname,           &  ! input: filename
-                     vname,           &  ! input: variable name
-                     array,           &  ! output: variable data
-                     iStart,          &  ! input: start index
-                     iCount,          &  ! input: length of vector
-                     ierr, message)      ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname     ! filename
-  character(*), intent(in)        :: vname     ! variable name
-  integer(i4b), intent(in)        :: iStart    ! start index
-  integer(i4b), intent(in)        :: iCount    ! length of vector to be read in
-  ! output variables
-  real(dp), intent(out)           :: array(:)  ! output variable data
-  integer(i4b), intent(out)       :: ierr      ! error code
-  character(*), intent(out)       :: message   ! error message
-  ! local variables
-  integer(i4b)                    :: ncid      ! NetCDF file ID
-  integer(i4b)                    :: iVarID    ! NetCDF variable ID
-
-  ! initialize error control
-  ierr=0; message='get_dvec/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get the data
-  ierr = nf90_get_var(ncid, iVarID, array, start=(/iStart/), count=(/iCount/))
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
- end subroutine
+ end subroutine get_vec
 
  ! *********************************************************************
  ! subroutine: read a integer 2D array
  ! *********************************************************************
- subroutine get_2d_iarray(fname,           &  ! input: filename
-                          vname,           &  ! input: variable name
-                          array,           &  ! output: variable data
-                          iStart,          &  ! input: start index
-                          iCount,          &  ! input: length of vector
-                          ierr, message)      ! output: error control
+ subroutine get_2d_array(fname,           &  ! input: filename
+                         vname,           &  ! input: variable name
+                         array,           &  ! output: variable data
+                         iStart,          &  ! input: start index
+                         iCount,          &  ! input: length of vector
+                         ierr, message)      ! output: error control
   implicit none
   ! input variables
   character(*), intent(in)        :: fname        ! filename
@@ -545,7 +396,7 @@ CONTAINS
   integer(i4b), intent(in)        :: iStart(1:2)  ! start indices
   integer(i4b), intent(in)        :: iCount(1:2)  ! length of vector
   ! output variables
-  integer(i4b), intent(out)       :: array(:,:)   ! variable data
+  class(*),     intent(out)       :: array(:,:)   ! variable data
   integer(i4b), intent(out)       :: ierr         ! error code
   character(*), intent(out)       :: message      ! error message
   ! local variables
@@ -553,7 +404,7 @@ CONTAINS
   integer(i4b)                    :: iVarId       ! NetCDF variable ID
 
   ! initialize error control
-  ierr=0; message='get_2d_iarray/'
+  ierr=0; message='get_2d_array/'
 
   ! open NetCDF file
   ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
@@ -564,24 +415,36 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! read data
-  ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+  select type (array)
+    type is (integer(i4b))
+      ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (integer(i8b))
+      ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(sp))
+      ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(dp))
+      ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! close output file
   ierr = nf90_close(ncid)
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
- end subroutine
+ end subroutine get_2d_array
+
 
  ! *********************************************************************
- ! subroutine: read a integer 3D array
+ ! subroutine: read a 3D array
  ! *********************************************************************
- subroutine get_3d_iarray(fname,          &  ! input: filename
-                          vname,          &  ! input: variable name
-                          array,          &  ! output: variable data
-                          iStart,         &  ! input: start index
-                          iCount,         &  ! input: length of vector
-                          ierr, message)     ! output: error control
+ subroutine get_3d_array(fname,          &  ! input: filename
+                         vname,          &  ! input: variable name
+                         array,          &  ! output: variable data
+                         iStart,         &  ! input: start index
+                         iCount,         &  ! input: length of vector
+                         ierr, message)     ! output: error control
   implicit none
   ! input variables
   character(*), intent(in)        :: fname        ! filename
@@ -589,14 +452,14 @@ CONTAINS
   integer(i4b), intent(in)        :: iStart(1:3)  ! start indices
   integer(i4b), intent(in)        :: iCount(1:3)  ! length of vector
   ! output variables
-  integer(i4b), intent(out)       :: array(:,:,:) ! variable data
+  class(*),     intent(out)       :: array(:,:,:) ! variable data
   integer(i4b), intent(out)       :: ierr         ! error code
   character(*), intent(out)       :: message      ! error message
   ! local variables
   integer(i4b)                    :: ncid         ! NetCDF file ID
   integer(i4b)                    :: iVarId       ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='get_3d_iarray/'
+
+  ierr=0; message='get_3d_array/'
 
   ! open NetCDF file
   ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
@@ -607,24 +470,35 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! read data
-  ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+  select type (array)
+    type is (integer(i4b))
+      ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (integer(i8b))
+      ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(sp))
+      ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(dp))
+      ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! close output file
   ierr = nf90_close(ncid)
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
- end subroutine
+ end subroutine get_3d_array
 
  ! *********************************************************************
- ! subroutine: read a integer 4D array
+ ! subroutine: read a 4D array
  ! *********************************************************************
- subroutine get_4d_iarray(fname,          &  ! input: filename
-                          vname,          &  ! input: variable name
-                          array,          &  ! output: variable data
-                          iStart,         &  ! input: start index
-                          iCount,         &  ! input: length of vector
-                          ierr, message)     ! output: error control
+ subroutine get_4d_array(fname,          &  ! input: filename
+                         vname,          &  ! input: variable name
+                         array,          &  ! output: variable data
+                         iStart,         &  ! input: start index
+                         iCount,         &  ! input: length of vector
+                         ierr, message)     ! output: error control
   implicit none
   ! input variables
   character(*), intent(in)        :: fname        ! filename
@@ -632,57 +506,14 @@ CONTAINS
   integer(i4b), intent(in)        :: iStart(1:4)  ! start indices
   integer(i4b), intent(in)        :: iCount(1:4)  ! length of vector
   ! output variables
-  integer(i4b), intent(out)       :: array(:,:,:,:) ! variable data
-  integer(i4b), intent(out)       :: ierr         ! error code
-  character(*), intent(out)       :: message      ! error message
-  ! local variables
-  integer(i4b)                    :: ncid         ! NetCDF file ID
-  integer(i4b)                    :: iVarId       ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='get_4d_iarray/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! read data
-  ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
- end subroutine
-
- ! *********************************************************************
- ! subroutine: read a single precision 2D array
- ! *********************************************************************
- subroutine get_2d_sarray(fname,          &  ! input: filename
-                          vname,          &  ! input: variable name
-                          array,          &  ! output: variable data
-                          iStart,         &  ! input: start index
-                          iCount,         &  ! input: length of vector
-                          ierr, message)     ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname        ! filename
-  character(*), intent(in)        :: vname        ! variable name
-  integer(i4b), intent(in)        :: iStart(1:2)  ! start indices
-  integer(i4b), intent(in)        :: iCount(1:2)  ! length of vector
-  ! output variables
-  real(sp), intent(out)           :: array(:,:)   ! variable data
-  integer(i4b), intent(out)       :: ierr         ! error code
-  character(*), intent(out)       :: message      ! error message
+  class(*),     intent(out)       :: array(:,:,:,:) ! variable data
+  integer(i4b), intent(out)       :: ierr           ! error code
+  character(*), intent(out)       :: message        ! error message
   ! local variables
   integer(i4b)                    :: ncid         ! NetCDF file ID
   integer(i4b)                    :: iVarId       ! NetCDF variable ID
 
-  ierr=0; message='get_2d_sarray/'
+  ierr=0; message='get_4d_array/'
 
   ! open NetCDF file
   ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
@@ -693,144 +524,25 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! read data
-  ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+  select type (array)
+    type is (integer(i4b))
+     ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (integer(i8b))
+     ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(sp))
+     ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(dp))
+     ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! close output file
   ierr = nf90_close(ncid)
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
- end subroutine
-
-
- ! *********************************************************************
- ! subroutine: read a double precision 2D array
- ! *********************************************************************
- subroutine get_2d_darray(fname,          &  ! input: filename
-                          vname,          &  ! input: variable name
-                          array,          &  ! output: variable data
-                          iStart,         &  ! input: start index
-                          iCount,         &  ! input: length of vector
-                          ierr, message)     ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname        ! filename
-  character(*), intent(in)        :: vname        ! variable name
-  integer(i4b), intent(in)        :: iStart(1:2)  ! start indices
-  integer(i4b), intent(in)        :: iCount(1:2)  ! length of vector
-  ! output variables
-  real(dp), intent(out)           :: array(:,:)   ! variable data
-  integer(i4b), intent(out)       :: ierr         ! error code
-  character(*), intent(out)       :: message      ! error message
-  ! local variables
-  integer(i4b)                    :: ncid         ! NetCDF file ID
-  integer(i4b)                    :: iVarId       ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='get_2d_darray/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! read data
-  ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
- end subroutine
-
- ! *********************************************************************
- ! subroutine: read a double precision 3D array
- ! *********************************************************************
- subroutine get_3d_darray(fname,          &  ! input: filename
-                          vname,          &  ! input: variable name
-                          array,          &  ! output: variable data
-                          iStart,         &  ! input: start index
-                          iCount,         &  ! input: length of vector
-                          ierr, message)     ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname         ! filename
-  character(*), intent(in)        :: vname         ! variable name
-  integer(i4b), intent(in)        :: iStart(1:3)   ! start indices
-  integer(i4b), intent(in)        :: iCount(1:3)   ! length of vector
-  ! output variables
-  real(dp), intent(out)           :: array(:,:,:)  ! variable data
-  integer(i4b), intent(out)       :: ierr          ! error code
-  character(*), intent(out)       :: message       ! error message
-  ! local variables
-  integer(i4b)                    :: ncid          ! NetCDF file ID
-  integer(i4b)                    :: iVarId        ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='get_3d_darray/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! read data
-  ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
- end subroutine
-
- ! *********************************************************************
- ! subroutine: read a double precision 4D array
- ! *********************************************************************
- subroutine get_4d_darray(fname,          &  ! input: filename
-                          vname,          &  ! input: variable name
-                          array,          &  ! output: variable data
-                          iStart,         &  ! input: start index
-                          iCount,         &  ! input: length of vector
-                          ierr, message)     ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname         ! filename
-  character(*), intent(in)        :: vname         ! variable name
-  integer(i4b), intent(in)        :: iStart(1:4)   ! start indices
-  integer(i4b), intent(in)        :: iCount(1:4)   ! length of vector
-  ! output variables
-  real(dp), intent(out)           :: array(:,:,:,:)  ! variable data
-  integer(i4b), intent(out)       :: ierr          ! error code
-  character(*), intent(out)       :: message       ! error message
-  ! local variables
-  integer(i4b)                    :: ncid          ! NetCDF file ID
-  integer(i4b)                    :: iVarId        ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='get_4d_darray/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_nowrite,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! read data
-  ierr = nf90_get_var(ncid,iVarId,array,start=iStart,count=iCount)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
- end subroutine
+ end subroutine get_4d_array
 
   ! *********************************************************************
   ! subroutine: write global attribute
@@ -857,9 +569,9 @@ CONTAINS
   end subroutine
 
   ! *********************************************************************
-  ! subroutine: write an integer vector
+  ! subroutine: write an vector (1D array)
   ! *********************************************************************
-  subroutine write_ivec(fname,           &  ! input: filename
+  SUBROUTINE write_vec(fname,           &  ! input: filename
                         vname,           &  ! input: variable name
                         array,           &  ! input: variable data
                         iStart,          &  ! input: start index
@@ -869,7 +581,7 @@ CONTAINS
   ! input variables
   character(*), intent(in)        :: fname        ! filename
   character(*), intent(in)        :: vname        ! variable name
-  integer(i4b), intent(in)        :: array(:)     ! variable data
+  class(*),     intent(in)        :: array(:)     ! variable data
   integer(i4b), intent(in)        :: iStart(:)    ! start index
   integer(i4b), intent(in)        :: iCount(:)    ! length of vector
   ! output variables
@@ -878,8 +590,8 @@ CONTAINS
   ! local variables
   integer(i4b)                    :: ncid         ! NetCDF file ID
   integer(i4b)                    :: iVarId       ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='write_ivec/'
+
+  ierr=0; message='write_vec/'
 
   ! open NetCDF file
   ierr = nf90_open(trim(fname),nf90_write,ncid)
@@ -890,29 +602,42 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! write data
-  ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+  select type (array)
+    type is (integer(i4b))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (integer(i8b))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(sp))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(dp))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (character(len=*))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! close output file
   ierr = nf90_close(ncid)
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
-  end subroutine
+  END SUBROUTINE write_vec
 
   ! *********************************************************************
-  ! subroutine: write a double precision vector
+  ! subroutine: write a 2D array
   ! *********************************************************************
-  subroutine write_dvec(fname,           &  ! input: filename
-                        vname,           &  ! input: variable name
-                        array,           &  ! input: variable data
-                        iStart,          &  ! input: start index
-                        iCount,          &  ! input: length of vector
-                        ierr, message)      ! output: error control
+  SUBROUTINE write_2d_array(fname,           &  ! input: filename
+                            vname,           &  ! input: variable name
+                            array,           &  ! input: variable data
+                            iStart,          &  ! input: start index
+                            iCount,          &  ! input: length of vector
+                            ierr, message)      ! output: error control
   implicit none
   ! input variables
   character(*), intent(in)        :: fname        ! filename
   character(*), intent(in)        :: vname        ! variable name
-  real(dp), intent(in)            :: array(:)     ! variable data
+  class(*),     intent(in)        :: array(:,:)   ! variable data
   integer(i4b), intent(in)        :: iStart(:)    ! start indices
   integer(i4b), intent(in)        :: iCount(:)    ! length of vector
   ! output variables
@@ -921,8 +646,8 @@ CONTAINS
   ! local variables
   integer(i4b)                    :: ncid         ! NetCDF file ID
   integer(i4b)                    :: iVarId       ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='write_dvec/'
+
+  ierr=0; message='write_2d_array/'
 
   ! open NetCDF file
   ierr = nf90_open(trim(fname),nf90_write,ncid)
@@ -933,29 +658,42 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! write data
-  ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+  select type (array)
+    type is (integer(i4b))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (integer(i8b))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(sp))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(dp))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (character(len=*))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! close output file
   ierr = nf90_close(ncid)
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
-  end subroutine
+  END SUBROUTINE write_2d_array
 
   ! *********************************************************************
-  ! subroutine: write a character vector
+  ! subroutine: write a 3D array
   ! *********************************************************************
-  subroutine write_charvec(fname,           &  ! input: filename
-                           vname,           &  ! input: variable name
-                           array,           &  ! input: variable data
-                           iStart,          &  ! input: start index
-                           iCount,          &  ! input: length of vector
-                           ierr, message)      ! output: error control
+  SUBROUTINE write_3d_array(fname,          &  ! input: filename
+                            vname,          &  ! input: variable name
+                            array,          &  ! input: variable data
+                            iStart,         &  ! input: start index
+                            iCount,         &  ! input: length of vector
+                            ierr, message)     ! output: error control
   implicit none
   ! input variables
   character(*), intent(in)        :: fname        ! filename
   character(*), intent(in)        :: vname        ! variable name
-  character(*), intent(in)        :: array(:)     ! variable data
+  class(*),     intent(in)        :: array(:,:,:) ! variable data
   integer(i4b), intent(in)        :: iStart(:)    ! start indices
   integer(i4b), intent(in)        :: iCount(:)    ! length of vector
   ! output variables
@@ -964,8 +702,8 @@ CONTAINS
   ! local variables
   integer(i4b)                    :: ncid         ! NetCDF file ID
   integer(i4b)                    :: iVarId       ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='write_charvec/'
+
+  ierr=0; message='write_3d_array/'
 
   ! open NetCDF file
   ierr = nf90_open(trim(fname),nf90_write,ncid)
@@ -976,186 +714,28 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! write data
-  ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+  select type (array)
+    type is (integer(i4b))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (integer(i8b))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(sp))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (real(dp))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    type is (character(len=*))
+      ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
   ! close output file
   ierr = nf90_close(ncid)
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
 
-  end subroutine
+  END SUBROUTINE write_3d_array
 
-  ! *********************************************************************
-  ! subroutine: write a double precision 2D array
-  ! *********************************************************************
-  subroutine write_2d_iarray(fname,           &  ! input: filename
-                             vname,           &  ! input: variable name
-                             array,           &  ! input: variable data
-                             iStart,          &  ! input: start index
-                             iCount,          &  ! input: length of vector
-                             ierr, message)      ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname        ! filename
-  character(*), intent(in)        :: vname        ! variable name
-  integer(i4b), intent(in)        :: array(:,:)   ! variable data
-  integer(i4b), intent(in)        :: iStart(:)    ! start indices
-  integer(i4b), intent(in)        :: iCount(:)    ! length of vector
-  ! output variables
-  integer(i4b), intent(out)       :: ierr         ! error code
-  character(*), intent(out)       :: message      ! error message
-  ! local variables
-  integer(i4b)                    :: ncid         ! NetCDF file ID
-  integer(i4b)                    :: iVarId       ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='write_2d_iarray/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_write,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! write data
-  ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  end subroutine
-
-  ! *********************************************************************
-  ! subroutine: write a double precision 3D array
-  ! *********************************************************************
-  subroutine write_3d_iarray(fname,          &  ! input: filename
-                             vname,          &  ! input: variable name
-                             array,          &  ! input: variable data
-                             iStart,         &  ! input: start index
-                             iCount,         &  ! input: length of vector
-                             ierr, message)     ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname        ! filename
-  character(*), intent(in)        :: vname        ! variable name
-  integer(i4b), intent(in)        :: array(:,:,:) ! variable data
-  integer(i4b), intent(in)        :: iStart(:)    ! start indices
-  integer(i4b), intent(in)        :: iCount(:)    ! length of vector
-  ! output variables
-  integer(i4b), intent(out)       :: ierr         ! error code
-  character(*), intent(out)       :: message      ! error message
-  ! local variables
-  integer(i4b)                    :: ncid         ! NetCDF file ID
-  integer(i4b)                    :: iVarId       ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='write_3d_iarray/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_write,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! write data
-  ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  end subroutine
-
-  ! *********************************************************************
-  ! subroutine: write a double precision 2D array
-  ! *********************************************************************
-  subroutine write_2d_darray(fname,          &  ! input: filename
-                             vname,          &  ! input: variable name
-                             array,          &  ! input: variable data
-                             iStart,         &  ! input: start index
-                             iCount,         &  ! input: length of vector
-                             ierr, message)     ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname        ! filename
-  character(*), intent(in)        :: vname        ! variable name
-  real(dp), intent(in)            :: array(:,:)   ! variable data
-  integer(i4b), intent(in)        :: iStart(:)    ! start indices
-  integer(i4b), intent(in)        :: iCount(:)    ! length of vector
-  ! output variables
-  integer(i4b), intent(out)       :: ierr         ! error code
-  character(*), intent(out)       :: message      ! error message
-  ! local variables
-  integer(i4b)                    :: ncid         ! NetCDF file ID
-  integer(i4b)                    :: iVarId       ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='write_2d_darray/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_write,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! write data
-  ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  end subroutine
-
-  ! *********************************************************************
-  ! subroutine: write a double precision 3D array
-  ! *********************************************************************
-  subroutine write_3d_darray(fname,          &  ! input: filename
-                             vname,          &  ! input: variable name
-                             array,          &  ! input: variable data
-                             iStart,         &  ! input: start index
-                             iCount,         &  ! input: length of vector
-                             ierr, message)      ! output: error control
-  implicit none
-  ! input variables
-  character(*), intent(in)        :: fname         ! filename
-  character(*), intent(in)        :: vname         ! variable name
-  real(dp), intent(in)            :: array(:,:,:)  ! variable data
-  integer(i4b), intent(in)        :: iStart(:)     ! start indices
-  integer(i4b), intent(in)        :: iCount(:)     ! length of vector
-  ! output variables
-  integer(i4b), intent(out)       :: ierr          ! error code
-  character(*), intent(out)       :: message       ! error message
-  ! local variables
-  integer(i4b)                    :: ncid          ! NetCDF file ID
-  integer(i4b)                    :: iVarId        ! NetCDF variable ID
-  ! initialize error control
-  ierr=0; message='write_3d_darray/'
-
-  ! open NetCDF file
-  ierr = nf90_open(trim(fname),nf90_write,ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! get variable ID
-  ierr = nf90_inq_varid(ncid,trim(vname),iVarId)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! write data
-  ierr = nf90_put_var(ncid,iVarId,array,start=iStart,count=iCount)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  ! close output file
-  ierr = nf90_close(ncid)
-  if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-
-  end subroutine
 
  ! *********************************************************************
  ! Public subroutine: define variable attributes NetCDF file

--- a/route/build/src/pio_utils.f90
+++ b/route/build/src/pio_utils.f90
@@ -51,39 +51,21 @@ MODULE pio_utils
     module procedure read_darray2D
   END INTERFACE
 
-  INTERFACE write_scalar_netcdf
-    module procedure write_int_scalar
-    module procedure write_double_scalar
-    module procedure write_char_scalar
-  END INTERFACE
-
   INTERFACE write_netcdf
-    module procedure write_int_array1D
-    module procedure write_int_array2D
-    module procedure write_double_array1D
-    module procedure write_double_array2D
+    module procedure write_array1D
+    module procedure write_array2D
   END INTERFACE
 
   INTERFACE write_pnetcdf
-    module procedure write_int_darray1D
-    module procedure write_int_darray2D
-    module procedure write_int_darray3D
-    module procedure write_float_darray1D
-    module procedure write_double_darray1D
-    module procedure write_double_darray2D
-    module procedure write_double_darray3D
+    module procedure write_darray1D
+    module procedure write_darray2D
+    module procedure write_darray3D
   END INTERFACE
 
   INTERFACE write_pnetcdf_recdim
-    module procedure write_int_darray2D_recdim
-    module procedure write_int_darray3D_recdim
-    module procedure write_int_darray4D_recdim
-    module procedure write_float_darray2D_recdim
-    module procedure write_float_darray3D_recdim
-    module procedure write_float_darray4D_recdim
-    module procedure write_double_darray2D_recdim
-    module procedure write_double_darray3D_recdim
-    module procedure write_double_darray4D_recdim
+    module procedure write_darray2D_recdim
+    module procedure write_darray3D_recdim
+    module procedure write_darray4D_recdim
   END INTERFACE
 
 CONTAINS
@@ -261,9 +243,8 @@ CONTAINS
   !-----------------------------------------------------------------------
   FUNCTION ioformat_id(ioformat,     &  ! input:  netcdf format name, default="64bit_offset"
                        ierr, message)   ! output: error handling
+
     ! Valid netcdf format: "64bit_offset"
-    !
-    !  - 64bit_offset,
 
     implicit none
     ! ARGUMENTS:
@@ -640,88 +621,44 @@ CONTAINS
 
   END SUBROUTINE put_attr
 
-
   ! ---------------------------------------------------------------
-  ! write global integer scalar
-  SUBROUTINE write_int_scalar(pioFileDesc,     &
-                              vname,           &  ! input: variable name
-                              scalar,          &  ! input: variable data
-                              ierr, message)      ! output: error control
+  ! write global scalar
+  SUBROUTINE write_scalar_netcdf(pioFileDesc,     &
+                                 vname,           &  ! input: variable name
+                                 scalar,          &  ! input: variable data
+                                 ierr, message)      ! output: error control
   implicit none
   ! Argument variables:
   type(file_desc_t),  intent(inout) :: pioFileDesc  ! pio file handle
   character(*),       intent(in)    :: vname        ! variable name
-  integer(i4b),       intent(in)    :: scalar       ! variable data
+  class(*),           intent(in)    :: scalar       ! variable data
   integer(i4b),       intent(out)   :: ierr
   character(*),       intent(out)   :: message      ! error message
   ! local variables
   type(var_desc_t)                  :: pioVarId
 
-  ierr=0; message='write_int_scalar/'
+  ierr=0; message='write_scalar_netcdf/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
+  select type (scalar)
+    type is (integer(i4b))
+      ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
+    type is (real(sp))
+      ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
+    type is (real(dp))
+      ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
+    type is (character(len=*))
+      ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
+  end select
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  END SUBROUTINE write_int_scalar
-
-  ! ---------------------------------------------------------------
-  ! write global real scalar
-  SUBROUTINE write_double_scalar(pioFileDesc,     &
-                               vname,           &  ! input: variable name
-                               scalar,          &  ! input: variable data
-                               ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),  intent(inout) :: pioFileDesc  ! pio file handle
-  character(*),       intent(in)    :: vname        ! variable name
-  real(dp),           intent(in)    :: scalar       ! variable data
-  integer(i4b),       intent(out)   :: ierr
-  character(*),       intent(out)   :: message      ! error message
-  ! local variables
-  type(var_desc_t)                  :: pioVarId
-
-  ierr=0; message='write_double_scalar/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_double_scalar
-
-  ! ---------------------------------------------------------------
-  ! write global character scalar
-  SUBROUTINE write_char_scalar(pioFileDesc,    &
-                              vname,           &  ! input: variable name
-                              scalar,          &  ! input: variable data
-                              ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),  intent(inout) :: pioFileDesc  ! pio file handle
-  character(*),       intent(in)    :: vname        ! variable name
-  character(*),       intent(in)    :: scalar       ! variable data
-  integer(i4b),       intent(out)   :: ierr
-  character(*),       intent(out)   :: message      ! error message
-  ! local variables
-  type(var_desc_t)                  :: pioVarId
-
-  ierr=0; message='write_char_scalar/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  ierr = pio_put_var(pioFileDesc, pioVarId, [scalar])
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_char_scalar
+  END SUBROUTINE write_scalar_netcdf
 
   ! ---------------------------------------------------------------
   ! write global integer vector into 1D variable
-  SUBROUTINE write_int_array1D(pioFileDesc,     &
+  SUBROUTINE write_array1D(pioFileDesc,     &
                                vname,           &  ! input: variable name
                                array,           &  ! input: variable data
                                iStart,          &  ! input: start index
@@ -731,37 +668,7 @@ CONTAINS
   ! Argument variables:
   type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
   character(*),          intent(in)    :: vname        ! variable name
-  integer(i4b),          intent(in)    :: array(:)     ! variable data
-  integer(i4b),          intent(in)    :: iStart(:)    ! start index
-  integer(i4b),          intent(in)    :: iCount(:)    ! length of vector
-  integer(i4b),     intent(out)        :: ierr
-  character(*),     intent(out)        :: message      ! error message
-  ! local variables
-  type(var_desc_t)                     :: pioVarId
-
-  ierr=0; message='write_int_array1D/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_int_array1D
-
-  ! ---------------------------------------------------------------
-  ! write global real vector into 1D variable
-  SUBROUTINE write_double_array1D(pioFileDesc,    &
-                                 vname,           &  ! input: variable name
-                                 array,           &  ! input: variable data
-                                 iStart,          &  ! input: start index
-                                 iCount,          &  ! input: length of vector
-                                 ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)    :: vname        ! variable name
-  real(dp),              intent(in)    :: array(:)     ! variable data
+  class(*),              intent(in)    :: array(:)     ! variable data
   integer(i4b),          intent(in)    :: iStart(:)    ! start index
   integer(i4b),          intent(in)    :: iCount(:)    ! length of vector
   integer(i4b),          intent(out)   :: ierr
@@ -769,59 +676,38 @@ CONTAINS
   ! local variables
   type(var_desc_t)                     :: pioVarId
 
-  ierr=0; message='write_double_array1D/'
+  ierr=0; message='write_array1D/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
+  select type (array)
+    type is (integer(i4b))
+      ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
+    type is (real(sp))
+      ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
+    type is (real(dp))
+      ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  END SUBROUTINE write_double_array1D
+  END SUBROUTINE write_array1D
 
   ! ---------------------------------------------------------------
   ! write global integer 2D into 2D variable
-  SUBROUTINE write_int_array2D(pioFileDesc,     &
-                               vname,           &  ! input: variable name
-                               array,           &  ! input: variable data
-                               iStart,          &  ! input: start index
-                               iCount,          &  ! input: length of vector
-                               ierr, message)      ! output: error control
+  SUBROUTINE write_array2D(pioFileDesc,     &
+                           vname,           &  ! input: variable name
+                           array,           &  ! input: variable data
+                           iStart,          &  ! input: start index
+                           iCount,          &  ! input: length of vector
+                           ierr, message)      ! output: error control
   implicit none
   ! Argument variables:
   type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
   character(*),          intent(in)    :: vname        ! variable name
-  integer(i4b),          intent(in)    :: array(:,:)   ! variable data
-  integer(i4b),          intent(in)    :: iStart(:)    ! start index
-  integer(i4b),          intent(in)    :: iCount(:)    ! length of vector
-  integer(i4b),     intent(out)        :: ierr
-  character(*),     intent(out)        :: message      ! error message
-  ! local variables
-  type(var_desc_t)                     :: pioVarId
-
-  ierr=0; message='write_int_array2D/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_int_array2D
-
-  ! ---------------------------------------------------------------
-  ! write global real 2D into 2D variable
-  SUBROUTINE write_double_array2D(pioFileDesc,     &
-                                  vname,           &  ! input: variable name
-                                  array,           &  ! input: variable data
-                                  iStart,          &  ! input: start index
-                                  iCount,          &  ! input: length of vector
-                                  ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)    :: vname        ! variable name
-  real(dp),              intent(in)    :: array(:,:)   ! variable data
+  class(*),              intent(in)    :: array(:,:)   ! variable data
   integer(i4b),          intent(in)    :: iStart(:)    ! start index
   integer(i4b),          intent(in)    :: iCount(:)    ! length of vector
   integer(i4b),          intent(out)   :: ierr
@@ -829,75 +715,102 @@ CONTAINS
   ! local variables
   type(var_desc_t)                     :: pioVarId
 
-  ierr=0; message='write_double_array2D/'
+  ierr=0; message='write_array2D/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
+  select type (array)
+    type is (integer(i4b))
+      ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
+    type is (real(sp))
+      ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
+    type is (real(dp))
+      ierr = pio_put_var(pioFileDesc, pioVarId, iStart, iCount, array)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  END SUBROUTINE write_double_array2D
+  END SUBROUTINE write_array2D
 
   ! ---------------------------------------------------------------
-  ! write distributed integer vector into 1D variable
-  SUBROUTINE write_int_darray1D(pioFileDesc,     &
-                                vname,           &  ! input: variable name
-                                array,           &  ! input: variable data
-                                iodesc,          &  ! input: ??? it is from initdecomp routine
-                                ierr, message)      ! output: error control
+  ! write distributed vector into 1D variable
+  SUBROUTINE write_darray1D(pioFileDesc,     &
+                            vname,           &  ! input: variable name
+                            array,           &  ! input: variable data
+                            iodesc,          &  ! input: ??? it is from initdecomp routine
+                            ierr, message)      ! output: error control
   implicit none
   ! Argument variables:
   type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
   character(*),          intent(in)    :: vname        ! variable name
-  integer(i4b),          intent(in)    :: array(:)     ! variable data
-  type(io_desc_t),       intent(inout) :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b), intent(out)            :: ierr         ! error code
-  character(*), intent(out)            :: message      ! error message
-  ! local variables
-  type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_int_darray1D/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_int_darray1D
-
-  ! ---------------------------------------------------------------
-  ! write distributed 2D integer array into 2D variable
-  SUBROUTINE write_int_darray2D(pioFileDesc,     &
-                                vname,           &  ! input: variable name
-                                array,           &  ! input: variable data
-                                iodesc,          &  ! input: ??? it is from initdecomp routine
-                                ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)    :: vname        ! variable name
-  integer(i4b),          intent(in)    :: array(:,:)   ! variable data
+  class(*),              intent(in)    :: array(:)     ! variable data
   type(io_desc_t),       intent(inout) :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
   integer(i4b),          intent(out)   :: ierr         ! error code
   character(*),          intent(out)   :: message      ! error message
   ! local variables
   type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
 
-  ierr=0; message='write_int_darray2D/'
+  ierr=0; message='write_darray1D/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+  select type (array)
+    type is (integer(i4b))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(sp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(dp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+   class default
+     ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  END SUBROUTINE write_int_darray2D
+  END SUBROUTINE write_darray1D
 
   ! ---------------------------------------------------------------
-  ! write distributed 3D integer array into 2D variable
-  SUBROUTINE write_int_darray3D(pioFileDesc,     &
+  ! write distributed 2D array into 2D variable
+  SUBROUTINE write_darray2D(pioFileDesc,     &
+                            vname,           &  ! input: variable name
+                            array,           &  ! input: variable data
+                            iodesc,          &  ! input: ??? it is from initdecomp routine
+                            ierr, message)      ! output: error control
+  implicit none
+  ! Argument variables:
+  type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
+  character(*),          intent(in)    :: vname        ! variable name
+  class(*),              intent(in)    :: array(:,:)   ! variable data
+  type(io_desc_t),       intent(inout) :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
+  integer(i4b),          intent(out)   :: ierr         ! error code
+  character(*),          intent(out)   :: message      ! error message
+  ! local variables
+  type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
+
+  ierr=0; message='write_darray2D/'
+
+  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
+  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
+
+  select type (array)
+    type is (integer(i4b))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(sp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(dp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+   class default
+     ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
+  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
+
+  END SUBROUTINE write_darray2D
+
+  ! ---------------------------------------------------------------
+  ! write distributed 3D array into 2D variable
+  SUBROUTINE write_darray3D(pioFileDesc,     &
                                 vname,           &  ! input: variable name
                                 array,           &  ! input: variable data
                                 iodesc,          &  ! input: ??? it is from initdecomp routine
@@ -906,151 +819,48 @@ CONTAINS
   ! Argument variables:
   type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
   character(*),          intent(in)    :: vname        ! variable name
-  integer(i4b),          intent(in)    :: array(:,:,:) ! variable data
+  class(*),              intent(in)    :: array(:,:,:) ! variable data
   type(io_desc_t),       intent(inout) :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
   integer(i4b),          intent(out)   :: ierr         ! error code
   character(*),          intent(out)   :: message      ! error message
   ! local variables
   type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
 
-  ierr=0; message='write_int_darray3D/'
+  ierr=0; message='write_darray3D/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+  select type (array)
+    type is (integer(i4b))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(sp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(dp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+   class default
+     ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  END SUBROUTINE write_int_darray3D
-
-  ! ---------------------------------------------------------------
-  ! write distributed double vector into 1D data
-  SUBROUTINE write_float_darray1D(pioFileDesc,   &
-                                  vname,           &  ! input: variable name
-                                  array,           &  ! input: variable data
-                                  iodesc,          &  ! input: ??? it is from initdecomp routine
-                                  ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)    :: vname        ! variable name
-  real(sp),              intent(in)    :: array(:)     ! variable data
-  type(io_desc_t),       intent(inout) :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b), intent(out)            :: ierr         ! error code
-  character(*), intent(out)            :: message      ! error message
-  ! local variables
-  type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_float_darray1D/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_float_darray1D
-
-  ! ---------------------------------------------------------------
-  ! write distributed double vector into 1D data
-  SUBROUTINE write_double_darray1D(pioFileDesc,   &
-                                 vname,           &  ! input: variable name
-                                 array,           &  ! input: variable data
-                                 iodesc,          &  ! input: ??? it is from initdecomp routine
-                                 ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),     intent(inout) :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)    :: vname        ! variable name
-  real(dp),              intent(in)    :: array(:)     ! variable data
-  type(io_desc_t),       intent(inout) :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b), intent(out)            :: ierr         ! error code
-  character(*), intent(out)            :: message      ! error message
-  ! local variables
-  type(var_desc_t)                     :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_double_darray1D/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_double_darray1D
-
-  ! ---------------------------------------------------------------
-  ! write distributed double 2D integer array into 2D variable
-  SUBROUTINE write_double_darray2D(pioFileDesc,   &
-                                 vname,           &  ! input: variable name
-                                 array,           &  ! input: variable data
-                                 iodesc,          &  ! input: ??? it is from initdecomp routine
-                                 ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)     :: vname        ! variable name
-  real(dp),              intent(in)     :: array(:,:)   ! variable data
-  type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b),          intent(out)    :: ierr         ! error code
-  character(*),          intent(out)    :: message      ! error message
-  ! local variables
-  type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_double_darray2D/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_double_darray2D
-
-  ! ---------------------------------------------------------------
-  ! write distributed double 3D integer array into 2D variable
-  SUBROUTINE write_double_darray3D(pioFileDesc,   &
-                                 vname,           &  ! input: variable name
-                                 array,           &  ! input: variable data
-                                 iodesc,          &  ! input: ??? it is from initdecomp routine
-                                 ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)     :: vname        ! variable name
-  real(dp),              intent(in)     :: array(:,:,:) ! variable data
-  type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b),          intent(out)    :: ierr         ! error code
-  character(*),          intent(out)    :: message      ! error message
-  ! local variables
-  type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_double_darray3D/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_double_darray3D
+  END SUBROUTINE write_darray3D
 
   !
   ! Writing distributed data in nc variable with record dimension
   !
   ! ---------------------------------------------------------------
-  ! write distributed integer vector into 2D variable with record dimension
-  SUBROUTINE write_int_darray2D_recdim(pioFileDesc,     &
-                                       vname,           &  ! input: variable name
-                                       array,           &  ! input: variable data
-                                       iodesc,          &  ! input: ??? it is from initdecomp routine
-                                       nr,              &  ! input: index of record dimension
-                                       ierr, message)      ! output: error control
+  ! write distributed vector into 2D variable with record dimension
+  SUBROUTINE write_darray2D_recdim(pioFileDesc,     &
+                                   vname,           &  ! input: variable name
+                                   array,           &  ! input: variable data
+                                   iodesc,          &  ! input: ??? it is from initdecomp routine
+                                   nr,              &  ! input: index of record dimension
+                                   ierr, message)      ! output: error control
   implicit none
   ! Argument variables:
   type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
   character(*),          intent(in)     :: vname        ! variable name
-  integer(i4b),          intent(in)     :: array(:)     ! variable data
+  class(*),              intent(in)     :: array(:)     ! variable data
   type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
   integer(i4b),          intent(in)     :: nr           ! index of record dimension
   integer(i4b),          intent(out)    :: ierr         ! error code
@@ -1058,87 +868,30 @@ CONTAINS
   ! local variables
   type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
 
-  ierr=0; message='write_int_darray2D_recdim/'
+  ierr=0; message='write_darray2D_recdim/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
   call pio_setframe(pioFileDesc, pioVarId, int(nr,kind=pio_offset_kind))
 
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+  select type (array)
+    type is (integer(i4b))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(sp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(dp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  END SUBROUTINE write_int_darray2D_recdim
-
-  ! ---------------------------------------------------------------
-  ! write distributed float vector into 2D variable with record dimension
-  ! ---------------------------------------------------------------
-  SUBROUTINE write_float_darray2D_recdim(pioFileDesc,     &
-                                         vname,           &  ! input: variable name
-                                         array,           &  ! input: variable data
-                                         iodesc,          &  ! input: it is from initdecomp routine
-                                         nr,              &  ! input: index of record dimension
-                                         ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)     :: vname        ! variable name
-  real(sp),              intent(in)     :: array(:)     ! variable data
-  type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b),          intent(in)     :: nr           ! index of record dimension
-  integer(i4b),          intent(out)    :: ierr         ! error code
-  character(*),          intent(out)    :: message      ! error message
-  ! local variables
-  type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_float_darray2D_recdim/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_setframe(pioFileDesc, pioVarId, int(nr, kind=pio_offset_kind))
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_float_darray2D_recdim
-
-  ! ---------------------------------------------------------------
-  ! write distributed real vector into 2D variable with record dimension
-  ! ---------------------------------------------------------------
-  SUBROUTINE write_double_darray2D_recdim(pioFileDesc,     &
-                                          vname,           &  ! input: variable name
-                                          array,           &  ! input: variable data
-                                          iodesc,          &  ! input: it is from initdecomp routine
-                                          nr,              &  ! input: index of record dimension
-                                          ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables:
-  type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)     :: vname        ! variable name
-  real(dp),              intent(in)     :: array(:)     ! variable data
-  type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b),          intent(in)     :: nr           ! index of record dimension
-  integer(i4b),          intent(out)    :: ierr         ! error code
-  character(*),          intent(out)    :: message      ! error message
-  ! local variables
-  type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_double_darray2D_recdim/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_setframe(pioFileDesc, pioVarId, int(nr, kind=pio_offset_kind))
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_double_darray2D_recdim
+  END SUBROUTINE write_darray2D_recdim
 
   ! ---------------------------------------------------------------
   ! write distributed integer 2D array into 3D variable with record dimension
-  SUBROUTINE write_int_darray3D_recdim(pioFileDesc,     &
+  SUBROUTINE write_darray3D_recdim(pioFileDesc,         &
                                        vname,           &  ! input: variable name
                                        array,           &  ! input: variable data
                                        iodesc,          &  ! input: ??? it is from initdecomp routine
@@ -1148,7 +901,7 @@ CONTAINS
   ! Argument variables
   type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
   character(*),          intent(in)     :: vname        ! variable name
-  integer(i4b),          intent(in)     :: array(:,:)   ! variable data
+  class(*),              intent(in)     :: array(:,:)   ! variable data
   type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
   integer(i4b),          intent(in)     :: nr           ! index of record dimension
   integer(i4b),          intent(out)    :: ierr         ! error code
@@ -1156,87 +909,30 @@ CONTAINS
   ! local variables
   type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
 
-  ierr=0; message='write_int_darray3D_recdim/'
+  ierr=0; message='write_darray3D_recdim/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
   call pio_setframe(pioFileDesc, pioVarId, int(nr,kind=pio_offset_kind))
 
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+  select type (array)
+    type is (integer(i4b))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(sp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(dp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  END SUBROUTINE write_int_darray3D_recdim
-
-  ! ---------------------------------------------------------------
-  ! write distributed float 2D array into 3D variable with record dimension
-  ! ---------------------------------------------------------------
-  SUBROUTINE write_float_darray3D_recdim(pioFileDesc,     &
-                                         vname,           &  ! input: variable name
-                                         array,           &  ! input: variable data
-                                         iodesc,          &  ! input: ??? it is from initdecomp routine
-                                         nr,              &  ! input: index of record dimension
-                                         ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables
-  type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)     :: vname        ! variable name
-  real(sp),              intent(in)     :: array(:,:)   ! variable data
-  type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b),          intent(in)     :: nr           ! index of record dimension
-  integer(i4b),          intent(out)    :: ierr         ! error code
-  character(*),          intent(out)    :: message      ! error message
-  ! local variables
-  type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_float_darray3D_recdim/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_setframe(pioFileDesc, pioVarId, int(nr, kind=pio_offset_kind))
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_float_darray3D_recdim
-
-  ! ---------------------------------------------------------------
-  ! write distributed double 2D array into 3D variable with record dimension
-  ! ---------------------------------------------------------------
-  SUBROUTINE write_double_darray3D_recdim(pioFileDesc,     &
-                                          vname,           &  ! input: variable name
-                                          array,           &  ! input: variable data
-                                          iodesc,          &  ! input: ??? it is from initdecomp routine
-                                          nr,              &  ! input: index of record dimension
-                                          ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables
-  type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)     :: vname        ! variable name
-  real(dp),              intent(in)     :: array(:,:)   ! variable data
-  type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b),          intent(in)     :: nr           ! index of record dimension
-  integer(i4b),          intent(out)    :: ierr         ! error code
-  character(*),          intent(out)    :: message      ! error message
-  ! local variables
-  type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_double_darray3D_recdim/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_setframe(pioFileDesc, pioVarId, int(nr, kind=pio_offset_kind))
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_double_darray3D_recdim
+  END SUBROUTINE write_darray3D_recdim
 
   ! ---------------------------------------------------------------
   ! write distributed integer 3D array into 4D variable with record dimension
-  SUBROUTINE write_int_darray4D_recdim(pioFileDesc,     &
+  SUBROUTINE write_darray4D_recdim(pioFileDesc,     &
                                        vname,           &  ! input: variable name
                                        array,           &  ! input: variable data
                                        iodesc,          &  ! input: ??? it is from initdecomp routine
@@ -1246,7 +942,7 @@ CONTAINS
   ! Argument variables
   type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
   character(*),          intent(in)     :: vname        ! variable name
-  integer(i4b),          intent(in)     :: array(:,:,:) ! variable data
+  class(*),              intent(in)     :: array(:,:,:) ! variable data
   type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
   integer(i4b),          intent(in)     :: nr           ! index of record dimension
   integer(i4b),          intent(out)    :: ierr         ! error code
@@ -1254,82 +950,25 @@ CONTAINS
   ! local variables
   type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
 
-  ierr=0; message='write_int_darray4D_recdim/'
+  ierr=0; message='write_darray4D_recdim/'
 
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
   call pio_setframe(pioFileDesc, pioVarId, int(nr,kind=pio_offset_kind))
 
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+  select type (array)
+    type is (integer(i4b))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(sp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    type is (real(dp))
+      call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
+    class default
+      ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
+  end select
   if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
 
-  END SUBROUTINE write_int_darray4D_recdim
-
-  ! ---------------------------------------------------------------
-  ! write distributed float 3D array into 4D variable with record dimension
-  ! ---------------------------------------------------------------
-  SUBROUTINE write_float_darray4D_recdim(pioFileDesc,     &
-                                         vname,           &  ! input: variable name
-                                         array,           &  ! input: variable data
-                                         iodesc,          &  ! input: ??? it is from initdecomp routine
-                                         nr,              &  ! input: index of record dimension
-                                         ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables
-  type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)     :: vname        ! variable name
-  real(sp),              intent(in)     :: array(:,:,:) ! variable data
-  type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b),          intent(in)     :: nr           ! index of record dimension
-  integer(i4b),          intent(out)    :: ierr         ! error code
-  character(*),          intent(out)    :: message      ! error message
-  ! local variables
-  type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_float_darray4D_recdim/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_setframe(pioFileDesc, pioVarId, int(nr, kind=pio_offset_kind))
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_float_darray4D_recdim
-
-  ! ---------------------------------------------------------------
-  ! write distributed double 3D array into 4D variable with record dimension
-  ! ---------------------------------------------------------------
-  SUBROUTINE write_double_darray4D_recdim(pioFileDesc,     &
-                                          vname,           &  ! input: variable name
-                                          array,           &  ! input: variable data
-                                          iodesc,          &  ! input: ??? it is from initdecomp routine
-                                          nr,              &  ! input: index of record dimension
-                                          ierr, message)      ! output: error control
-  implicit none
-  ! Argument variables
-  type(file_desc_t),     intent(inout)  :: pioFileDesc  ! pio file handle
-  character(*),          intent(in)     :: vname        ! variable name
-  real(dp),              intent(in)     :: array(:,:,:) ! variable data
-  type(io_desc_t),       intent(inout)  :: iodesc       ! io descriptor handle that is generated in PIO_initdecomp
-  integer(i4b),          intent(in)     :: nr           ! index of record dimension
-  integer(i4b),          intent(out)    :: ierr         ! error code
-  character(*),          intent(out)    :: message      ! error message
-  ! local variables
-  type(var_desc_t)                      :: pioVarId     ! netCDF variable ID
-
-  ierr=0; message='write_double_darray4D_recdim/'
-
-  ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
-  if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
-
-  call pio_setframe(pioFileDesc, pioVarId, int(nr, kind=pio_offset_kind))
-
-  call pio_write_darray(pioFileDesc, pioVarId, iodesc, array, ierr)
-  if(ierr/=pio_noerr)then; message=trim(message)//'cannot write data'; return; endif
-
-  END SUBROUTINE write_double_darray4D_recdim
+  END SUBROUTINE write_darray4D_recdim
 
 END MODULE pio_utils


### PR DESCRIPTION
use `select type construct` as follow:

```
select type (attr_value)
   type is (integer(i4b))
      <integer type specific procedure>
   type is (integer(i8b))
      <long integer type specific procedure>
   type is (real(sp))
      <single precision float type specific procedure>
   type is (real(dp))
     <double precision float type specific procedure>
   type is (character(len=*))
      <character type specific procedure>
   class default
     ierr = 1; message=trim(message)//'ERROR: invalid array type'; return
 end select
```

This reduces several hundreds of lines