### PR TITLE
Adding a few channel properties and water take option for other routing

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -187,10 +187,12 @@ implicit none
 
  ! -- Reach physical parameters
  type, public ::  RCHPRP
-  real(dp)                                   :: R_SLOPE
-  real(dp)                                   :: R_MAN_N
-  real(dp)                                   :: R_WIDTH
-  real(dp)                                   :: RLENGTH
+  real(dp)                                   :: R_SLOPE        ! channel slope [-]
+  real(dp)                                   :: R_MAN_N        ! channel bed manning coefficient [-]
+  real(dp)                                   :: R_WIDTH        ! channel width [m]
+  real(dp)                                   :: R_DEPTH        ! channel bankfull depth [m]
+  real(dp)                                   :: RLENGTH        ! channel length [m]
+  real(dp)                                   :: FLDP_SLOPE     ! floodplain slope [-]
   real(dp)                                   :: UPSAREA        ! upstream area (zero if headwater basin)
   real(dp)                                   :: BASAREA        ! local basin area
   real(dp)                                   :: TOTAREA        ! UPSAREA + BASAREA

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -357,6 +357,7 @@ implicit none
    real(dp)        :: REACH_ELE              ! water height at current time step [m]
    real(dp)        :: REACH_Q                ! discharge at current time step [m3/s]
    real(dp)        :: REACH_VOL(0:1)         ! water volume at previous and current time steps [m3]
+   real(dp)        :: REACH_WM_FLUX_actual   ! water management fluxes to and from each reach [m3/s]
    real(dp)        :: WB                     ! reach water balance error [m3]
  end type hydraulic
 
@@ -370,7 +371,6 @@ implicit none
   real(dp)                             :: BASIN_QR(0:1)          ! routed runoff volume from the local basin [m3/s]
   type(hydraulic), allocatable         :: ROUTE(:)               ! reach fluxes and states for each routing method
   real(dp)                             :: REACH_WM_FLUX          ! water management fluxes to and from each reach [m3/s]
-  real(dp)                             :: REACH_WM_FLUX_actual   ! water management fluxes to and from each reach [m3/s]
   real(dp)                             :: REACH_WM_VOL           ! target volume from the second water management file [m3]
   real(dp)                             :: Qobs                   ! observed discharge [m3/s]
   real(dp)                             :: basinEvapo             ! remapped river network catchment Evaporation [unit] (size: number of nHRU)

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -152,8 +152,10 @@ MODULE globalData
   real(dp),                        public :: tscale                     ! scaling factor for the time delay histogram [sec]
   real(dp),                        public :: velo                       ! velocity [m/s] for Saint-Venant equation
   real(dp),                        public :: diff                       ! diffusivity [m2/s] for Saint-Venant equation
-  real(dp),                        public :: mann_n                     ! manning's roughness coefficient [unitless]
+  real(dp),                        public :: mann_n                     ! manning's roughness coefficient [-]
   real(dp),                        public :: wscale                     ! scaling factor for river width [-]
+  real(dp),                        public :: channelDepth=10.           ! channel bankfull depth [m]
+  real(dp),                        public :: floodplainSlope=0.001      ! floodplain down slope [-]
 
   ! ---------- general structure information --------------------------------------------------------
 

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -305,6 +305,7 @@ CONTAINS
   USE public_var, ONLY: kinematicWave          ! KW routing ID = 3
   USE public_var, ONLY: muskingumCunge         ! MC routing ID = 4
   USE public_var, ONLY: diffusiveWave          ! DW routing ID = 5
+  USE public_var, ONLY: is_lake_sim            ! logical if lakes are activated in simulation
   USE globalData, ONLY: idxIRF, idxKWT, &
                         idxKW, idxMC, idxDW
   USE globalData, ONLY: nRoutes                ! number of available routing methods
@@ -368,7 +369,7 @@ CONTAINS
       end if
       if (onRoute(kinematicWaveTracking)) then
         do ix = 1, nRch_mainstem+nTribOutlet
-          if (NETOPO_main(ix)%islake) then
+          if (is_lake_sim .and. NETOPO_main(ix)%islake) then
             allocate(RCHSTA_trib(iens,ix)%LKW_ROUTE%KWAVE(0:0),stat=ierr, errmsg=cmessage)
             if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA_trib%LKW_ROUTE%KWAVE]'; return; endif
             RCHSTA_trib(iens,ix)%LKW_ROUTE%KWAVE(0)%QF=-9999
@@ -379,7 +380,7 @@ CONTAINS
           end if
         end do
         do ix = 1, rch_per_proc(0)
