### PR TITLE
Fix cesm restarting: 

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -27,7 +27,7 @@ MODULE RtmMod
   USE globalData,   ONLY: npes       => nNodes
   USE globalData,   ONLY: mpicom_rof => mpicom_route
   USE globalData,   ONLY: masterproc
-  USE globalData,   ONLY: isRestart                  ! restart flag
+  USE globalData,   ONLY: isColdStart                ! restart flag
   USE mpi_utils, ONLY: shr_mpi_barrier
 
   implicit none
@@ -247,16 +247,13 @@ CONTAINS
     ! 5. For continue and/or Branch run-- Initialize restart and history files
     !-------------------------------------------------------
     ! Obtain last restart name, and obtain and open last history file depending on which run types-- contiuous or branch
-    if ((nsrest == nsrContinue) .or. &
-        (nsrest == nsrBranch)) then
+    if ((nsrest == nsrContinue) then
       call RtmRestGetfile()
-      isRestart=.true.
-      if (nsrest == nsrContinue) then
-        call init_histFile(ierr, cmessage)
-        if(ierr/=0)then; call shr_sys_abort(trim(subname)//trim(cmessage)); endif
-      end if
+      isColdStart=.false.
+      call init_histFile(ierr, cmessage)
+      if(ierr/=0)then; call shr_sys_abort(trim(subname)//trim(cmessage)); endif
     else
-      isRestart=.false.
+      isColdStart=.true.
     endif
 
     !-------------------------------------------------------
@@ -267,7 +264,7 @@ CONTAINS
     if(ierr/=0)then; call shr_sys_abort(trim(subname)//trim(cmessage)); endif
 
     ! put reach flux variables to associated HRUs
-    if (isRestart) then
+    if (.not. isColdStart) then
       if (masterproc) then
         if (nRch_mainstem > 0) then
           lwr=1

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -255,6 +255,8 @@ CONTAINS
         call init_histFile(ierr, cmessage)
         if(ierr/=0)then; call shr_sys_abort(trim(subname)//trim(cmessage)); endif
       end if
+    else
+      isRestart=.false.
     endif
 
     !-------------------------------------------------------

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -27,8 +27,8 @@ MODULE RtmMod
   USE globalData,   ONLY: npes       => nNodes
   USE globalData,   ONLY: mpicom_rof => mpicom_route
   USE globalData,   ONLY: masterproc
-  USE globalData,   ONLY: isColdStart                ! restart flag
-  USE mpi_utils, ONLY: shr_mpi_barrier
+  USE globalData,   ONLY: isColdStart                ! initial river state - cold start (T) or from restart file (F)
+  USE mpi_utils,    ONLY: shr_mpi_barrier
 
   implicit none
   logical, parameter :: verbose=.false.
@@ -247,7 +247,7 @@ CONTAINS
     ! 5. For continue and/or Branch run-- Initialize restart and history files
     !-------------------------------------------------------
     ! Obtain last restart name, and obtain and open last history file depending on which run types-- contiuous or branch
-    if ((nsrest == nsrContinue) then
+    if (nsrest == nsrContinue) then
       call RtmRestGetfile()
       isColdStart=.false.
       call init_histFile(ierr, cmessage)

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -53,7 +53,6 @@ CONTAINS
     ! 6. initialize state variables
 
     ! mizuRoute share routines
-    USE globalData,          ONLY: runMode                     ! "ctsm-coupling" or "standalone" to differentiate some behaviours in mizuRoute
     USE globalData,          ONLY: ixHRU_order                 ! global HRU index in the order of proc assignment (size = num of hrus contributing reach in entire network)
     USE globalData,          ONLY: hru_per_proc                ! number of hrus assigned to each proc (size = num of procs
     USE globalData,          ONLY: nRch_mainstem               ! scalar data: number of mainstem reaches
@@ -154,8 +153,6 @@ CONTAINS
     !-------------------------------------------------------
     ! 2. update mizuRoute PIO parameter from CIME
     !-------------------------------------------------------
-    runMode='cesm-coupling'
-
     select case(shr_pio_getioformat(inst_name))
       case(PIO_64BIT_OFFSET); pio_netcdf_format = '64bit_offset'
       case(PIO_64BIT_DATA);   pio_netcdf_format = '64bit_data'

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -252,8 +252,6 @@ CONTAINS
       isColdStart=.false.
       call init_histFile(ierr, cmessage)
       if(ierr/=0)then; call shr_sys_abort(trim(subname)//trim(cmessage)); endif
-    else
-      isColdStart=.true.
     endif
 
     !-------------------------------------------------------

--- a/route/build/cpl/nuopc/rof_comp_nuopc.F90
+++ b/route/build/cpl/nuopc/rof_comp_nuopc.F90
@@ -25,6 +25,7 @@ module rof_comp_nuopc
   use globalData            , only : npes       => nNodes
   use globalData            , only : mpicom_rof => mpicom_route
   use globalData            , only : nHRU
+  use globalData,           , only : runMode                     ! "ctsm-coupling" or "standalone" to differentiate some behaviours in mizuRoute
   use init_model_data       , only : get_mpi_omp, init_model
   use RunoffMod             , only : rtmCTL
   use RtmMod                , only : route_ini, route_run
@@ -411,7 +412,13 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) username
 
-    ! Temporal fix
+    ! set mizuRoute run mode
+    runMode='cesm-coupling'
+
+    ! mizuRoute model configuration setup
+    ! 1. read control file
+    ! 2. read spatially constant parameter (namelist)
+    ! 3. (optional) gauge information
     call init_model(cfile_name, ierr, cmessage)
     if(ierr/=0) then; cmessage = trim(subname)//trim(cmessage); return; endif
 

--- a/route/build/cpl/nuopc/rof_comp_nuopc.F90
+++ b/route/build/cpl/nuopc/rof_comp_nuopc.F90
@@ -25,7 +25,7 @@ module rof_comp_nuopc
   use globalData            , only : npes       => nNodes
   use globalData            , only : mpicom_rof => mpicom_route
   use globalData            , only : nHRU
-  use globalData,           , only : runMode                     ! "ctsm-coupling" or "standalone" to differentiate some behaviours in mizuRoute
+  use globalData            , only : runMode                     ! "ctsm-coupling" or "standalone" to differentiate some behaviours in mizuRoute
   use init_model_data       , only : get_mpi_omp, init_model
   use RunoffMod             , only : rtmCTL
   use RtmMod                , only : route_ini, route_run

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -118,6 +118,7 @@ MODULE globalData
   character(300),                  public :: hfileout_gage=charMissing   ! gage-only history output file name
   character(300),                  public :: rfileout=charMissing        ! restart output file name
   logical(lgt),                    public :: initHvars=.false.           ! status of history variable data initialization
+  logical(lgt),                    public :: isRestart=.false.           ! restart run or not?
 
   ! ---------- MPI/OMP/PIO variables ----------------------------------------------------------------
 

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -118,7 +118,7 @@ MODULE globalData
   character(300),                  public :: hfileout_gage=charMissing   ! gage-only history output file name
   character(300),                  public :: rfileout=charMissing        ! restart output file name
   logical(lgt),                    public :: initHvars=.false.           ! status of history variable data initialization
-  logical(lgt),                    public :: isRestart=.false.           ! restart run or not?
+  logical(lgt),                    public :: isColdStart=.true.          ! restart run or not?
 
   ! ---------- MPI/OMP/PIO variables ----------------------------------------------------------------
 

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -118,7 +118,7 @@ MODULE globalData
   character(300),                  public :: hfileout_gage=charMissing   ! gage-only history output file name
   character(300),                  public :: rfileout=charMissing        ! restart output file name
   logical(lgt),                    public :: initHvars=.false.           ! status of history variable data initialization
-  logical(lgt),                    public :: isColdStart=.true.          ! restart run or not?
+  logical(lgt),                    public :: isColdStart=.true.          ! initial river state - cold start (T) or from restart file (F)
 
   ! ---------- MPI/OMP/PIO variables ----------------------------------------------------------------
 

--- a/route/build/src/histVars_data.f90
+++ b/route/build/src/histVars_data.f90
@@ -454,13 +454,13 @@ MODULE histVars_data
           if (routeMethods(ixRoute)==accumRunoff) cycle  ! accumuRunoff has only discharge
 
           if (meta_rflx(ixVol)%varFile) then
-            call read_dist_array(pioFileDesc, meta_rflx(ixVol)%varName, this%volume(1:nRch,ixRoute), ioDescRchHist, ierr, cmessage)
+            call read_dist_array(pioFileDesc, meta_rflx(ixVol)%varName, array_tmp, ioDescRchHist, ierr, cmessage)
             if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
           end if
           ! need to shift tributary part in main core to after halo reaches (nTribOutlet)
           if (masterproc) then
             this%volume(1:nRch_mainstem, ixRoute) = array_tmp(1:nRch_mainstem)
-            this%volume(nRch_mainstem+nTribOutlet+1:this%nRch,:) = this%volume(nRch_mainstem+1:nRch_mainstem+nRch_trib,:)
+            this%volume(nRch_mainstem+nTribOutlet+1:this%nRch,ixRoute) = this%volume(nRch_mainstem+1:nRch_mainstem+nRch_trib,ixRoute)
           else
             this%volume(:,ixRoute) = array_tmp
           end if

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -325,7 +325,7 @@ CONTAINS
   USE globalData, ONLY: nMolecule              ! computational molecule
   USE globalData, ONLY: TSEC                   ! begining/ending of simulation time step [sec]
   USE globalData, ONLY: initHvars              ! status of history variabiable data initialization
-  USE globalData, ONLY: isRestart              ! restart flag
+  USE globalData, ONLY: isColdStart            ! restart flag
   USE write_simoutput_pio, ONLY: hVars         ! history variable data
 
   implicit none
@@ -356,7 +356,7 @@ CONTAINS
     end if
   end do
 
-  if (.not. isRestart) then    ! Cold start ....... initialize flux structures
+  if (isColdStart) then    ! Cold start ....... initialize flux structures
     if (masterproc) then
       RCHFLX_trib(:,:)%BASIN_QI     = 0._dp
       RCHFLX_trib(:,:)%BASIN_QR(0)  = 0._dp

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -325,7 +325,7 @@ CONTAINS
   USE globalData, ONLY: nMolecule              ! computational molecule
   USE globalData, ONLY: TSEC                   ! begining/ending of simulation time step [sec]
   USE globalData, ONLY: initHvars              ! status of history variabiable data initialization
-  USE globalData, ONLY: isColdStart            ! restart flag
+  USE globalData, ONLY: isColdStart            ! initial river state - cold start (T) or from restart file (F)
   USE write_simoutput_pio, ONLY: hVars         ! history variable data
 
   implicit none
@@ -356,7 +356,7 @@ CONTAINS
     end if
   end do
 
-  if (isColdStart) then    ! Cold start ....... initialize flux structures
+  if (isColdStart) then
     if (masterproc) then
       RCHFLX_trib(:,:)%BASIN_QI     = 0._dp
       RCHFLX_trib(:,:)%BASIN_QR(0)  = 0._dp

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -325,6 +325,7 @@ CONTAINS
   USE globalData, ONLY: nMolecule              ! computational molecule
   USE globalData, ONLY: TSEC                   ! begining/ending of simulation time step [sec]
   USE globalData, ONLY: initHvars              ! status of history variabiable data initialization
+  USE globalData, ONLY: isRestart              ! restart flag
   USE write_simoutput_pio, ONLY: hVars         ! history variable data
 
   implicit none
@@ -355,8 +356,7 @@ CONTAINS
     end if
   end do
 
-  if (trim(fname_state_in)==charMissing .or. lower(trim(fname_state_in))=='none' .or. lower(trim(fname_state_in))=='coldstart') then
-    ! Cold start ....... initialize flux structures
+  if (.not. isRestart) then    ! Cold start ....... initialize flux structures
     if (masterproc) then
       RCHFLX_trib(:,:)%BASIN_QI     = 0._dp
       RCHFLX_trib(:,:)%BASIN_QR(0)  = 0._dp

--- a/route/build/src/lake_route.f90
+++ b/route/build/src/lake_route.f90
@@ -12,7 +12,7 @@ USE public_var, ONLY: integerMissing ! missing value for integer number
 USE public_var, ONLY: pi             ! pi value of 3.14159265359_dp
 USE public_var, ONLY: charMissing    ! missing character
 USE globalData, ONLY: idxIRF         ! index of IRF method
-USE globalData, ONLY: isRestart      ! restart flag
+USE globalData, ONLY: isColdStart    ! restart flag
 USE water_balance, ONLY: comp_reach_wb     ! compute water balance error
 ! subroutines: model time info
 USE time_utils_module, ONLY: compJulday,&      ! compute julian day
@@ -132,7 +132,7 @@ CONTAINS
       if ((is_vol_wm_jumpstart).and.(NETOPO_in(segIndex)%LakeTargVol)) then
         RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(0) = RCHFLX_out(iens,segIndex)%REACH_WM_VOL ! update the initial condition with first target volume value
       else ! the lake volume is not jump started based on lake target volume
-        if (.not. isRestart) then    ! Cold start ....... initialize flux structures
+        if (isColdStart) then    ! Cold start ....... initialize flux structures
           select case(NETOPO_in(segIndex)%LakeModelType)
             case(endorheic)
               RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(0) = RPARAM_in(segIndex)%D03_S0 ! currently assumes all endorheic max storage are provided under doll formulation

--- a/route/build/src/lake_route.f90
+++ b/route/build/src/lake_route.f90
@@ -10,9 +10,9 @@ USE public_var, ONLY: iulog          ! i/o logical unit number
 USE public_var, ONLY: realMissing    ! missing value for real number
 USE public_var, ONLY: integerMissing ! missing value for integer number
 USE public_var, ONLY: pi             ! pi value of 3.14159265359_dp
-USE public_var, ONLY: fname_state_in ! name of state input file
 USE public_var, ONLY: charMissing    ! missing character
 USE globalData, ONLY: idxIRF         ! index of IRF method
+USE globalData, ONLY: isRestart      ! restart flag
 USE water_balance, ONLY: comp_reach_wb     ! compute water balance error
 ! subroutines: model time info
 USE time_utils_module, ONLY: compJulday,&      ! compute julian day
@@ -132,7 +132,7 @@ CONTAINS
       if ((is_vol_wm_jumpstart).and.(NETOPO_in(segIndex)%LakeTargVol)) then
         RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(0) = RCHFLX_out(iens,segIndex)%REACH_WM_VOL ! update the initial condition with first target volume value
       else ! the lake volume is not jump started based on lake target volume
-        if (trim(fname_state_in)==charMissing .or. lower(trim(fname_state_in))=='none' .or. lower(trim(fname_state_in))=='coldstart') then
+        if (.not. isRestart) then    ! Cold start ....... initialize flux structures
           select case(NETOPO_in(segIndex)%LakeModelType)
             case(endorheic)
               RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(0) = RPARAM_in(segIndex)%D03_S0 ! currently assumes all endorheic max storage are provided under doll formulation

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -580,41 +580,41 @@ CONTAINS
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! basin runoff array
-      allocate(basinRunoff_main(nHRU_mainstem), stat=ierr, errmsg=cmessage)
+      allocate(basinRunoff_main(nHRU_mainstem), source=0.0_dp, stat=ierr, errmsg=cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-      allocate(basinRunoff_trib(nHRU_trib), stat=ierr, errmsg=cmessage)
+      allocate(basinRunoff_trib(nHRU_trib), source=0.0_dp, stat=ierr, errmsg=cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! precipitation and evaporation
       if (is_lake_sim) then
-        allocate(basinEvapo_main(nHRU_mainstem), stat=ierr, errmsg=cmessage)
+        allocate(basinEvapo_main(nHRU_mainstem), source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-        allocate(basinPrecip_main(nHRU_mainstem), stat=ierr, errmsg=cmessage)
+        allocate(basinPrecip_main(nHRU_mainstem), source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-        allocate(basinEvapo_trib(nHRU_trib), stat=ierr, errmsg=cmessage)
+        allocate(basinEvapo_trib(nHRU_trib), source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-        allocate(basinPrecip_trib(nHRU_trib), stat=ierr, errmsg=cmessage)
+        allocate(basinPrecip_trib(nHRU_trib), source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       end if
 
       ! reach abstraction array
       if (is_flux_wm) then
-        allocate(flux_wm_main(nRch_mainstem), stat=ierr, errmsg=cmessage)
+        allocate(flux_wm_main(nRch_mainstem), source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-        allocate(flux_wm_trib(nRch_trib), stat=ierr, errmsg=cmessage)
+        allocate(flux_wm_trib(nRch_trib), source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       end if
 
       if (is_vol_wm.and.is_lake_sim) then
-        allocate(vol_wm_main(nRch_mainstem), stat=ierr, errmsg=cmessage)
+        allocate(vol_wm_main(nRch_mainstem), source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-        allocate(vol_wm_trib(nRch_trib), stat=ierr, errmsg=cmessage)
+        allocate(vol_wm_trib(nRch_trib), source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       end if
     else
@@ -630,27 +630,27 @@ CONTAINS
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! basin runoff array
-      allocate(basinRunoff_trib(nHRU_trib), stat=ierr, errmsg=cmessage)
+      allocate(basinRunoff_trib(nHRU_trib),source=0.0_dp, stat=ierr, errmsg=cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! precipitation and evaporation
       if (is_lake_sim) then
-        allocate(basinEvapo_trib(nHRU_trib), stat=ierr, errmsg=cmessage)
+        allocate(basinEvapo_trib(nHRU_trib), source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-        allocate(basinPrecip_trib(nHRU_trib), stat=ierr, errmsg=cmessage)
+        allocate(basinPrecip_trib(nHRU_trib),source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       end if
 
       ! reach abstraction array
       if (is_flux_wm) then
-        allocate(flux_wm_trib(nRch_trib), stat=ierr, errmsg=cmessage)
+        allocate(flux_wm_trib(nRch_trib),source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       end if
 
       ! target volume data
       if (is_vol_wm.and.is_lake_sim) then
-        allocate(vol_wm_trib(nRch_trib), stat=ierr, errmsg=cmessage)
+        allocate(vol_wm_trib(nRch_trib),source=0.0_dp, stat=ierr, errmsg=cmessage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       end if
     end if
@@ -665,7 +665,6 @@ CONTAINS
 
   if (nRch_mainstem > 0) then
     if (masterproc) then
-      ! allocation, RCHFLX, RCHSTA, basinRunoff, basinEvapo, basinPrecip, flux_wm
 
       call alloc_struct(nHRU_mainstem,              & ! input: number of HRUs
                         nRch_mainstem+nTribOutlet,  & ! input: number of stream segments

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -28,6 +28,7 @@ CONTAINS
  USE globalData, ONLY: meta_PFAF               ! pfafstetter code
  USE globalData, ONLY: meta_rflx               ! river flux variables
  USE globalData, ONLY: meta_hflx               ! river flux variables
+ USE globalData, ONLY: isRestart               ! number of active routing methods
  USE globalData, ONLY: nRoutes                 ! number of active routing methods
  USE globalData, ONLY: routeMethods            ! active routing method index and id
  USE globalData, ONLY: onRoute                 ! logical to indicate actiive routing method(s)
@@ -44,6 +45,7 @@ CONTAINS
  ! external subroutines
  USE ascii_utils, ONLY: file_open        ! open file (performs a few checks as well)
  USE ascii_utils, ONLY: get_vlines       ! get a list of character strings from non-comment lines
+ USE ascii_utils, ONLY: lower            ! convert string to lower case
  USE nr_utils,    ONLY: char2int         ! convert integer number to a array containing individual digits
 
  implicit none
@@ -341,6 +343,13 @@ CONTAINS
  if (trim(restart_dir)==charMissing) then
    restart_dir = output_dir
  endif
+
+ ! ---------- restart option  ---------------------------------------------------------------------
+ if (trim(fname_state_in)==charMissing .or. lower(trim(fname_state_in))=='none' .or. lower(trim(fname_state_in))=='coldstart') then
+   isRestart=.false.
+ else
+   isRestart=.true.
+ end if
 
  ! ---------- control river network writing option  ---------------------------------------------------------------------
  ! option 1- river network subset mode (idSegOut>0):  Write the network variables read from file over only upstream network specified idSegOut

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -34,6 +34,7 @@ CONTAINS
  USE globalData, ONLY: onRoute                 ! logical to indicate actiive routing method(s)
  USE globalData, ONLY: idxSUM,idxIRF,idxKWT, &
                        idxKW,idxMC,idxDW
+ USE globalData, ONLY: runMode                 ! mizuRoute run mode: standalone, cesm-coupling
  ! index of named variables in each structure
  USE var_lookup, ONLY: ixHRU
  USE var_lookup, ONLY: ixHRU2SEG
@@ -345,10 +346,12 @@ CONTAINS
  endif
 
  ! ---------- restart option  ---------------------------------------------------------------------
- if (trim(fname_state_in)==charMissing .or. lower(trim(fname_state_in))=='none' .or. lower(trim(fname_state_in))=='coldstart') then
-   isRestart=.false.
- else
-   isRestart=.true.
+ if (trim(runMode)=='standalone') then
+   if (trim(fname_state_in)==charMissing .or. lower(trim(fname_state_in))=='none' .or. lower(trim(fname_state_in))=='coldstart') then
+     isRestart=.false.
+   else
+     isRestart=.true.
+   end if
  end if
 
  ! ---------- control river network writing option  ---------------------------------------------------------------------

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -28,7 +28,7 @@ CONTAINS
  USE globalData, ONLY: meta_PFAF               ! pfafstetter code
  USE globalData, ONLY: meta_rflx               ! river flux variables
  USE globalData, ONLY: meta_hflx               ! river flux variables
- USE globalData, ONLY: isRestart               ! number of active routing methods
+ USE globalData, ONLY: isColdStart             ! number of active routing methods
  USE globalData, ONLY: nRoutes                 ! number of active routing methods
  USE globalData, ONLY: routeMethods            ! active routing method index and id
  USE globalData, ONLY: onRoute                 ! logical to indicate actiive routing method(s)
@@ -348,9 +348,9 @@ CONTAINS
  ! ---------- restart option  ---------------------------------------------------------------------
  if (trim(runMode)=='standalone') then
    if (trim(fname_state_in)==charMissing .or. lower(trim(fname_state_in))=='none' .or. lower(trim(fname_state_in))=='coldstart') then
-     isRestart=.false.
+     isColdStart=.true.
    else
-     isRestart=.true.
+     isColdStart=.false.
    end if
  end if
 

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -28,7 +28,7 @@ CONTAINS
  USE globalData, ONLY: meta_PFAF               ! pfafstetter code
  USE globalData, ONLY: meta_rflx               ! river flux variables
  USE globalData, ONLY: meta_hflx               ! river flux variables
- USE globalData, ONLY: isColdStart             ! number of active routing methods
+ USE globalData, ONLY: isColdStart             ! initial river state - cold start (T) or from restart file (F)
  USE globalData, ONLY: nRoutes                 ! number of active routing methods
  USE globalData, ONLY: routeMethods            ! active routing method index and id
  USE globalData, ONLY: onRoute                 ! logical to indicate actiive routing method(s)

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -346,7 +346,7 @@ CONTAINS
  endif
 
  ! ---------- restart option  ---------------------------------------------------------------------
- if (trim(runMode)=='standalone') then
+ if (trim(runMode)=='standalone' .or. .not. continue_run) then
    if (trim(fname_state_in)==charMissing .or. lower(trim(fname_state_in))=='none' .or. lower(trim(fname_state_in))=='coldstart') then
      isColdStart=.true.
    else


### PR DESCRIPTION
For CESM coupling mode, restart information is not quite set (for `rtmCTL`). This affect all negative runoff handling (irrigation and qgwl). 

Initialize some `rtmCTL` variables (river volume-`rtmCTL%volr` and also river discharge-`rtmCTL%discharge`) from restart file.

Use isRestart global variable (newly created) instead of using `fname_restart_in` to detect restart run.

Fixed one history output variable (volume) initialization from restart file.

Additional fix:  Right now, precipitation and evaporation are not passed from coupler and mizuRoute assume they are zero. So need to initialize precipitation and evaporation array with zero (gnu compiler put large values). 

Fixes #377 