### PR TITLE
history file name change

### DIFF
--- a/route/build/cpl/nuopc/rof_comp_nuopc.F90
+++ b/route/build/cpl/nuopc/rof_comp_nuopc.F90
@@ -26,6 +26,7 @@ module rof_comp_nuopc
   use globalData            , only : mpicom_rof => mpicom_route
   use globalData            , only : nHRU
   use globalData            , only : runMode                     ! "ctsm-coupling" or "standalone" to differentiate some behaviours in mizuRoute
+  use globalData            , only : fhile_dayStamp              ! daily history file time stamp - "period-end" or "period-start:
   use init_model_data       , only : get_mpi_omp, init_model
   use RunoffMod             , only : rtmCTL
   use RtmMod                , only : route_ini, route_run
@@ -411,8 +412,9 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) username
 
-    ! set mizuRoute run mode
+    ! set mizuRoute run mode and daily history file day stamp
     runMode='cesm-coupling'
+    hfile_dayStamp='period-end' ! period-end: daily history file uses end of day for time stamp. This is for current CESM,but may be switched to "period-start"
 
     ! mizuRoute model configuration setup
     ! 1. read control file

--- a/route/build/src/datetime_data.f90
+++ b/route/build/src/datetime_data.f90
@@ -284,8 +284,8 @@ CONTAINS
 
   type(datetime) FUNCTION fn_add_months(this, nmonths)
     implicit none
-    class(datetime),     intent(inout)  :: this
-    integer(i4b),         intent(in)    :: nmonths
+    class(datetime),     intent(in)    :: this
+    integer(i4b),        intent(in)    :: nmonths
     fn_add_months%iy   = this%iy + (nmonths/12_i4b)
     fn_add_months%im   = this%im + mod(nmonths,12)
     fn_add_months%id   = this%id
@@ -296,7 +296,7 @@ CONTAINS
 
   type(datetime) FUNCTION fn_add_days(this, days, ierr, message)
     implicit none
-    class(datetime),      intent(inout) :: this
+    class(datetime),      intent(in)    :: this
     integer(i4b),         intent(in)    :: days
     integer(i4b),         intent(out)   :: ierr
     character(len=strLen),intent(out)   :: message

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -111,6 +111,7 @@ MODULE globalData
 
   ! ---------- Misc. data -------------------------------------------------------------------------
   character(len=strLen),           public :: runMode='standalone'        ! run options: standalone or cesm-coupling
+  character(len=12),               public :: hfile_dayStamp='period-start' ! day stamp in history file for daily file. period-start or period-end
   integer(i4b),                    public :: ixPrint(1:2)=integerMissing ! index of desired reach to be on-screen print
   integer(i4b),                    public :: nEns=1                      ! number of ensemble
   integer(i4b),                    public :: maxtdh                      ! maximum unit-hydrograph future time steps

--- a/route/build/src/mpi_utils.f90
+++ b/route/build/src/mpi_utils.f90
@@ -974,7 +974,7 @@ CONTAINS
     character(strLen),parameter :: subName = 'shr_mpi_abort/'
     integer(i4b)                :: jerr
 
-    write(iulog,*) trim(subName),trim(message),ierr
+    write(iulog,*) trim(subName),trim(message)
     call flush(6)
 
     if (present(comm)) then

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -442,10 +442,12 @@ CONTAINS
        write(timeString, fmtYMDS) inDatetime%year(),'-',inDatetime%month(),'-',inDatetime%day(),'-',sec_in_day
      case('daily')
        if (trim(hfile_dayStamp)=='period-start') then
-         write(timeString, fmtYMD) inDatetime%year(),'-',inDatetime%month(),'-',inDatetime%day()
+         sec_in_day = inDatetime%hour()*int(secprhour)+inDatetime%minute()*int(secprmin)+nint(inDatetime%sec())
+         write(timeString, fmtYMDS) inDatetime%year(),'-',inDatetime%month(),'-',inDatetime%day(),'-',sec_in_day
        else if (trim(hfile_dayStamp)=='period-end') then
          datetime_stamp = inDatetime%add_day(1, ierr, cmessage)
-         write(timeString, fmtYMD) datetime_stamp%year(),'-',datetime_stamp%month(),'-',datetime_stamp%day()
+         sec_in_day = datetime_stamp%hour()*int(secprhour)+datetime_stamp%minute()*int(secprmin)+nint(datetime_stamp%sec())
+         write(timeString, fmtYMDS) datetime_stamp%year(),'-',datetime_stamp%month(),'-',datetime_stamp%day(),'-',sec_in_day
        end if
      case('monthly')
        write(timeString, fmtYM) inDatetime%year(),'-',inDatetime%month()

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -411,38 +411,60 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE get_hfilename(inDatetime, ierr, message)
 
-   USE public_var, ONLY: output_dir        ! output directory
-   USE public_var, ONLY: case_name         ! simulation name ==> output filename head
-   USE public_var, ONLY: outputAtGage      ! ascii containing last restart and history files
+   USE public_var, ONLY: output_dir          ! output directory
+   USE public_var, ONLY: case_name           ! simulation name ==> output filename head
+   USE public_var, ONLY: newFileFrequency    ! new file frequency
+   USE public_var, ONLY: outputAtGage        ! ascii containing last restart and history files
+   USE public_var, ONLY: secprhour,secprmin  ! time conversion to sec
+   USE globalData, ONLY: hfile_dayStamp      ! day stamp for history file name - period-start or period-end
 
    implicit none
    ! argument variables
