### PR TITLE
Enable to run at user specified routing time step rather than using coupling_frequency

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -21,7 +21,6 @@ MODULE RtmMod
   USE public_var,   ONLY: secprday                   ! second per day
   USE public_var,   ONLY: dt                         ! routing time step
   USE public_var,   ONLY: iulog
-  USE public_var,   ONLY: verySmall                  ! minimum values >0.0
   USE public_var,   ONLY: qgwl_runoff_option
   USE public_var,   ONLY: bypass_routing_option
   USE globalData,   ONLY: iam        => pid
@@ -123,7 +122,7 @@ CONTAINS
     !-------------------------------------------------------
     delt_coupling = coupling_period*secprday   ! day -> sec
 
-    if (abs(mod(delt_coupling, dt)-0._r8)>verySmall) then
+    if (abs(mod(delt_coupling, dt)-0._r8)>0._r8) then
       if (masterproc) then
         write(iulog,'(2a,g20.12,a)') trim(subname),' mizuRoute coupling period ', delt_coupling, '[sec]'
         write(iulog,'(2a,g20.12,a)') trim(subname),' mizuRoute simulation step <dt_qstim> ', dt, '[sec]'

--- a/route/build/cpl/RtmVar.F90
+++ b/route/build/cpl/RtmVar.F90
@@ -51,7 +51,9 @@ MODULE RtmVar
   logical,           public            :: do_flood       = .false.                  !
   character(len=CL), public            :: nrevsn_rtm     = ' '                      ! restart data file name for branch run
   real(r8),          public            :: river_depth_minimum = 1.e-1               ! minimum river depth for water take [mm]
-  integer,           public            :: coupling_period                           ! coupling period
+  real(r8),          public            :: delt_coupling                             ! coupling period [sec]
+  integer,           public            :: nsub                                      ! number of subcyling for rof simulation per coupling
+  integer,           public            :: coupling_period                           ! coupling period [day]
   integer,           public            :: rtmhist_ndens  = 1                        ! namelist: output density of netcdf history files
   integer,           public            :: rtmhist_mfilt  = 30                       ! namelist: number of time samples per tape
   integer,           public            :: rtmhist_nhtfrq = 0                        ! namelist: history write freq(0=monthly)


### PR DESCRIPTION
**This is for CESM coupled run.**

So far, mizuRoute runs at the same time step as coupling time step (== coupling frequency, now set to 1 days). IRF routing is ok to run at whatever time step.   `dt_qsim` In control file is reset to coupling frequency (`coupling_period`) in initializing phase.

With this PR,  `dt_qsim` In control file is kept and mizuRoute run at this time step. `dt_qsim` is smaller than `coupling_period`, mizuRoute run with the same runoff input at `nsub` (`coupling_period/dt_qsim`) time, called sub-cycling.  `dt_qsim` should be less than 86400 second.

One caveat. 
Now, after sub-cycling, river volume is computed at last sub-time step is exported to the coupler, but what should be exported would be average over the coupling period?
