### PR TITLE
Including t_bound variable in a history file and resulting changes

### DIFF
--- a/route/build/cpl/RtmTimeManager.F90
+++ b/route/build/cpl/RtmTimeManager.F90
@@ -110,8 +110,9 @@ CONTAINS
   ! number of time step from reference time to simulation end time
   nTime = int(endJulday - begJulday/dt_day) + 1
 
-  ! Initialize timeVar : starting with 0 and increment of model time step in model time unit (t_unit)
-  timeVar = (begJulday - refJulday)*timePerDay
+  ! Initialize timeVar : model time (time step endpoints) in model time unit (t_unit), used for time output
+  timeVar(1) = (begJulday - refJulday)*timePerDay
+  timeVar(2) = timeVar(1) + dt/secPerTime
 
   ! check that the dates are aligned
   if(endDatetime < begDatetime) then; ierr=20; message=trim(message)//'simulation end is before simulation start'; return; endif
@@ -129,7 +130,8 @@ CONTAINS
     write(iulog,*) 'simDatetime           = ', simDatetime(1)%year(), simDatetime(1)%month(), simDatetime(1)%day(), simDatetime(1)%hour(), simDatetime(1)%minute(), simDatetime(1)%sec()
     write(iulog,*) 'dt [sec]              = ', dt
     write(iulog,*) 'nTime                 = ', nTime
-    write(iulog,*) 'iTime, timeVar(iTime) = ', iTime, timeVar
+    write(iulog,*) 'iTime                 = ', iTime
+    write(iulog,*) 'timeVar(1),timeVar(2) = ', timeVar(1), timeVar(2)
     call shr_sys_flush(iulog)
   end if
 

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -93,8 +93,8 @@ MODULE globalData
   ! ---------- Date/Time data  -------------------------------------------------------------------------
 
   integer(i4b),                    public :: iTime                ! time index at simulation time step
-  real(dp),                        public :: timeVar              ! time variables (unit given by time variable)
-  real(dp),                        public :: TSEC(0:1)            ! begning and end of time step since simulation started (sec)
+  real(dp),                        public :: timeVar(1:2)         ! time variables at endpoints of a simulation time step (time unit used for time variable in history file)
+  real(dp),                        public :: TSEC(1:2)            ! seconds at endpoints of a simulation time step since simulation started
   type(datetime),                  public :: simDatetime(0:2)     ! previous, current and next simulation time (yyyy:mm:dd:hh:mm:ss)
   type(datetime),                  public :: begDatetime          ! simulation start date/time (yyyy:mm:dd:hh:mm:ss)
   type(datetime),                  public :: endDatetime          ! simulation end date/time (yyyy:mm:dd:hh:mm:ss)

--- a/route/build/src/historyFile.f90
+++ b/route/build/src/historyFile.f90
@@ -41,8 +41,8 @@ MODULE historyFile
 
     CONTAINS
 
-      generic,    public :: createNC => createNC_rch, createNC_rch_hru
       generic,    public :: set_compdof => set_compdof_rch, set_compdof_rch_hru
+      procedure,  public :: createNC
       procedure,  public :: openNC
       procedure,  public :: fileOpen
       generic,    public :: write_loc => write_loc_rch, write_loc_rch_hru
@@ -53,8 +53,6 @@ MODULE historyFile
       procedure, private :: cleanup_hru
       procedure, private :: write_flux_hru
       procedure, private :: write_flux_rch
-      procedure, private :: createNC_rch
-      procedure, private :: createNC_rch_hru
       procedure, private :: set_compdof_rch
       procedure, private :: set_compdof_rch_hru
       procedure, private :: write_loc_rch
@@ -143,9 +141,9 @@ MODULE historyFile
     END SUBROUTINE
 
     ! ---------------------------------------------------------------
-    ! Create netCDF and define dimension and variables - only reach
+    ! Create history netCDF and define dimension and variables
     ! ---------------------------------------------------------------
-    SUBROUTINE createNC_rch(this, nRch_in, ierr, message)
+    SUBROUTINE createNC(this, ierr, message, nRch_in, nHRU_in)
 
       USE var_lookup, ONLY: ixQdims
       USE globalData, ONLY: meta_qDims
@@ -155,171 +153,120 @@ MODULE historyFile
       implicit none
       ! Argument variables
       class(histFile),          intent(inout)  :: this
-      integer(i4b),             intent(in)     :: nRch_in          ! total number of reaches
       integer(i4b),             intent(out)    :: ierr             ! error code
       character(*),             intent(out)    :: message          ! error message