-          if (NETOPO_trib(ix)%islake) then
+          if (is_lake_sim .and. NETOPO_trib(ix)%islake) then
             allocate(RCHSTA_trib(iens,nRch_mainstem+nTribOutlet+ix)%LKW_ROUTE%KWAVE(0:0),stat=ierr, errmsg=cmessage)
             if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA_trib%LKW_ROUTE%KWAVE]'; return; endif
             RCHSTA_trib(iens,ix+nRch_mainstem+nTribOutlet)%LKW_ROUTE%KWAVE(0)%QF=-9999
@@ -434,7 +435,7 @@ CONTAINS
         end if
         if (onRoute(kinematicWaveTracking)) then
           do ix = 1, size(RCHSTA_trib(iens,:))
-            if (NETOPO_trib(ix)%islake) then
+            if (is_lake_sim .and. NETOPO_trib(ix)%islake) then
               allocate(RCHSTA_trib(iens,ix)%LKW_ROUTE%KWAVE(0:0),stat=ierr, errmsg=cmessage)
               if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA_trib%LKW_ROUTE%KWAVE]'; return; endif
               RCHSTA_trib(iens,ix)%LKW_ROUTE%KWAVE(0)%QF=-9999

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -93,6 +93,8 @@ CONTAINS
     end do
   endif
 
+  RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX ! initialize actual water abstraction
+
   ! perform UH convolution
   call conv_upsbas_qr(NETOPO_in(segIndex)%UH,    &    ! input: reach unit hydrograph
                       q_upstream,                &    ! input: total discharge at top of the reach being processed
@@ -122,7 +124,7 @@ CONTAINS
   if((RCHFLX_out(iens,segIndex)%REACH_WM_FLUX /= realMissing).and.(is_flux_wm)) then
     if (RCHFLX_out(iens,segIndex)%REACH_WM_FLUX <= 0) then ! negative/injection
       RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
-      RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
+      RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
     else ! positive/abstraction
       Qabs = min(RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1)/dt+RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q, &
                  RCHFLX_out(iens,segIndex)%REACH_WM_FLUX)
@@ -130,7 +132,7 @@ CONTAINS
 
       RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_VOL(1) + Vmod*dt
       RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q      = RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q - (Qabs+Vmod)
-      RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = Qabs
+      RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_WM_FLUX_actual = Qabs
     endif
   endif
 

--- a/route/build/src/kwe_route.f90
+++ b/route/build/src/kwe_route.f90
@@ -11,6 +11,8 @@ USE dataTypes,     ONLY: kwRCH           ! kw specific state data structure
 USE public_var,    ONLY: iulog           ! i/o logical unit number
 USE public_var,    ONLY: realMissing     ! missing value for real number
 USE public_var,    ONLY: integerMissing  ! missing value for integer number
+USE public_var,    ONLY: dt              ! simulation time step [sec]
+USE public_var,    ONLY: is_flux_wm      ! logical water management components fluxes should be read
 USE public_var,    ONLY: qmodOption      ! qmod option (use 1==direct insertion)
 USE globalData,    ONLY: idxKW           ! routing method index for kinematic wwave
 USE water_balance, ONLY: comp_reach_wb   ! compute water balance error
@@ -61,7 +63,10 @@ CONTAINS
  integer(i4b)                              :: nUps              ! number of upstream segment
  integer(i4b)                              :: iUps              ! upstream reach index
  integer(i4b)                              :: iRch_ups          ! index of upstream reach in NETOPO
- real(dp)                                  :: q_upstream        ! total discharge at top of the reach being processed
+ real(dp)                                  :: Qlat              ! lateral flow into channel [m3/s]
+ real(dp)                                  :: Qabs              ! maximum allowable water abstraction rate [m3/s]
+ real(dp)                                  :: q_upstream        ! total discharge at top of the reach [m3/s]
+ real(dp)                                  :: q_upstream_mod    ! total discharge at top of the reach after water abstraction [m3/s]
  character(len=strLen)                     :: cmessage          ! error message from subroutine
 
  ierr=0; message='kw_rch/'
@@ -86,6 +91,43 @@ CONTAINS
    end do
  endif
 
