### PR TITLE
Fix error in writing history_file variable for gauge-only history file in restart file 

### DIFF
--- a/route/build/src/pio_utils.f90
+++ b/route/build/src/pio_utils.f90
@@ -692,19 +692,18 @@ CONTAINS
   ierr=0; message='write_char0D/'
 
   if ( len(string) > size(tmpString) )then
-      ierr = 1
-      message=trim(message)//'ERROR: length of string being written is larger than tmpString'
-      return
+    ierr = 1
+    message=trim(message)//'ERROR: length of string being written is larger than tmpString'
+    return
   end if
   ierr = pio_inq_varid(pioFileDesc, trim(vname), pioVarId)
   if(ierr/=0)then; message=trim(message)//'ERROR: getting variable id'; return; endif
 
-
   do m = 1,len(string)
-     tmpString(m:m) = string(m:m)
+    tmpString(m:m) = string(m:m)
   end do
-  start(1) = iStart
-  start(2) = 1
+  start(1) = 1
+  start(2) = iStart
   icount(1) = len(string)
   icount(2) = 1
   var_id = pioVarId%varid

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -941,10 +941,10 @@ CONTAINS
                    iStart=1, ierr=ierr, message=cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  if ( outputAtGage )then
-    call write_netcdf(pioFileDescState, 'history_file', hfileOut_gage, &
-                      iStart=2, ierr=ierr, message=cmessage)
+   call write_netcdf(pioFileDescState, 'history_file', hfileOut_gage, &
+                     iStart=2, ierr=ierr, message=cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
- if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  call write_basinQ_state(ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif


### PR DESCRIPTION
I got error in restart file writing (`history_file` variable) when gauge history file writing option is on.

I think `start` variable in `write_char0D` had a bug.