+      integer(i4b), optional,   intent(in)     :: nRch_in
+      integer(i4b), optional,   intent(in)     :: nHRU_in
       ! local variables
       character(strLen)                        :: cmessage         ! error message of downwind routine
+      integer(i4b)                             :: nRch_local
+      integer(i4b)                             :: nHRU_local
       integer(i4b)                             :: ixDim,iVar       ! dimension, and variable index
       integer(i4b)                             :: dim_array(20)    ! dimension id array (max. 20 dimensions
       integer(i4b)                             :: nDims            ! number of dimension
 
-      ierr=0; message='createNC_rch/'
+      ierr=0; message='createNC/'
 
-      ! 1. Create new netCDF - initialize pioFileDesc under pioSystem
-      call createFile(this%pioSys, trim(this%fname), pio_typename, pio_netcdf_format, this%pioFileDesc, ierr, cmessage)
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+      nRch_local=0
+      if (present(nRch_in)) then
+        nRch_local=nRch_in
+      end if
 
-      ! 2. Define dimension
-      call def_dim(this%pioFileDesc, trim(meta_qDims(ixQdims%time)%dimName), recordDim, meta_qDims(ixQdims%time)%dimId)
-      call def_dim(this%pioFileDesc, trim(meta_qDims(ixQdims%seg)%dimName),  nRch_in,   meta_qDims(ixQdims%seg)%dimId)
-      call def_dim(this%pioFileDesc, trim(meta_qDims(ixQdims%ens)%dimName),  1,         meta_qDims(ixQdims%ens)%dimId)
+      nHRU_local=0
+      if (present(nHRU_in)) then
+        nHRU_local=nHRU_in
+      end if
 
-      ! 3. Define variables
-      ! --- time variable
-      call def_var(this%pioFileDesc,                           &                                        ! pio file descriptor
-                  trim(meta_qDims(ixQdims%time)%dimName),      &                                        ! variable name
-                  ncd_float,                                   &                                        ! variable type
-                  ierr, cmessage,                              &                                        ! error handle
-                  pioDimId=[meta_qDims(ixQdims%time)%dimId],   &                                        ! dimension array
-                  vdesc=trim(meta_qDims(ixQdims%time)%dimName), vunit=trim(time_units), vcal=calendar)  ! optional attributes
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-      ! --- reach ID variables
-      call def_var(this%pioFileDesc, 'reachID', ncd_int, ierr, cmessage, pioDimId=[meta_qDims(ixQdims%seg)%dimId], vdesc='reach ID', vunit='-')
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-      ! ---- flux variables
-      do iVar=1,nVarsRFLX
-        if (.not.meta_rflx(iVar)%varFile) cycle
-
-        ! define dimension ID array
-        nDims = size(meta_rflx(iVar)%varDim)
-        do ixDim = 1, nDims
-          dim_array(ixDim) = meta_qDims(meta_rflx(iVar)%varDim(ixDim))%dimId
-        end do
-
-        ! define variable
-        call def_var(this%pioFileDesc,            &                 ! pio file descriptor
-                     meta_rflx(iVar)%varName,     &                 ! variable name
-                     ncd_float,                   &                 ! dimension array and type
-                     ierr, cmessage,              &                 ! error handling
-                     pioDimId=dim_array(1:nDims), &                 ! dimension id
-                     vdesc=meta_rflx(iVar)%varDesc, vunit=meta_rflx(iVar)%varUnit)
-        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-      end do
-
-      call put_attr(this%pioFileDesc, ncd_global, 'mizuRoute-version', version ,ierr, cmessage)
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-      call put_attr(this%pioFileDesc, ncd_global, 'gitBranch', gitBranch ,ierr, cmessage)
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-      call put_attr(this%pioFileDesc, ncd_global, 'gitHash', gitHash ,ierr, cmessage)
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-      ! 4. End definitions
-      call end_def(this%pioFileDesc, ierr, cmessage)
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-    END SUBROUTINE createNC_rch
-
-    ! ---------------------------------------------------------------
-    ! Create netCDF and define dimension and variables - hru & reach
-    ! ---------------------------------------------------------------
-    SUBROUTINE createNC_rch_hru(this, nRch_in, nHRU_in, ierr, message)
-
-      USE var_lookup, ONLY: ixQdims
-      USE globalData, ONLY: meta_qDims
-      USE public_var, ONLY: calendar          ! calendar name
-      USE public_var, ONLY: time_units        ! time units (seconds, hours, or days)
-
-      implicit none
-      ! Argument variables
-      class(histFile),       intent(inout)  :: this
-      integer(i4b),             intent(in)     :: nRch_in
-      integer(i4b),             intent(in)     :: nHru_in
-      integer(i4b),             intent(out)    :: ierr             ! error code
-      character(*),             intent(out)    :: message          ! error message
-      ! local variables
-      character(strLen)                        :: cmessage         ! error message of downwind routine
-      integer(i4b)                             :: ixDim,iVar       ! dimension, and variable index
-      integer(i4b)                             :: dim_array(20)    ! dimension id array (max. 20 dimensions
-      integer(i4b)                             :: nDims            ! number of dimension
-
-      ierr=0; message='createNC_rch_hru/'
+      ! gauge only history file does not include hru fluxes
+      if ( this%gageOutput) then
+        nHRU_local=0
+      end if
 
       ! 1. Create new netCDF
-      call createFile(this%pioSys, trim(this%fname), pio_typename, pio_netcdf_format, this%pioFileDesc, ierr, cmessage)
+      call createFile(this%pioSys, this%fname, pio_typename, pio_netcdf_format, this%pioFileDesc, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! 2. Define dimension
-      call def_dim(this%pioFileDesc, trim(meta_qDims(ixQdims%time)%dimName), recordDim, meta_qDims(ixQdims%time)%dimId)
-      call def_dim(this%pioFileDesc, trim(meta_qDims(ixQdims%seg)%dimName),  nRch_in,   meta_qDims(ixQdims%seg)%dimId)
-      if (meta_hflx(ixHFLX%basRunoff)%varFile) then
-        call def_dim(this%pioFileDesc, trim(meta_qDims(ixQdims%hru)%dimName), nHru_in, meta_qDims(ixQdims%hru)%dimId)
+      call def_dim(this%pioFileDesc, meta_qDims(ixQdims%time)%dimName,   recordDim, meta_qDims(ixQdims%time)%dimId)
+      call def_dim(this%pioFileDesc, meta_qDims(ixQdims%tbound)%dimName, 2,         meta_qDims(ixQdims%tbound)%dimId)
+      call def_dim(this%pioFileDesc, meta_qDims(ixQdims%ens)%dimName,    1,         meta_qDims(ixQdims%ens)%dimId)
+      if (nRch_local>0) then
+        call def_dim(this%pioFileDesc, meta_qDims(ixQdims%seg)%dimName, nRch_in, meta_qDims(ixQdims%seg)%dimId)
       end if
-      call def_dim(this%pioFileDesc, trim(meta_qDims(ixQdims%ens)%dimName),  1,         meta_qDims(ixQdims%ens)%dimId)
+      if (nHRU_local>0) then ! gauge only history file does not include hru fluxes
+        call def_dim(this%pioFileDesc, meta_qDims(ixQdims%hru)%dimName, nHru_in, meta_qDims(ixQdims%hru)%dimId)
+      end if
 
       ! 3. Define variables
       ! --- time variable
-      call def_var(this%pioFileDesc,                           &                                        ! pio file descriptor
-                  trim(meta_qDims(ixQdims%time)%dimName),      &                                        ! variable name
-                  ncd_float,                                   &                                        ! variable type
-                  ierr, cmessage,                              &                                        ! error handle
-                  pioDimId=[meta_qDims(ixQdims%time)%dimId],   &                                        ! dimension array
-                  vdesc=trim(meta_qDims(ixQdims%time)%dimName), vunit=trim(time_units), vcal=calendar)  ! optional attributes
+      call def_var(this%pioFileDesc,                           &                           ! pio file descriptor
+                  meta_qDims(ixQdims%time)%dimName,            &                           ! variable name
+                  ncd_double,                                  &                           ! variable type
+                  ierr, cmessage,                              &                           ! error handle
+                  pioDimId=[meta_qDims(ixQdims%time)%dimId],   &                           ! dimension array
+                  vdesc=meta_qDims(ixQdims%time)%dimName, vunit=time_units, vcal=calendar) ! optional attributes
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-      ! --- hru ID variables
-      if (meta_hflx(ixHFLX%basRunoff)%varFile) then
-        call def_var(this%pioFileDesc, 'basinID', ncd_int, ierr, cmessage, pioDimId=[meta_qDims(ixQdims%hru)%dimId], vdesc='basin ID', vunit='-')
+      ! --- time bound variable
+      call def_var(this%pioFileDesc,                           &                                  ! pio file descriptor
+                  'time_bounds',                               &                                  ! variable name
+                  ncd_double,                                  &                                  ! variable type
+                  ierr, cmessage,                              &                                  ! error handle
+                  pioDimId=[meta_qDims(ixQdims%tbound)%dimId, meta_qDims(ixQdims%time)%dimId], &  ! dimension array
+                  vdesc='time interval endpoints', vunit=time_units, vcal=calendar)               ! optional attributes
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      ! ---- basinID and hru flux variables
+      if (nHRU_local>0) then
+        call def_var(this%pioFileDesc, 'basinID', ncd_int, ierr, cmessage, &
+                     pioDimId=[meta_qDims(ixQdims%hru)%dimId], vdesc='basin ID', vunit='-')
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+        do iVar=1,nVarsHFLX
+          if (.not.meta_hflx(iVar)%varFile) cycle
+
+          ! define dimension ID array
+          nDims = size(meta_hflx(iVar)%varDim)
+          do ixDim = 1, nDims
+            dim_array(ixDim) = meta_qDims(meta_hflx(iVar)%varDim(ixDim))%dimId
+          end do
+
+          ! define variable
+          call def_var(this%pioFileDesc,            &                 ! pio file descriptor
+                       meta_hflx(iVar)%varName,     &                 ! variable name
+                       meta_hflx(iVar)%varType,     &                 ! variable type
+                       ierr, cmessage,              &                 ! error handling
+                       pioDimId=dim_array(1:nDims), &                 ! dimension id
+                       vdesc=meta_hflx(iVar)%varDesc, vunit=meta_hflx(iVar)%varUnit)
+          if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+        end do
       end if
 
-      ! --- reach ID variables
-      call def_var(this%pioFileDesc, 'reachID', ncd_int, ierr, cmessage, pioDimId=[meta_qDims(ixQdims%seg)%dimId], vdesc='reach ID', vunit='-')
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-      ! ---- hru flux variables
-      do iVar=1,nVarsHFLX
-        if (.not.meta_hflx(iVar)%varFile) cycle
-
-        ! define dimension ID array
-        nDims = size(meta_hflx(iVar)%varDim)
-        do ixDim = 1, nDims
-          dim_array(ixDim) = meta_qDims(meta_hflx(iVar)%varDim(ixDim))%dimId
-        end do
-
-        ! define variable
-        call def_var(this%pioFileDesc,            &                 ! pio file descriptor
-                     meta_hflx(iVar)%varName,     &                 ! variable name
-                     ncd_float,                   &                 ! dimension array and type
-                     ierr, cmessage,              &                 ! error handling
-                     pioDimId=dim_array(1:nDims), &                 ! dimension id
-                     vdesc=meta_hflx(iVar)%varDesc, vunit=meta_hflx(iVar)%varUnit)
+      ! --- reach ID and rch flux variables
+      if (nRch_local>0) then
+        call def_var(this%pioFileDesc, 'reachID', ncd_int, ierr, cmessage, &
+                     pioDimId=[meta_qDims(ixQdims%seg)%dimId], vdesc='reach ID', vunit='-')
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-      end do
 
-      ! ---- rch flux variables
-      do iVar=1,nVarsRFLX
-        if (.not.meta_rflx(iVar)%varFile) cycle
+        do iVar=1,nVarsRFLX
+          if (.not.meta_rflx(iVar)%varFile) cycle
 
-        ! define dimension ID array
-        nDims = size(meta_rflx(iVar)%varDim)
-        do ixDim = 1, nDims
-          dim_array(ixDim) = meta_qDims(meta_rflx(iVar)%varDim(ixDim))%dimId
+          ! define dimension ID array
+          nDims = size(meta_rflx(iVar)%varDim)
+          do ixDim = 1, nDims
+            dim_array(ixDim) = meta_qDims(meta_rflx(iVar)%varDim(ixDim))%dimId
+          end do
+
+          ! define variable
+          call def_var(this%pioFileDesc,            &                 ! pio file descriptor
+                       meta_rflx(iVar)%varName,     &                 ! variable name
+                       meta_rflx(iVar)%varType,     &                 ! variable type
+                       ierr, cmessage,              &                 ! error handling
+                       pioDimId=dim_array(1:nDims), &                 ! dimension id
+                       vdesc=meta_rflx(iVar)%varDesc, vunit=meta_rflx(iVar)%varUnit)
+          if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
         end do
-
-        ! define variable
-        call def_var(this%pioFileDesc,            &                 ! pio file descriptor
-                     meta_rflx(iVar)%varName,     &                 ! variable name
-                     ncd_float,                   &                 ! dimension array and type
-                     ierr, cmessage,              &                 ! error handling
-                     pioDimId=dim_array(1:nDims), &                 ! dimension id
-                     vdesc=meta_rflx(iVar)%varDesc, vunit=meta_rflx(iVar)%varUnit)
-        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-      end do
+      end if
 
       call put_attr(this%pioFileDesc, ncd_global, 'mizuRoute-version', version ,ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -334,7 +281,7 @@ MODULE historyFile
       call end_def(this%pioFileDesc, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-    END SUBROUTINE createNC_rch_hru
+    END SUBROUTINE createNC
 
     ! ---------------------------------
     ! open netCDF
@@ -488,7 +435,10 @@ MODULE historyFile
       this%iTime = this%iTime + 1 ! this is only line to increment time step index
 
       ! write time -- note time is just carried across from the input
-      call write_netcdf(this%pioFileDesc, 'time', [hVars_local%timeVar], [this%iTime], [1], ierr, cmessage)
+      call write_netcdf(this%pioFileDesc, 'time', [hVars_local%timeVar(1)], [this%iTime], [1], ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+      call write_netcdf(this%pioFileDesc, 'time_bounds', hVars_local%timeVar, [1,this%iTime], [2,1], ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       if (.not.this%gageOutput) then

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -265,8 +265,8 @@ CONTAINS
    endif
 
    ! update model time step bound
-   TSEC(0) = TSEC(0) + dt
-   TSEC(1) = TSEC(0) + dt
+   TSEC(1) = TSEC(2)
+   TSEC(2) = TSEC(1) + dt
 
    ! update model time index
    iTime=iTime+1
@@ -276,17 +276,18 @@ CONTAINS
    simDatetime(1) = simDatetime(1)%add_sec(dt, calendar, ierr, cmessage)
    simDatetime(2) = simDatetime(1)%add_sec(dt, calendar, ierr, cmessage)
 
+   ! increment time variable for history file
    ! model time stamp variable for output - dt is in second
+   timeVar(1) = timeVar(2)
    t_unit = trim( time_units(1:index(time_units,' ')) )
    select case( trim(t_unit) )
-     case('seconds','second','sec','s'); timeVar = timeVar+ dt
-     case('minutes','minute','min');     timeVar = timeVar+ dt/60._dp
-     case('hours','hour','hr','h');      timeVar = timeVar+ dt/3600._dp
-     case('days','day','d');             timeVar = timeVar+ dt/86400._dp
+     case('seconds','second','sec','s'); timeVar(2) = timeVar(1) + dt
+     case('minutes','minute','min');     timeVar(2) = timeVar(1) + dt/60._dp
+     case('hours','hour','hr','h');      timeVar(2) = timeVar(1) + dt/3600._dp
+     case('days','day','d');             timeVar(2) = timeVar(1) + dt/86400._dp
      case default
        ierr=20; message=trim(message)//'<tunit>= '//trim(t_unit)//': <tunit> must be seconds, minutes, hours or days.'; return
    end select
-
 
  END SUBROUTINE update_time
 
@@ -448,7 +449,7 @@ CONTAINS
       end if
     end if
     ! initialize time
-    TSEC(0)=0._dp; TSEC(1)=dt
+    TSEC(1)=0._dp; TSEC(2)=dt
   else
     ! start with restart condition
     if (masterproc) then
@@ -456,7 +457,7 @@ CONTAINS
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! time bound [sec] is at previous time step, so need to add dt for curent time step
-      TSEC(0)=T0+dt; TSEC(1)=T1+dt
+      TSEC(1)=T0+dt; TSEC(2)=T1+dt
     else ! if other processors, just allocate RCHSTA for dummy
       allocate(RCHSTA(1,1),RCHFLX(1,1), stat=ierr, errmsg=cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA,RCHFLX]'; return; endif

--- a/route/build/src/main_route.f90
+++ b/route/build/src/main_route.f90
@@ -95,7 +95,7 @@ CONTAINS
    ierr=0; message = "main_routing/"
 
   ! define the start and end of the time step
-  T0=TSEC(0); T1=TSEC(1)
+  T0=TSEC(1); T1=TSEC(2)
 
   ! number of reaches to be processed
   nSeg = size(ixRchProcessed)

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -106,6 +106,7 @@ contains
  meta_stateDims(ixStateDims%tdh     ) = dim_info('tdh',     integerMissing, integerMissing)  ! future time steps for bsasin irf routing
 
  meta_qDims(ixQdims%time    ) = dim_info('time',    integerMissing, integerMissing)   ! time
+ meta_qDims(ixQdims%tbound  ) = dim_info('tbound',  integerMissing, 2)                ! time bound (always 2 - start and end)
  meta_qDims(ixQdims%seg     ) = dim_info('seg',     integerMissing, integerMissing)   ! stream segment vector
  meta_qDims(ixQdims%hru     ) = dim_info('hru',     integerMissing, integerMissing)   ! hru vector
  meta_qDims(ixQdims%ens     ) = dim_info('ens',     integerMissing, integerMissing)   ! ensemble

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -47,10 +47,11 @@ MODULE var_lookup
  endtype iLook_stateDims
  ! For river discharge variables
  type, public  ::  iLook_qDims
-  integer(i4b)     :: time         = integerMissing   ! 1. time
-  integer(i4b)     :: seg          = integerMissing   ! 2. stream segment vector
-  integer(i4b)     :: hru          = integerMissing   ! 3. hru vector
-  integer(i4b)     :: ens          = integerMissing   ! 4. runoff ensemble
+  integer(i4b)     :: time         = integerMissing   ! 1. time stamp
+  integer(i4b)     :: tbound       = integerMissing   ! 2. time bound
+  integer(i4b)     :: seg          = integerMissing   ! 3. stream segment vector
+  integer(i4b)     :: hru          = integerMissing   ! 4. hru vector
+  integer(i4b)     :: ens          = integerMissing   ! 5. runoff ensemble
  endtype iLook_qDims
  ! ***********************************************************************************************************
  ! ** define variables desired for each HRU
@@ -261,7 +262,7 @@ MODULE var_lookup
  type(iLook_dims)     ,public,parameter :: ixDims      = iLook_dims     ( 1, 2, 3, 4, 5, 6, 7)
  type(iLook_stateDims),public,parameter :: ixStateDims = iLook_stateDims( 1, 2, 3, 4, 5, 6, 7, 8, 9,10, &
                                                                          11)
- type(iLook_qDims)    ,public,parameter :: ixqDims     = iLook_qDims    ( 1, 2, 3, 4)
+ type(iLook_qDims)    ,public,parameter :: ixQdims     = iLook_qDims    ( 1, 2, 3, 4, 5)
  type(iLook_HRU)      ,public,parameter :: ixHRU       = iLook_HRU      ( 1)
  type(iLook_HRU2SEG)  ,public,parameter :: ixHRU2SEG   = iLook_HRU2SEG  ( 1, 2, 3, 4)
  type(iLook_SEG)      ,public,parameter :: ixSEG       = iLook_SEG      ( 1, 2, 3, 4, 5, 6, 7, 8, 9,10, &

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -78,7 +78,7 @@ CONTAINS
 
       call hist_all_network%set_compdof(compdof_rch, compdof_hru, nRch, nHRU)
 
-      call hist_all_network%createNC(nRch, nHRU, ierr, cmessage)
+      call hist_all_network%createNC(ierr, cmessage, nRch_in=nRch, nHRU_in=nHRU)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       call hist_all_network%openNC(ierr, message)
@@ -95,7 +95,7 @@ CONTAINS
 
         call hist_gage%set_compdof(compdof_rch_gage, gage_data%nGage)
 
-        call hist_gage%createNC(gage_data%nGage, ierr, cmessage)
+        call hist_gage%createNC(ierr, cmessage, nRch_in=gage_data%nGage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
         call hist_gage%openNC(ierr, message)


### PR DESCRIPTION
Output `time_bounds` variable (datetime at time step endpoints).  This is CESM history file standard, but it is useful information for standalone.

Changes made are:
- time variable in history file uses double precision
- new metadata for `tbound` added in `meta_qDims` and resulting change var_lookup.
- change `timeVar` from scalar to 2 element array.
- also `TSEC` array uses the same array index bound (1:2) as `timeVar`
- track time at bounds while history variable aggregation.
- moderate refactoring historyFile bound procedure - `createNC`
- fix comparison of simulation ending time and forcing ending time. 


No answer change, but history file now has `time_bounds` with new dimension `tbound` (size=2)

Fix #387 