+ q_upstream_mod  = q_upstream
+ Qlat = RCHFLX_out(iens,segIndex)%BASIN_QR(1)
+ Qabs = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX ! initial water abstraction (positive) or injection (negative)
+ RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX ! initialize actual water abstraction
+
+ ! update volume at previous time step
+ RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(0) = RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1)
+
+ ! Water management - water injection or abstraction (irrigation or industrial/domestic water usage)
+ ! For water abstraction, water is extracted from the following priorities:
+ ! 1. existing storage(REACH_VOL(0), 2. upstream inflow , 3 lateral flow (BASIN_QR)
+ if((RCHFLX_out(iens,segIndex)%REACH_WM_FLUX /= realMissing).and.(is_flux_wm)) then
+   if (Qabs > 0) then ! positive == abstraction
+     if (RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1)/dt > Qabs) then ! take out all abstraction from strorage
+       RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1) - Qabs*dt
+     else ! if inital abstraction is greater than volume
+       Qabs = Qabs - RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1)/dt ! get residual Qabs after extracting from strorage
+       RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_VOL(1) = 0._dp ! voluem gets 0
+       if (q_upstream > Qabs) then ! then take out all residual abstraction from upstream inflow
+         q_upstream_mod = q_upstream - Qabs
+       else ! if residual abstraction is still greater than lateral flow
+         Qabs = Qabs - q_upstream ! get residual abstraction after extracting upstream inflow and storage.
+         q_upstream_mod = 0._dp ! upstream inflow gets 0 (all is gone to abstracted flow).
+         if (Qlat > Qabs) then ! then take residual abstraction out from lateral flow
+           Qlat = Qlat - Qabs
+         else ! if residual abstraction is greater than upstream inflow
+           Qabs = Qabs - Qlat ! take out residual abstraction from lateral flow
+           Qlat = 0._dp ! lateral flow gets 0 (all are gone to abstraction)
+           RCHFLX_out(iens,segIndex)%ROUTE(idxKW)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX - Qabs
+         end if
+       end if
+     end if
+   else ! negative == injection
+     Qlat = Qlat - Qabs
+   endif
+ endif
+
  if(verbose)then
    write(iulog,'(2A)') new_line('a'), '** CHECK Kinematic wave routing **'
    if (nUps>0) then