-   type(datetime), intent(in)  :: inDatetime     ! datetime at previous and current timestep
+   type(datetime), intent(in)  :: inDatetime     ! datetime at current timestep
    integer(i4b),   intent(out) :: ierr           ! error code
    character(*),   intent(out) :: message        ! error message
    ! local variables
-   integer(i4b)              :: sec_in_day       ! second within day
-   character(*),parameter    :: fmtYMDS='(a,I0.4,a,I0.2,a,I0.2,a,I0.5,a)'
+   character(strLen)           :: cmessage        ! error message from subroutine
+   type(datetime)              :: datetime_stamp  ! datetime used in history file name
+   integer(i4b)                :: sec_in_day      ! second within day
+   character(len=strLen)       :: timeString
+   character(len=27),parameter :: fmtYMDS='(I0.4,a,I0.2,a,I0.2,a,I0.5)'
+   character(len=20),parameter :: fmtYMD ='(I0.4,a,I0.2,a,I0.2)'
+   character(len=13),parameter :: fmtYM  ='(I0.4,a,I0.2)'
+   character(len=6),parameter  :: fmtY   ='(I0.4)'
 
    ierr=0; message='get_hfilename/'
 
-   ! Define history filename
-   sec_in_day = inDatetime%hour()*60*60+inDatetime%minute()*60+nint(inDatetime%sec())
+   ! construct time stamp string in history file: timeString
+   select case(trim(newFileFrequency))
+     case('single')
+       sec_in_day = inDatetime%hour()*int(secprhour)+inDatetime%minute()*int(secprmin)+nint(inDatetime%sec())
+       write(timeString, fmtYMDS) inDatetime%year(),'-',inDatetime%month(),'-',inDatetime%day(),'-',sec_in_day
+     case('daily')
+       if (trim(hfile_dayStamp)=='period-start') then
+         write(timeString, fmtYMD) inDatetime%year(),'-',inDatetime%month(),'-',inDatetime%day()
+       else if (trim(hfile_dayStamp)=='period-end') then
+         datetime_stamp = inDatetime%add_day(1, ierr, cmessage)
+         write(timeString, fmtYMD) datetime_stamp%year(),'-',datetime_stamp%month(),'-',datetime_stamp%day()
+       end if
+     case('monthly')
+       write(timeString, fmtYM) inDatetime%year(),'-',inDatetime%month()
+     case('yearly')
+       write(timeString, fmtY) inDatetime%year()
+     case default; ierr=20; message=trim(message)//'Invalid file frequency'; return
+   end select
+
+   ! construct history file name: hfileout
    select case(trim(runMode))
      case('cesm-coupling')
-       write(hfileout, fmtYMDS) trim(output_dir)//trim(case_name)//'.mizuroute.h.', &
-                             inDatetime%year(),'-',inDatetime%month(),'-',inDatetime%day(),'-',sec_in_day,'.nc'
-
+       write(hfileout,'(a)') trim(output_dir)//trim(case_name)//'.mizuroute.h.'//trim(timeString)//'.nc'
        if (outputAtGage) then
-         write(hfileout_gage, fmtYMDS) trim(output_dir)//trim(case_name)//'.mizuroute.h_gauge.', &
-                                    inDatetime%year(),'-',inDatetime%month(),'-',inDatetime%day(),'-',sec_in_day,'.nc'
+         write(hfileout_gage,'(a)') trim(output_dir)//trim(case_name)//'.mizuroute.h_gauge.'//trim(timeString)//'.nc'
        end if
      case('standalone')
-       write(hfileout, fmtYMDS) trim(output_dir)//trim(case_name)//'.h.', &
-                             inDatetime%year(),'-',inDatetime%month(),'-',inDatetime%day(),'-',sec_in_day,'.nc'
+       write(hfileout, '(a)') trim(output_dir)//trim(case_name)//'.h.'//trim(timeString)//'.nc'
        if (outputAtGage) then
-         write(hfileout_gage, fmtYMDS) trim(output_dir)//trim(case_name)//'.h_gauge.', &
-                                    inDatetime%year(),'-',inDatetime%month(),'-',inDatetime%day(),'-',sec_in_day,'.nc'
+         write(hfileout_gage, '(a)') trim(output_dir)//trim(case_name)//'.h_gauge.'//trim(timeString)//'.nc'
        end if
      case default; ierr=20; message=trim(message)//'unable to identify the run option. Avaliable options are standalone and cesm-coupling'; return
    end select


### PR DESCRIPTION
History file name datetime stamp changes.

single history file:  `<case>.mizuroute.h.yyyy-mm-dd-sssss.nc` for cesm-coupling, and `<case>.h.yyyy-mm-dd-sssss.nc` for standalone.
daily history file:  `<case>.mizuroute.h.yyyy-mm-dd.nc` for cesm-coupling, and `<case>.h.yyyy-mm-dd.nc` for standalone.
monthly history file: `<case>.mizuroute.h.yyyy-mm.nc` for cesm-coupling, and `<case>.h.yyyy-mm.nc` for standalone.
yearly history file: `<case>.mizuroute.h.yyyy.nc` for cesm-coupling, and `<case>.h.yyyy.nc` for standalone.

cesm-coupling mode uses end of day for daily history time stamp
standalone model still uses start of day for daily history time stamp 

close #388 
close #386 

Further discussion:  
- Maybe add hourly history file for sub-hourly simulation and output.
- if simulation start during a day (e.g., 03:00:00) and dt is daily and output frequency is daily,  output is from 03:00:00 through 03:00:00 next day. 