@@ -101,9 +143,7 @@ CONTAINS
  ! perform river network KW routing
  call kinematic_wave(RPARAM_in(segIndex),                     & ! input: parameter at segIndex reach
                      T0,T1,                                   & ! input: start and end of the time step
-                     q_upstream,                              & ! input: total discharge at top of the reach being processed
-                     RCHFLX_out(iens,segIndex)%REACH_WM_FLUX, & ! input: abstraction(-)/injection(+) [m3/s]
-                     RPARAM_in(segIndex)%MINFLOW,             & ! input: minimum environmental flow [m3/s]
+                     q_upstream_mod,                          & ! input: total discharge at top of the reach being processed
                      isHW,                                    & ! input: is this headwater basin?
                      RCHSTA_out(iens,segIndex)%KW_ROUTE,      & ! inout:
                      RCHFLX_out(iens,segIndex),               & ! inout: updated fluxes at reach
@@ -133,8 +173,6 @@ CONTAINS
  SUBROUTINE kinematic_wave(rch_param,     & ! input: river parameter data structure
                            T0,T1,         & ! input: start and end of the time step
                            q_upstream,    & ! input: discharge from upstream
-                           Qtake,         & ! input: abstraction(-)/injection(+) [m3/s]
-                           Qmin,          & ! input: minimum environmental flow [m3/s]
                            isHW,          & ! input: is this headwater basin?
                            rstate,        & ! inout: reach state at a reach
                            rflux,         & ! inout: reach flux at a reach
@@ -159,8 +197,6 @@ CONTAINS
  type(RCHPRP), intent(in)                 :: rch_param    ! River reach parameter
  real(dp),     intent(in)                 :: T0,T1        ! start and end of the time step (seconds)
  real(dp),     intent(in)                 :: q_upstream   ! total discharge at top of the reach being processed
- real(dp),     intent(in)                 :: Qtake        ! abstraction(-)/injection(+) [m3/s]
- real(dp),     intent(in)                 :: Qmin         ! minimum environmental flow [m3/s]
  logical(lgt), intent(in)                 :: isHW         ! is this headwater basin?
  type(kwRCH),  intent(inout)              :: rstate       ! curent reach states
  type(STRFLX), intent(inout)              :: rflux        ! current Reach fluxes
@@ -176,29 +212,18 @@ CONTAINS
  real(dp)                                 :: omega        ! right-hand side of kw finite difference
  real(dp)                                 :: f0,f1,f2     ! values of function f, 1st and 2nd derivatives at solution
  real(dp)                                 :: X            !
- real(dp)                                 :: dT           ! interval of time step [sec]
  real(dp)                                 :: dX           ! length of segment [m]
  real(dp)                                 :: Q(0:1,0:1)   !
  real(dp)                                 :: Qtrial(2)    ! trial solution of kw equation
  real(dp)                                 :: Qbar         !
  real(dp)                                 :: absErr(2)    ! absolute error of nonliear equation solution
  real(dp)                                 :: f0eval(2)    !
- real(dp)                                 :: QupMod       ! modified total discharge at top of the reach being processed
- real(dp)                                 :: Qabs         ! maximum allowable water abstraction rate [m3/s]
- real(dp)                                 :: Qmod         ! abstraction rate to be taken from outlet discharge [m3/s]
  integer(i4b)                             :: imin         ! index at minimum value
 
  ierr=0; message='kinematic_wave/'
 
  Q(0,0) = rstate%molecule%Q(1) ! previous time and inlet  1 (0,0)
  Q(0,1) = rstate%molecule%Q(2) ! previous time and outlet 2 (0,1)
- dt = T1-T0
-
- ! Q injection, add at top of reach
- QupMod = q_upstream
- if (Qtake>0) then
-   QupMod = QupMod+ Qtake
- end if
 
  if (.not. isHW) then
 
@@ -215,7 +240,7 @@ CONTAINS
    theta = dt/dX
 
    ! compute total flow rate and flow area at upstream end at current time step
-   Q(1,0) = QupMod
+   Q(1,0) = q_upstream
 
    if (verbose) then
      write(iulog,'(A,1X,G12.5)') ' length [m]        =',rch_param%RLENGTH
@@ -274,33 +299,15 @@ CONTAINS
 
  endif
 
- ! compute volume
- rflux%ROUTE(idxKW)%REACH_VOL(0) = rflux%ROUTE(idxKW)%REACH_VOL(1)
  ! For very low flow condition, outflow - inflow > current storage, so limit outflow and adjust Q(1,1)
- Q(1,1) = min(rflux%ROUTE(idxKW)%REACH_VOL(0)/dt + Q(1,0)*0.999, Q(1,1))
- rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(0) + (Q(1,0)-Q(1,1))*dt
+ Q(1,1) = min(rflux%ROUTE(idxKW)%REACH_VOL(1)/dt + Q(1,0)*0.999, Q(1,1))
+ rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(1) + (Q(1,0)-Q(1,1))*dt
 
  ! add catchment flow
  rflux%ROUTE(idxKW)%REACH_Q = Q(1,1)+rflux%BASIN_QR(1)
 
  if (verbose) then
    write(iulog,'(1(A,1X,G15.4))') ' Q(1,1)=',Q(1,1)
- end if
-
- ! Q abstraction
- ! Compute actual abstraction (Qabs) m3/s - values should be negative
- ! Compute abstraction (Qmod) m3 taken from outlet discharge (REACH_Q)
- ! Compute REACH_Q subtracted from Qmod abstraction
- ! Compute REACH_VOL subtracted from total abstraction minus abstraction from outlet discharge
- if (Qtake<0) then
-   Qabs = max(-(rflux%ROUTE(idxKW)%REACH_VOL(1)/dt+rflux%ROUTE(idxKW)%REACH_Q-Qmin), Qtake)
-   Qmod = min(rflux%ROUTE(idxKW)%REACH_VOL(1) + Qabs*dt, 0._dp) ! Qtake taken from outflow portion, Qmod <=0
-
-   rflux%ROUTE(idxKW)%REACH_Q      = rflux%ROUTE(idxKW)%REACH_Q + Qmod/dt
-   rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(1) + (Qabs*dt - Qmod)
-
-   ! modify computational molecule state (Q)
-   Q(1,1) = Q(1,1) - max(abs(Qmod/dt)-rflux%BASIN_QR(1), 0._dp)
  end if
 
  ! update state

--- a/route/build/src/lake_route.f90
+++ b/route/build/src/lake_route.f90
@@ -154,19 +154,21 @@ CONTAINS
       RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1)=0._dp
     endif
 
+    RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX ! initialize actual water abstraction
+
     ! take out the water from the reach if the wm flag is true and the value are not missing
     ! here we should make sure the real missing is not injection (or negative abstration)
     if((RCHFLX_out(iens,segIndex)%REACH_WM_FLUX /= realMissing).and.(is_flux_wm)) then
       ! abstraction or injection
       if (RCHFLX_out(iens,segIndex)%REACH_WM_FLUX <= 0) then ! negative/injection
         RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX*dt
-        RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
+        RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
       else ! positive/abstraction
         if (RCHFLX_out(iens,segIndex)%REACH_WM_FLUX*dt <= RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1)) then ! abstraction is smaller than water in the lake
           RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX*dt
-          RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
+          RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX
         else ! abstraction is larger than water in the river
-          RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1)/dt
+          RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1)/dt
           RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) = 0._dp
         endif
       endif

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -133,6 +133,8 @@ contains
  meta_SEG    (ixSEG%slope            ) = var_info('slope'          , 'slope of segment'                                  ,'-'     ,ixDims%seg   , .true.)
  meta_SEG    (ixSEG%width            ) = var_info('width'          , 'width of segment'                                  ,'m'     ,ixDims%seg   , .false.)
  meta_SEG    (ixSEG%man_n            ) = var_info('man_n'          , 'Mannings n'                                        ,'weird' ,ixDims%seg   , .false.)
+ meta_SEG    (ixSEG%depth            ) = var_info('depth'          , 'bankfull depth of segment'                         ,'m'     ,ixDims%seg   , .false.)
+ meta_SEG    (ixSEG%floodplainSlope  ) = var_info('floodplainSlope', 'slope of floodplain'                               ,'-'     ,ixDims%seg   , .false.)
  meta_SEG    (ixSEG%hruArea          ) = var_info('hruArea'        , 'area of each contributing HRU'                     ,'m2'    ,ixDims%upHRU , .false.)
  meta_SEG    (ixSEG%weight           ) = var_info('weight'         , 'weight assigned to each HRU'                       ,'-'     ,ixDims%upHRU , .false.)
  meta_SEG    (ixSEG%timeDelayHist    ) = var_info('timeDelayHist'  , 'time delay histogram for each reach'               ,'-'     ,ixDims%uh    , .false.)

--- a/route/build/src/process_ntopo.f90
+++ b/route/build/src/process_ntopo.f90
@@ -68,7 +68,9 @@ CONTAINS
  ! Routing parameter estimation routine
  USE process_param,ONLY: make_uh               ! construct reach unit hydrograph
  ! routing spatial constant parameters
- USE globalData,   ONLY: mann_n, wscale        ! KWT routing parameters (Transfer function parameters)
+ USE globalData,   ONLY: mann_n, wscale        ! spatial constant channel parameters
+ USE globalData,   ONLY: channelDepth          ! spatial constant channel bankfull depth [m]
+ USE globalData,   ONLY: floodplainSlope       ! spatial constant floodplain slope
  USE globalData,   ONLY: velo, diff            ! IRF routing parameters (Transfer function parameters)
  USE public_var,   ONLY: dt                    ! simulation time step [sec]
 
@@ -211,7 +213,7 @@ CONTAINS
 
  ! ---------- Compute routing parameters  --------------------------------------------------------------------
 
- ! compute hydraulic geometry (width and Manning's "n")
+ ! compute channel parameters (width, depth, Manning's n, and floodplain slope)
  if(hydGeometryOption==compute)then
 
   ! (hydraulic geometry needed for all the routing methods except impulse response function)
@@ -219,7 +221,9 @@ CONTAINS
       onRoute(diffusiveWave) .or. onRoute(muskingumCunge)) then
     do iSeg=1,nSeg
       structSEG(iSeg)%var(ixSEG%width)%dat(1) = wscale * sqrt(structSEG(iSeg)%var(ixSEG%totalArea)%dat(1))  ! channel width (m)
+      structSEG(iSeg)%var(ixSEG%depth)%dat(1) = channelDepth                                                ! channel bankfull depth (m)
       structSEG(iSeg)%var(ixSEG%man_n)%dat(1) = mann_n                                                      ! Manning's "n" paramater (unitless)
+      structSEG(iSeg)%var(ixSEG%floodplainSlope)%dat(1) = floodplainSlope                                   ! floodplain slope
     end do
   end if
 
@@ -397,6 +401,8 @@ END SUBROUTINE augment_ntopo
    RPARAM_in(iSeg)%R_SLOPE         = max(structSEG(iSeg)%var(ixSEG%slope)%dat(1), min_slope)
    RPARAM_in(iSeg)%R_MAN_N         =     structSEG(iSeg)%var(ixSEG%man_n)%dat(1)
    RPARAM_in(iSeg)%R_WIDTH         =     structSEG(iSeg)%var(ixSEG%width)%dat(1)
+   RPARAM_in(iSeg)%R_DEPTH         =     structSEG(iSeg)%var(ixSEG%depth)%dat(1)
+   RPARAM_in(iSeg)%FLDP_SLOPE      =     structSEG(iSeg)%var(ixSEG%floodplainSlope)%dat(1)
 
    if (is_lake_sim) then
      RPARAM_in(iSeg)%D03_MaxStorage  =     structSEG(iSeg)%var(ixSEG%D03_MaxStorage)%dat(1)

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -81,77 +81,79 @@ MODULE var_lookup
   integer(i4b)     :: slope            = integerMissing  !  2. slope of segment (-)
   integer(i4b)     :: width            = integerMissing  !  3. width of segment (m)
   integer(i4b)     :: man_n            = integerMissing  !  4. Manning's n (weird units)
+  integer(i4b)     :: depth            = integerMissing  !  5. bankfull depth (m)
+  integer(i4b)     :: floodplainSlope  = integerMissing  !  6. floodplain slope (-)
   ! contributing HRUs
-  integer(i4b)     :: hruArea          = integerMissing  !  5. contributing area for each HRU (m2)
-  integer(i4b)     :: weight           = integerMissing  !  6. weight assigned to each HRU (-)
+  integer(i4b)     :: hruArea          = integerMissing  !  7. contributing area for each HRU (m2)
+  integer(i4b)     :: weight           = integerMissing  !  8. weight assigned to each HRU (-)
   ! unit hydrograph routing
-  integer(i4b)     :: timeDelayHist    = integerMissing  !  7. time delay histogram for each reach (-)
-  integer(i4b)     :: basArea          = integerMissing  !  8. area of the local HRUs contributing to each reach (m2)
-  integer(i4b)     :: upsArea          = integerMissing  !  9. area above the top of the reach -- zero if headwater (m2)
-  integer(i4b)     :: totalArea        = integerMissing  ! 10. basArea + upsArea -- area at the bottom of the reach (m2)
+  integer(i4b)     :: timeDelayHist    = integerMissing  !  9. time delay histogram for each reach (-)
+  integer(i4b)     :: basArea          = integerMissing  ! 10. area of the local HRUs contributing to each reach (m2)
+  integer(i4b)     :: upsArea          = integerMissing  ! 11. area above the top of the reach -- zero if headwater (m2)
+  integer(i4b)     :: totalArea        = integerMissing  ! 12. basArea + upsArea -- area at the bottom of the reach (m2)
   ! lakes
-  integer(i4b)     :: basUnderLake     = integerMissing  ! 11. Area of basin under lake (m2)
-  integer(i4b)     :: rchUnderLake     = integerMissing  ! 12. Length of reach under lake (m)
+  integer(i4b)     :: basUnderLake     = integerMissing  ! 13. Area of basin under lake (m2)
+  integer(i4b)     :: rchUnderLake     = integerMissing  ! 14. Length of reach under lake (m)
   ! Doll 2003 parameter (Natural lake outflow)
-  integer(i4b)     :: D03_MaxStorage   = integerMissing  ! 13. Lake maximum volume (m3)
-  integer(i4b)     :: D03_Coefficient  = integerMissing  ! 14.
-  integer(i4b)     :: D03_Power        = integerMissing  ! 15.
-  integer(i4b)     :: D03_S0           = integerMissing  ! 16.
+  integer(i4b)     :: D03_MaxStorage   = integerMissing  ! 15. Lake maximum volume (m3)
+  integer(i4b)     :: D03_Coefficient  = integerMissing  ! 16.
+  integer(i4b)     :: D03_Power        = integerMissing  ! 17.
+  integer(i4b)     :: D03_S0           = integerMissing  ! 18.
   ! HYPE parameter (reservoir outflow)
-  integer(i4b)     :: HYP_E_emr        = integerMissing  ! 17.
-  integer(i4b)     :: HYP_E_lim        = integerMissing  ! 18.
-  integer(i4b)     :: HYP_E_min        = integerMissing  ! 19.
-  integer(i4b)     :: HYP_E_zero       = integerMissing  ! 20.
-  integer(i4b)     :: HYP_Qrate_emr    = integerMissing  ! 21.
-  integer(i4b)     :: HYP_Erate_emr    = integerMissing  ! 22.
-  integer(i4b)     :: HYP_Qrate_prim   = integerMissing  ! 23.
-  integer(i4b)     :: HYP_Qrate_amp    = integerMissing  ! 24.
-  integer(i4b)     :: HYP_Qrate_phs    = integerMissing  ! 25.
-  integer(i4b)     :: HYP_prim_F       = integerMissing  ! 26.
-  integer(i4b)     :: HYP_A_avg        = integerMissing  ! 27.
+  integer(i4b)     :: HYP_E_emr        = integerMissing  ! 19.
+  integer(i4b)     :: HYP_E_lim        = integerMissing  ! 20.
+  integer(i4b)     :: HYP_E_min        = integerMissing  ! 21.
+  integer(i4b)     :: HYP_E_zero       = integerMissing  ! 22.
+  integer(i4b)     :: HYP_Qrate_emr    = integerMissing  ! 23.
+  integer(i4b)     :: HYP_Erate_emr    = integerMissing  ! 24.
+  integer(i4b)     :: HYP_Qrate_prim   = integerMissing  ! 25.
+  integer(i4b)     :: HYP_Qrate_amp    = integerMissing  ! 26.
+  integer(i4b)     :: HYP_Qrate_phs    = integerMissing  ! 27.
+  integer(i4b)     :: HYP_prim_F       = integerMissing  ! 28.
+  integer(i4b)     :: HYP_A_avg        = integerMissing  ! 29.
   ! Hanasaki 2006 parameter (reservoir outlfow)
-  integer(i4b)     :: H06_Smax         = integerMissing  ! 28.
-  integer(i4b)     :: H06_alpha        = integerMissing  ! 29.
-  integer(i4b)     :: H06_envfact      = integerMissing  ! 30.
-  integer(i4b)     :: H06_S_ini        = integerMissing  ! 31.
-  integer(i4b)     :: H06_c1           = integerMissing  ! 32.
-  integer(i4b)     :: H06_c2           = integerMissing  ! 33.
-  integer(i4b)     :: H06_exponent     = integerMissing  ! 34.
-  integer(i4b)     :: H06_denominator  = integerMissing  ! 35.
-  integer(i4b)     :: H06_c_compare    = integerMissing  ! 36.
-  integer(i4b)     :: H06_frac_Sdead   = integerMissing  ! 37.
-  integer(i4b)     :: H06_E_rel_ini    = integerMissing  ! 38.
-  integer(i4b)     :: H06_I_Jan        = integerMissing  ! 39.
-  integer(i4b)     :: H06_I_Feb        = integerMissing  ! 40.
-  integer(i4b)     :: H06_I_Mar        = integerMissing  ! 41.
-  integer(i4b)     :: H06_I_Apr        = integerMissing  ! 42.
-  integer(i4b)     :: H06_I_May        = integerMissing  ! 43.
-  integer(i4b)     :: H06_I_Jun        = integerMissing  ! 44.
-  integer(i4b)     :: H06_I_Jul        = integerMissing  ! 45.
-  integer(i4b)     :: H06_I_Aug        = integerMissing  ! 46.
-  integer(i4b)     :: H06_I_Sep        = integerMissing  ! 47.
-  integer(i4b)     :: H06_I_Oct        = integerMissing  ! 48.
-  integer(i4b)     :: H06_I_Nov        = integerMissing  ! 49.
-  integer(i4b)     :: H06_I_Dec        = integerMissing  ! 50.
-  integer(i4b)     :: H06_D_Jan        = integerMissing  ! 51.
-  integer(i4b)     :: H06_D_Feb        = integerMissing  ! 52.
-  integer(i4b)     :: H06_D_Mar        = integerMissing  ! 53.
-  integer(i4b)     :: H06_D_Apr        = integerMissing  ! 54.
-  integer(i4b)     :: H06_D_May        = integerMissing  ! 55.
-  integer(i4b)     :: H06_D_Jun        = integerMissing  ! 56.
-  integer(i4b)     :: H06_D_Jul        = integerMissing  ! 57.
-  integer(i4b)     :: H06_D_Aug        = integerMissing  ! 58.
-  integer(i4b)     :: H06_D_Sep        = integerMissing  ! 59.
-  integer(i4b)     :: H06_D_Oct        = integerMissing  ! 60.
-  integer(i4b)     :: H06_D_Nov        = integerMissing  ! 61.
-  integer(i4b)     :: H06_D_Dec        = integerMissing  ! 62.
-  integer(i4b)     :: H06_purpose      = integerMissing  ! 63.
-  integer(i4b)     :: H06_I_mem_F      = integerMissing  ! 64.
-  integer(i4b)     :: H06_D_mem_F      = integerMissing  ! 65.
-  integer(i4b)     :: H06_I_mem_L      = integerMissing  ! 66.
-  integer(i4b)     :: H06_D_mem_L      = integerMissing  ! 67.
+  integer(i4b)     :: H06_Smax         = integerMissing  ! 30.
+  integer(i4b)     :: H06_alpha        = integerMissing  ! 31.
+  integer(i4b)     :: H06_envfact      = integerMissing  ! 32.
+  integer(i4b)     :: H06_S_ini        = integerMissing  ! 33.
+  integer(i4b)     :: H06_c1           = integerMissing  ! 34.
+  integer(i4b)     :: H06_c2           = integerMissing  ! 35.
+  integer(i4b)     :: H06_exponent     = integerMissing  ! 36.
+  integer(i4b)     :: H06_denominator  = integerMissing  ! 37.
+  integer(i4b)     :: H06_c_compare    = integerMissing  ! 38.
+  integer(i4b)     :: H06_frac_Sdead   = integerMissing  ! 39.
+  integer(i4b)     :: H06_E_rel_ini    = integerMissing  ! 40.
+  integer(i4b)     :: H06_I_Jan        = integerMissing  ! 41.
+  integer(i4b)     :: H06_I_Feb        = integerMissing  ! 42.
+  integer(i4b)     :: H06_I_Mar        = integerMissing  ! 43.
+  integer(i4b)     :: H06_I_Apr        = integerMissing  ! 44.
+  integer(i4b)     :: H06_I_May        = integerMissing  ! 45.
+  integer(i4b)     :: H06_I_Jun        = integerMissing  ! 46.
+  integer(i4b)     :: H06_I_Jul        = integerMissing  ! 47.
+  integer(i4b)     :: H06_I_Aug        = integerMissing  ! 48.
+  integer(i4b)     :: H06_I_Sep        = integerMissing  ! 49.
+  integer(i4b)     :: H06_I_Oct        = integerMissing  ! 50.
+  integer(i4b)     :: H06_I_Nov        = integerMissing  ! 51.
+  integer(i4b)     :: H06_I_Dec        = integerMissing  ! 52.
+  integer(i4b)     :: H06_D_Jan        = integerMissing  ! 53.
+  integer(i4b)     :: H06_D_Feb        = integerMissing  ! 54.
+  integer(i4b)     :: H06_D_Mar        = integerMissing  ! 55.
+  integer(i4b)     :: H06_D_Apr        = integerMissing  ! 56.
+  integer(i4b)     :: H06_D_May        = integerMissing  ! 57.
+  integer(i4b)     :: H06_D_Jun        = integerMissing  ! 58.
+  integer(i4b)     :: H06_D_Jul        = integerMissing  ! 59.
+  integer(i4b)     :: H06_D_Aug        = integerMissing  ! 60.
+  integer(i4b)     :: H06_D_Sep        = integerMissing  ! 61.
+  integer(i4b)     :: H06_D_Oct        = integerMissing  ! 62.
+  integer(i4b)     :: H06_D_Nov        = integerMissing  ! 63.
+  integer(i4b)     :: H06_D_Dec        = integerMissing  ! 64.
+  integer(i4b)     :: H06_purpose      = integerMissing  ! 65.
+  integer(i4b)     :: H06_I_mem_F      = integerMissing  ! 66.
+  integer(i4b)     :: H06_D_mem_F      = integerMissing  ! 67.
+  integer(i4b)     :: H06_I_mem_L      = integerMissing  ! 68.
+  integer(i4b)     :: H06_D_mem_L      = integerMissing  ! 69.
   ! constraints
-  integer(i4b)     :: minFlow       = integerMissing     ! 68. minimum environmental flow (m3/s)
+  integer(i4b)     :: minFlow       = integerMissing     ! 70. minimum environmental flow (m3/s)
  endtype iLook_SEG
  ! ***********************************************************************************************************
  ! ** define variables for the network topology (all are unitless)
@@ -275,7 +277,7 @@ MODULE var_lookup
                                                                          31,32,33,34,35,36,37,38,39,40, &
                                                                          41,42,43,44,45,46,47,48,49,50, &
                                                                          51,52,53,54,55,56,57,58,59,60, &
-                                                                         61,62,63,64,65,66,67,68)
+                                                                         61,62,63,64,65,66,67,68,69,70)
  type(iLook_NTOPO)    ,public,parameter :: ixNTOPO     = iLook_NTOPO    ( 1, 2, 3, 4, 5, 6, 7, 8, 9,10, &
                                                                          11,12,13,14,15,16,17,18,19,20, &
                                                                          21,22)

--- a/route/build/src/water_balance.f90
+++ b/route/build/src/water_balance.f90
@@ -75,7 +75,7 @@ CONTAINS
   ! out flux
   Qout         = -1._dp *RCHFLX_in%ROUTE(ixRoute)%REACH_Q *dt
   Qtake_demand = -1._dp *RCHFLX_in%REACH_WM_FLUX *dt
-  Qtake_actual = -1._dp *RCHFLX_in%REACH_WM_FLUX_actual *dt
+  Qtake_actual = -1._dp *RCHFLX_in%ROUTE(ixRoute)%REACH_WM_FLUX_actual *dt
   if (lakeFlag) then
     evapo    = -1._dp *RCHFLX_in%basinevapo *dt
   else
@@ -236,7 +236,7 @@ CONTAINS
           water_budget(3) = water_budget(3) + RCHFLX_in(ix)%basinprecip *dt
         end if
         ! out flux
-        water_budget(4) = water_budget(4) - RCHFLX_in(ix)%REACH_WM_FLUX_actual *dt
+        water_budget(4) = water_budget(4) - RCHFLX_in(ix)%ROUTE(ixRoute)%REACH_WM_FLUX_actual *dt
         if (NETOPO_in(ix)%isLake) then
           water_budget(5) = water_budget(5) - RCHFLX_in(ix)%basinevapo *dt
         end if


### PR DESCRIPTION
This PR includes a few different topics.

1. Added bankfull depth and floodplain slope as a reach properties (to be used for flood volume, and currently populate with spatially constant values)
2. Move actual REACH_WM_FLUX under ROUTE data structure so it can be tracked independently for each routing method
3. conditions where KWT state arrays are initialized at lake; using `is_lake_sim`  in addition to `isLake` variable (for gnu compiler).


This PR will enable CTSM-mizuRoute with irrigation on (w/ and w/o lake). 

