### PR TITLE
Refactoring related to PIO decomposition initialization

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -185,6 +185,7 @@ IO = \
     standalone/read_remap.f90 \
     io_rpointfile.f90 \
     read_restart.f90 \
+    pio_decomp_data.f90 \
     write_simoutput_pio.f90 \
     write_restart_pio.f90
 # CORE

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -170,7 +170,7 @@ CONTAINS
     end select
 
     !pio_numiotasks    = shr_pio_(inst_name)    ! there is no function to extract pio_numiotasks in cime/src/drivers/nuops/nems/util/shr_pio_mod.F90
-    pioSystem         = shr_pio_getiosys(inst_name)
+    pioSystem         => shr_pio_getiosys(inst_name)
     pio_rearranger    = shr_pio_getrearranger(inst_name)
     pio_root          = shr_pio_getioroot(inst_name)
 

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -139,7 +139,7 @@ MODULE globalData
   integer(i4b),                    public :: pio_rearranger    = 2              ! 0=>PIO_rearr_none 1=> PIO_rearr_box 2=> PIO_rearr_subset
   integer(i4b),                    public :: pio_root          = 1              ! PIO root
   integer(i4b),                    public :: pio_stride        = 1              ! PIO stride - see PIO documentation for more information
-  type(iosystem_desc_t),           public :: pioSystem                          ! PIO I/O system data
+  type(iosystem_desc_t), pointer,  public :: pioSystem                          ! PIO I/O system data
   ! pio decomposition used for history file variables
   type(io_desc_t),                 public :: ioDesc_hru_float                   ! [hru] (float)
   type(io_desc_t),                 public :: ioDesc_rch_float                   ! [reach] (float)

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -133,31 +133,32 @@ MODULE globalData
   integer(i4b),                    public :: nThreads                           ! number of threads
   logical(lgt),                    public :: masterproc                         ! root logical. root processor => true, other => false
   logical(lgt),                    public :: multiProcs                         ! MPI multi-processors logical. => number of processors>1 true, other => false
-  character(len=strLen),           public :: pio_netcdf_format = "64bit_offset" !
-  character(len=strLen),           public :: pio_typename      = "pnetcdf"      !
-  integer(i4b),                    public :: pio_numiotasks    = -99            !
+  character(len=strLen),           public :: pio_netcdf_format = "64bit_offset" ! netCDF format - use '64bit_offset' for PIO use or 'netCDF-4'
+  character(len=strLen),           public :: pio_typename      = "pnetcdf"      ! netcdf, pnetcdf, netcdf4c, or netcdf4p
+  integer(i4b),                    public :: pio_numiotasks    = -99            ! Number of iotasks (ntasks/stride) - see PIO documentation for more information
   integer(i4b),                    public :: pio_rearranger    = 2              ! 0=>PIO_rearr_none 1=> PIO_rearr_box 2=> PIO_rearr_subset
-  integer(i4b),                    public :: pio_root          = 1              !
-  integer(i4b),                    public :: pio_stride        = 1              !
-  type(iosystem_desc_t), target,   public :: pioSystem                          ! PIO I/O system data
+  integer(i4b),                    public :: pio_root          = 1              ! PIO root
+  integer(i4b),                    public :: pio_stride        = 1              ! PIO stride - see PIO documentation for more information
+  type(iosystem_desc_t),           public :: pioSystem                          ! PIO I/O system data
   ! pio decomposition used for history file variables
-  type(io_desc_t),                 public :: ioDesc_hru_float
-  type(io_desc_t),                 public :: ioDesc_rch_float
-  type(io_desc_t),                 public :: ioDesc_gauge_float
-   ! decomposition used for restart variables
-  type(io_desc_t),                 public :: ioDesc_rch_int
-  type(io_desc_t),                 public :: ioDesc_rch_double
-  type(io_desc_t),                 public :: ioDesc_hist_rch_double
-  type(io_desc_t),                 public :: ioDesc_hru_double
-  type(io_desc_t),                 public :: ioDesc_wave_int
-  type(io_desc_t),                 public :: ioDesc_wave_double
-  type(io_desc_t),                 public :: ioDesc_mesh_kw_double
-  type(io_desc_t),                 public :: ioDesc_mesh_mc_double
-  type(io_desc_t),                 public :: ioDesc_mesh_dw_double
-  type(io_desc_t),                 public :: ioDesc_irf_double
-  type(io_desc_t),                 public :: ioDesc_vol_double
-  type(io_desc_t),                 public :: ioDesc_irf_bas_double
-  integer(i4b),   allocatable,     public :: index_write_gage(:)                !
+  type(io_desc_t),                 public :: ioDesc_hru_float                   ! [hru] (float)
+  type(io_desc_t),                 public :: ioDesc_rch_float                   ! [reach] (float)
+  type(io_desc_t),                 public :: ioDesc_gauge_float                 ! [gauge points] (float)
+  ! decomposition used for restart variables
+  type(io_desc_t),                 public :: ioDesc_rch_int                     ! [reach x ensemble] (integer)
+  type(io_desc_t),                 public :: ioDesc_rch_double                  ! [reach x ensemble] (double precision)
+  type(io_desc_t),                 public :: ioDesc_hist_rch_double             ! [reach] (double precision)
+  type(io_desc_t),                 public :: ioDesc_hru_double                  ! [hru] (double precision)
+  type(io_desc_t),                 public :: ioDesc_wave_int                    ! [reach x max. number of waves x ensemble] (integer)
+  type(io_desc_t),                 public :: ioDesc_wave_double                 ! [reach x max. number of waves x ensemble] (double precision)
+  type(io_desc_t),                 public :: ioDesc_mesh_kw_double              ! [reach x Euler kinematic wave computational meshes x ensemble] (double precision)
+  type(io_desc_t),                 public :: ioDesc_mesh_mc_double              ! [reach x Muskingum-Cunge computational meshes x ensemble] (double precision)
+  type(io_desc_t),                 public :: ioDesc_mesh_dw_double              ! [reach x Duffusive wave computational meshes x ensemble] (double precision)
+  type(io_desc_t),                 public :: ioDesc_irf_double                  ! [reach x IRF future timer-steps x ensemble] (double precision)
+  type(io_desc_t),                 public :: ioDesc_vol_double                  ! [reach x time-bounds x ensemble] (double precision)
+  type(io_desc_t),                 public :: ioDesc_irf_bas_double              ! [reach x basin UH future time-steps x ensemble] (double precision)
+  integer(i4b),   allocatable,     public :: index_write_gage(:)                ! reach indices to gauge points w.r.t. distributed domains
+
   ! ---------- conversion factors -------------------------------------------------------------------
 
   real(dp),                        public :: time_conv                  ! time conversion factor -- used to convert to mm/s

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -139,8 +139,25 @@ MODULE globalData
   integer(i4b),                    public :: pio_rearranger    = 2              ! 0=>PIO_rearr_none 1=> PIO_rearr_box 2=> PIO_rearr_subset
   integer(i4b),                    public :: pio_root          = 1              !
   integer(i4b),                    public :: pio_stride        = 1              !
-  type(iosystem_desc_t),           public :: pioSystem                          ! PIO I/O system data
-
+  type(iosystem_desc_t), target,   public :: pioSystem                          ! PIO I/O system data
+  ! pio decomposition used for history file variables
+  type(io_desc_t),                 public :: ioDesc_hru_float
+  type(io_desc_t),                 public :: ioDesc_rch_float
+  type(io_desc_t),                 public :: ioDesc_gauge_float
+   ! decomposition used for restart variables
+  type(io_desc_t),                 public :: ioDesc_rch_int
+  type(io_desc_t),                 public :: ioDesc_rch_double
+  type(io_desc_t),                 public :: ioDesc_hist_rch_double
+  type(io_desc_t),                 public :: ioDesc_hru_double
+  type(io_desc_t),                 public :: ioDesc_wave_int
+  type(io_desc_t),                 public :: ioDesc_wave_double
+  type(io_desc_t),                 public :: ioDesc_mesh_kw_double
+  type(io_desc_t),                 public :: ioDesc_mesh_mc_double
+  type(io_desc_t),                 public :: ioDesc_mesh_dw_double
+  type(io_desc_t),                 public :: ioDesc_irf_double
+  type(io_desc_t),                 public :: ioDesc_vol_double
+  type(io_desc_t),                 public :: ioDesc_irf_bas_double
+  integer(i4b),   allocatable,     public :: index_write_gage(:)                !
   ! ---------- conversion factors -------------------------------------------------------------------
 
   real(dp),                        public :: time_conv                  ! time conversion factor -- used to convert to mm/s

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -58,6 +58,10 @@ CONTAINS
 
   ! pio system initialization
   if (trim(runMode)=='standalone') then
+
+    allocate(pioSystem, stat=ierr, errmsg=cmessage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage)//': pioSystem'; return; endif
+
     pio_numiotasks = nNodes/pio_stride
     call pio_sys_init(pid, mpicom_route,          & ! input: MPI related parameters
                       pio_stride, pio_numiotasks, & ! input: PIO related parameters

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -28,8 +28,48 @@ public :: init_model
 public :: init_ntopo_data
 public :: init_state_data
 public :: update_time
+public :: init_pio
 
 CONTAINS
+
+ ! *********************************************************************
+ ! public subroutine: initialize pio system and decomposition
+ ! *********************************************************************
+ SUBROUTINE init_pio(pid, nNodes, ierr, message)
+
+  USE pio_utils,       ONLY: pio_sys_init
+  USE globalData,      ONLY: pioSystem
+  USE globalData,      ONLY: mpicom_route
+  USE globalData,      ONLY: pio_numiotasks
+  USE globalData,      ONLY: pio_rearranger
+  USE globalData,      ONLY: pio_root
+  USE globalData,      ONLY: pio_stride
+  USE globalData,      ONLY: runMode
+  USE pio_decomp_data, ONLY: set_pio_decomp
+
+  implicit none
+  ! Argument variables
+  integer(i4b), intent(in)    :: pid              ! proc id
+  integer(i4b), intent(in)    :: nNodes           ! number of procs
+  integer(i4b), intent(out)   :: ierr             ! error code
+  character(*), intent(out)   :: message          ! error message
+  ! local variables
+  character(len=strLen)       :: cmessage         ! error message from subroutine
+
+  ! pio system initialization
+  if (trim(runMode)=='standalone') then
+    pio_numiotasks = nNodes/pio_stride
+    call pio_sys_init(pid, mpicom_route,          & ! input: MPI related parameters
+                      pio_stride, pio_numiotasks, & ! input: PIO related parameters
+                      pio_rearranger, pio_root,   & ! input: PIO related parameters
+                      pioSystem)                    ! output: PIO system descriptors
+  end if
+
+  ! pio domain decomposition
+  call set_pio_decomp(ierr, cmessage)
+  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+ END SUBROUTINE init_pio
 
  ! *********************************************************************
  ! public subroutine: get mpi and omp info
@@ -354,6 +394,9 @@ CONTAINS
       nMolecule%DW_ROUTE = 20
     end if
   end do
+
+  call init_pio(pid, nNodes, ierr, message)
+  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   if (isColdStart) then
     if (masterproc) then

--- a/route/build/src/pio_decomp_data.f90
+++ b/route/build/src/pio_decomp_data.f90
@@ -1,0 +1,334 @@
+MODULE pio_decomp_data
+
+  USE nrtype
+
+  USE var_lookup, ONLY: ixStateDims
+  USE var_lookup, ONLY: ixHFLX
+  USE globalData, ONLY: masterproc
+  USE globalData, ONLY: pid
+  USE globalData, ONLY: ioDesc_hru_float
+  USE globalData, ONLY: ioDesc_rch_float
+  USE globalData, ONLY: ioDesc_gauge_float
+  USE globalData, ONLY: ioDesc_rch_int
+  USE globalData, ONLY: ioDesc_rch_double
+  USE globalData, ONLY: ioDesc_hist_rch_double
+  USE globalData, ONLY: ioDesc_hru_double
+  USE globalData, ONLY: ioDesc_wave_int
+  USE globalData, ONLY: ioDesc_wave_double
+  USE globalData, ONLY: ioDesc_mesh_kw_double
+  USE globalData, ONLY: ioDesc_mesh_mc_double
+  USE globalData, ONLY: ioDesc_mesh_dw_double
+  USE globalData, ONLY: ioDesc_irf_double
+  USE globalData, ONLY: ioDesc_vol_double
+  USE globalData, ONLY: ioDesc_irf_bas_double
+  USE globalData, ONLY: index_write_gage
+
+  private
+
+  public::set_pio_decomp
+  public::get_compdof_all_network ! used in write_restart_pio
+
+CONTAINS
+
+  SUBROUTINE set_pio_decomp(ierr, message)
+
+    USE public_var, ONLY: doesBasinRoute
+    USE public_var, ONLY: impulseResponseFunc
+    USE public_var, ONLY: kinematicWaveTracking
+    USE public_var, ONLY: kinematicWave
+    USE public_var, ONLY: muskingumCunge
+    USE public_var, ONLY: diffusiveWave
+    USE globalData, ONLY: meta_stateDims         !
+    USE globalData, ONLY: meta_hflx         !
+    USE globalData, ONLY: nRch                   !
+    USE globalData, ONLY: nHRU                   !
+    USE globalData, ONLY: nEns                   !
+    USE globalData, ONLY: onRoute                !
+    USE globalData, ONLY: gage_data
+    USE globalData, ONLY: pioSystem              !
+    USE pio_utils,  ONLY: pio_decomp
+    USE pio_utils,  ONLY: ncd_int
+    USE pio_utils,  ONLY: ncd_float
+    USE pio_utils,  ONLY: ncd_double
+
+    ! populate state netCDF dimension size
+    USE public_var, ONLY: MAXQPAR, outputAtGage
+    USE globalData, ONLY: nMolecule
+    USE globalData, ONLY: maxtdh           ! maximum unit-hydrogrph future time
+    USE globalData, ONLY: FRAC_FUTURE      ! To get size of q future for basin IRF
+
+    implicit none
+    ! argument variables
+    integer(i4b),   intent(out)     :: ierr                ! error code
+    character(*),   intent(out)     :: message             ! error message
+    ! local variables
+    integer(i4b), allocatable       :: compdof_rch(:)      !
+    integer(i4b), allocatable       :: compdof_rch_gage(:) !
+    integer(i4b), allocatable       :: compdof_hru(:)      !
+    character(len=strLen)           :: cmessage            ! error message of downwind routine
+
+    ierr=0; message='set_pio_decomp/'
+
+    associate(ndim_seg      => meta_stateDims(ixStateDims%seg)%dimLength,      & !
+              ndim_hru      => meta_stateDims(ixStateDims%hru)%dimLength,      & !
+              ndim_ens      => meta_stateDims(ixStateDims%ens)%dimLength,      & !
+              ndim_hist_fil => meta_stateDims(ixStateDims%hist_fil)%dimLength, & !
+              ndim_tdh      => meta_stateDims(ixStateDims%tdh)%dimLength,      & ! maximum future q time steps among basins
+              ndim_tdh_irf  => meta_stateDims(ixStateDims%tdh_irf)%dimLength,  & ! maximum future q time steps among reaches
+              ndim_tbound   => meta_stateDims(ixStateDims%tbound)%dimLength,   & ! time bound
+              ndim_Mesh_kw  => meta_stateDims(ixStateDims%mol_kw)%dimLength,   & ! kw_finite difference mesh points
+              ndim_Mesh_mc  => meta_stateDims(ixStateDims%mol_mc)%dimLength,   & ! mc_finite difference mesh points
+              ndim_Mesh_dw  => meta_stateDims(ixStateDims%mol_dw)%dimLength,   & ! dw_finite difference mesh points
+              ndim_Wave     => meta_stateDims(ixStateDims%wave)%dimLength)      ! maximum waves allowed in a reach
+
+    ! set state file dimension length
+    ndim_seg = nRch
+    ndim_hru = nHru
+    ndim_ens = nEns
+    ndim_tbound = 2
+    if (doesBasinRoute==1)              ndim_tdh = size(FRAC_FUTURE)
+    if (onRoute(impulseResponseFunc))   ndim_tdh_irf = maxtdh
+    if (onRoute(kinematicWave))         ndim_Mesh_kw = nMolecule%KW_ROUTE
+    if (onRoute(muskingumCunge))        ndim_Mesh_mc = nMolecule%MC_ROUTE
+    if (onRoute(diffusiveWave))         ndim_Mesh_dw = nMolecule%DW_ROUTE
+    if (onRoute(kinematicWaveTracking)) ndim_wave = MAXQPAR
+    if (outputAtGage) then
+      ndim_hist_fil= 2
+    else
+      ndim_hist_fil= 1
+    end if
+
+    ! compute PIO domain decomposition for entire network
+    call get_compdof_all_network(compdof_rch, compdof_hru)
+
+    ! For gauge history files
+    if (outputAtGage) then
+      call get_compdof_gage(compdof_rch_gage, ierr, cmessage)
+
+      call pio_decomp(pioSystem,         & ! inout: pio system descriptor
+                      ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [gage_data%nGage], & ! input: dimension length == global array size
+                      compdof_rch_gage,  & ! input: local->global mapping
+                      ioDesc_gauge_float)
+    end if
+
+    ! For history files for entire network ---------
+    call pio_decomp(pioSystem,         & ! inout: pio system descriptor
+                    ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                    [ndim_seg],        & ! input: dimension length == global array size
+                    compdof_rch,       & ! input: local->global mapping
+                    ioDesc_rch_float)
+
+    call pio_decomp(pioSystem,         & ! inout: pio system descriptor
+                    ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                    [ndim_hru],        & ! input: dimension length == global array size
+                    compdof_hru,       & ! input: local->global mapping
+                    ioDesc_hru_float)
+
+    ! For restart file ----------
+    ! type: float  dim: [dim_seg, dim_ens]  -- channel runoff coming from hru
+    call pio_decomp(pioSystem,              & ! inout: pio system descriptor
+                    ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                    [ndim_seg,ndim_ens],    & ! input: dimension length == global array size
+                    compdof_rch,            & ! input:
+                    ioDesc_rch_double)
+
+    ! type: int  dim: [dim_seg, dim_ens]  -- number of wave or uh future time steps
+    call pio_decomp(pioSystem,              & ! inout: pio system descriptor
+                    ncd_int,                & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                    [ndim_seg,ndim_ens],    & ! input: dimension length == global array size
+                    compdof_rch,            & ! input:
+                    ioDesc_rch_int)
+
+    ! type: float  dim: [dim_seg, dim_ens]  -- channel runoff coming from hru
+    call pio_decomp(pioSystem,              & ! inout: pio system descriptor
+                    ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                    [ndim_seg],             & ! input: dimension length == global array size
+                    compdof_rch,            & ! input:
+                    ioDesc_hist_rch_double)
+
+    if (meta_hflx(ixHFLX%basRunoff)%varFile) then
+      ! type: single precision float  dim: [dim_hru,dim_ens]  --
+      call pio_decomp(pioSystem,              & ! inout: pio system descriptor
+                      ncd_double,             & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [ndim_hru],             & ! input: dimension length == global array size
+                      compdof_hru,            & ! input:
+                      ioDesc_hru_double)
+    end if
+
+    if (doesBasinRoute==1) then
+      ! type: float dim: [dim_seg, dim_tdh_irf]
+      call pio_decomp(pioSystem,                     & ! inout: pio system descriptor
+                      ncd_double,                    & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [ndim_seg,ndim_tdh,ndim_ens],  & ! input: dimension length == global array size
+                      compdof_rch,                   & ! input:
+                      ioDesc_irf_bas_double)
+    end if
+
+    if (onRoute(impulseResponseFunc))then
+      ! type: float dim: [dim_seg, dim_tdh_irf, dim_ens]
+      call pio_decomp(pioSystem,                         & ! inout: pio system descriptor
+                      ncd_double,                        & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [ndim_seg,ndim_tdh_irf,ndim_ens],  & ! input: dimension length == global array size
+                      compdof_rch,                       & ! input:
+                      ioDesc_irf_double)
+
+      ! type: float dim: [dim_seg, dim_ens]
+      call pio_decomp(pioSystem,                         & ! inout: pio system descriptor
+                      ncd_double,                        & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [ndim_seg,ndim_tbound,ndim_ens],   & ! input: dimension length == global array size
+                      compdof_rch,                       & ! input:
+                      ioDesc_vol_double)
+    end if
+
+    if (onRoute(kinematicWaveTracking)) then
+      ! type: int, dim: [dim_seg, dim_wave, dim_ens]
+      call pio_decomp(pioSystem,                         & ! inout: pio system descriptor
+                      ncd_int,                           & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [ndim_seg,ndim_wave,ndim_ens],     & ! input: dimension length == global array size
+                      compdof_rch,                       & ! input:
+                      ioDesc_wave_int)
+
+      ! type: float, dim: [dim_seg, dim_wave, dim_ens]
+      call pio_decomp(pioSystem,                         & ! inout: pio system descriptor
+                      ncd_double,                        & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [ndim_seg,ndim_wave,ndim_ens],     & ! input: dimension length == global array size
+                      compdof_rch,                       & ! input:
+                      ioDesc_wave_double)
+    end if
+
+    if (onRoute(kinematicWave)) then
+      ! type: float, dim: [dim_seg, dim_mesh, dim_ens]
+      call pio_decomp(pioSystem,                         & ! inout: pio system descriptor
+                      ncd_double,                        & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [ndim_seg,ndim_Mesh_kw,ndim_ens],  & ! input: dimension length == global array size
+                      compdof_rch,                       & ! input:
+                      ioDesc_mesh_kw_double)
+    end if
+
+    if (onRoute(muskingumCunge)) then
+      ! type: float, dim: [dim_seg, dim_mesh, dim_ens]
+      call pio_decomp(pioSystem,                         & ! inout: pio system descriptor
+                      ncd_double,                        & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [ndim_seg,ndim_Mesh_mc,ndim_ens],  & ! input: dimension length == global array size
+                      compdof_rch,                       & ! input:
+                      ioDesc_mesh_mc_double)
+    end if
+
+    if (onRoute(diffusiveWave)) then
+      ! type: float, dim: [dim_seg, dim_mesh, dim_ens]
+      call pio_decomp(pioSystem,                         & ! inout: pio system descriptor
+                      ncd_double,                        & ! input: data type (pio_int, pio_real, pio_double, pio_char)
+                      [ndim_seg,ndim_Mesh_dw,ndim_ens],  & ! input: dimension length == global array size
+                      compdof_rch,                       & ! input:
+                      ioDesc_mesh_dw_double)
+    end if
+
+    end associate
+
+  END SUBROUTINE set_pio_decomp
+
+  ! *********************************************************************
+  ! private subroutine: get pio local-global mapping data
+  ! *********************************************************************
+  SUBROUTINE get_compdof_all_network(compdof_rch, compdof_hru)
+
+    USE globalData,        ONLY: hru_per_proc      ! number of hrus assigned to each proc (size = num of procs+1)
+    USE globalData,        ONLY: rch_per_proc      ! number of reaches assigned to each proc (size = num of procs+1)
+    USE nr_utils,          ONLY: arth
+
+    implicit none
+    ! Argument variables
+    integer(i4b), allocatable, intent(out) :: compdof_rch(:) !
+    integer(i4b), allocatable, intent(out) :: compdof_hru(:) !
+    ! Local variables
+    integer(i4b)                :: ix1, ix2               ! frst and last indices of global array for local array chunk
+
+    if (masterproc) then
+      allocate(compdof_rch(sum(rch_per_proc(-1:pid))))
+      allocate(compdof_hru(sum(hru_per_proc(-1:pid))))
+    else
+      allocate(compdof_rch(rch_per_proc(pid)))
+      allocate(compdof_hru(hru_per_proc(pid)))
+    end if
+
+    ! For reach flux/volume
+    if (masterproc) then
+      ix1 = 1
+    else
+      ix1 = sum(rch_per_proc(-1:pid-1))+1
+    endif
+    ix2 = sum(rch_per_proc(-1:pid))
+    compdof_rch = arth(ix1, 1, ix2-ix1+1)
+
+    ! For HRU flux/volume
+    if (masterproc) then
+      ix1 = 1
+    else
+      ix1 = sum(hru_per_proc(-1:pid-1))+1
+    endif
+    ix2 = sum(hru_per_proc(-1:pid))
+    compdof_hru = arth(ix1, 1, ix2-ix1+1)
+
+  END SUBROUTINE get_compdof_all_network
+
+  ! *********************************************************************
+  ! private subroutine: get pio local-global mapping data
+  ! *********************************************************************
+  SUBROUTINE get_compdof_gage(compdof_rch, ierr, message)
+
+    USE globalData, ONLY: rch_per_proc        ! number of reaches assigned to each proc (size = num of procs+1)
+    USE globalData, ONLY: nRch_mainstem       ! number of mainstem reaches
+    USE globalData, ONLY: nTribOutlet         ! number of tributary outlets flowing to the mainstem
+    USE globalData, ONLY: NETOPO_main         ! mainstem Reach neteork
+    USE globalData, ONLY: NETOPO_trib         ! tributary Reach network
+    USE globalData, ONLY: gage_data
+    USE process_gage_meta, ONLY: reach_subset
+
+    implicit none
+    ! Argument variables
+    integer(i4b), allocatable, intent(out) :: compdof_rch(:)   !
+    integer(i4b), intent(out)              :: ierr             ! error code
+    character(*), intent(out)              :: message          ! error message
+    ! Local variables
+    integer(i4b)                           :: ix
+    integer(i4b)                           :: nRch_local
+    integer(i4b),allocatable               :: reachID_local(:) !
+    character(len=strLen)                  :: cmessage         ! error message of downwind routine
+
+    ierr=0; message='get_compdof_gage/'
+
+    ! Only For reach flux/volume
+    if (masterproc) then
+      nRch_local = nRch_mainstem+rch_per_proc(0)
+      allocate(reachID_local(nRch_local), stat=ierr, errmsg=cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [reachID_local]'; return; endif
+
+      if (nRch_mainstem>0)   reachID_local(1:nRch_mainstem) = NETOPO_main(1:nRch_mainstem)%REACHID
+      if (rch_per_proc(0)>0) reachID_local(nRch_mainstem+1:nRch_local) = NETOPO_trib(:)%REACHID
+    else
+      nRch_local = rch_per_proc(pid)
+      allocate(reachID_local(nRch_local), stat=ierr, errmsg=cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [reachID_local]'; return; endif
+      reachID_local = NETOPO_trib(:)%REACHID
+    endif
+
+    call reach_subset(reachID_local, gage_data, ierr, cmessage, compdof=compdof_rch, index2=index_write_gage)
+    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+    ! Need to adjust tributary indices in root processor
+    ! This is because RCHFLX has three components in the order: mainstem, halo, tributary
+    ! mainstem (1,2,..,nRch_mainstem),
+    ! halo(nRch_mainstem+1,..,nRch_mainstem+nTribOutlet), and
+    ! tributary(nRch_mainstem+nTribOutlet+1,...,nRch_total)
+    ! index_write_gage is computed based on reachID consisting of mainstem and tributary
+    if (masterproc) then
+      do ix=1,size(index_write_gage)
+        if (index_write_gage(ix)<=nRch_mainstem) cycle
+        index_write_gage(ix) = index_write_gage(ix) + nTribOutlet
+      end do
+    end if
+
+  END SUBROUTINE get_compdof_gage
+
+END MODULE pio_decomp_data

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -1,5 +1,4 @@
 MODULE model_setup
-
 USE nrtype
 USE public_var,        ONLY: iulog
 USE public_var,        ONLY: debug
@@ -10,7 +9,6 @@ USE nr_utils,          ONLY: match_index
 USE nr_utils,          ONLY: arth
 USE nr_utils,          ONLY: unique         ! get unique element array
 USE nr_utils,          ONLY: indexx         ! get rank of data value
-USE pio_utils
 
 implicit none
 
@@ -55,12 +53,6 @@ CONTAINS
 
    USE public_var,          ONLY: continue_run        ! T-> append output in existing history files. F-> write output in new history file
    USE globalData,          ONLY: mpicom_route
-   USE globalData,          ONLY: pio_numiotasks
-   USE globalData,          ONLY: pio_rearranger
-   USE globalData,          ONLY: pio_root
-   USE globalData,          ONLY: pio_stride
-   USE globalData,          ONLY: pioSystem
-   USE globalData,          ONLY: runMode
    USE globalData,          ONLY: version             ! mizuRoute version
    USE globalData,          ONLY: gitBranch           ! git branch
    USE globalData,          ONLY: gitHash             ! git commit hash
@@ -91,15 +83,6 @@ CONTAINS
 #if defined(BRANCH)
   gitBranch=BRANCH
 #endif
-
-   ! pio initialization
-   if (trim(runMode)=='standalone') then
-     pio_numiotasks = nNodes/pio_stride
-     call pio_sys_init(pid, mpicom_route,          & ! input: MPI related parameters
-                       pio_stride, pio_numiotasks, & ! input: PIO related parameters
-                       pio_rearranger, pio_root,   & ! input: PIO related parameters
-                       pioSystem)                    ! output: PIO system descriptors
-   end if
 
    ! runoff input files initialization
    call init_inFile_pop(ierr, cmessage)

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -66,9 +66,6 @@ USE globalData,        ONLY: ioDesc_irf_bas_double
 
 implicit none
 
-! The following variables used only in this module
-type(file_desc_t)    :: pioFileDescState     ! contains data identifying the file
-
 integer(i4b),    parameter :: currTimeStep = 1
 integer(i4b),    parameter :: nextTimeStep = 2
 
@@ -177,6 +174,7 @@ CONTAINS
   integer(i4b),   intent(out)          :: ierr             ! error code
   character(*),   intent(out)          :: message          ! error message
   ! local variables
+  type(file_desc_t)                    :: pioFileDescState ! pio file descriptor
   character(len=strLen)                :: cmessage         ! error message of downwind routine
 
   ierr=0; message='restart_output/'
@@ -184,10 +182,10 @@ CONTAINS
   call restart_fname(rfileout, nextTimeStep, ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-  call define_state_nc(rfileout, ierr, cmessage)
+  call define_state_nc(rfileout, pioFileDescState, ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-  call write_state_nc(rfileout, ierr, cmessage)
+  call write_state_nc(rfileout, pioFileDescState, ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   call io_rpfile('w', ierr, cmessage)
@@ -253,6 +251,7 @@ CONTAINS
  ! subroutine: define restart NetCDF file
  ! *********************************************************************
  SUBROUTINE define_state_nc(fname,           &  ! input: filename
+                            pioFileDesc,     &  ! inout: pio file descriptor
                             ierr, message)      ! output: error control
 
  USE public_var, ONLY: time_units               ! time units (seconds, hours, or days)
@@ -267,12 +266,11 @@ CONTAINS
 
  implicit none
  ! argument variables
- character(*),   intent(in)      :: fname            ! filename
- integer(i4b),   intent(out)     :: ierr             ! error code
- character(*),   intent(out)     :: message          ! error message
+ character(*),      intent(in)       :: fname            ! filename
+ type(file_desc_t), intent(inout)    :: pioFileDesc      ! pio file descriptor
+ integer(i4b),      intent(out)      :: ierr             ! error code
+ character(*),      intent(out)      :: message          ! error message
  ! local variables
- integer(i4b), allocatable       :: compdof_rch(:)      !
- integer(i4b), allocatable       :: compdof_hru(:)      !
  integer(i4b)                    :: jDim             ! loop index for dimension
  integer(i4b)                    :: ixDim_common(6)  ! custom dimension ID array
  character(len=strLen)           :: cmessage         ! error message of downwind routine
@@ -288,7 +286,7 @@ CONTAINS
  ! ----------------------------------
  ! Create file
  ! ----------------------------------
- call createFile(pioSystem, trim(fname), pio_typename, pio_netcdf_format, pioFileDescState, ierr, cmessage)
+ call createFile(pioSystem, trim(fname), pio_typename, pio_netcdf_format, pioFileDesc, ierr, cmessage)
  if(ierr/=0)then; message=trim(cmessage)//'cannot create state netCDF'; return; endif
 
  ! For common dimension/variables - seg id, time, time-bound -----------
@@ -299,32 +297,32 @@ CONTAINS
  ! ----------------------------------
  do jDim = 1,size(ixDim_common)
   associate(ixDim => ixDim_common(jDim))
-  call def_dim(pioFileDescState, trim(meta_stateDims(ixDim)%dimName), meta_stateDims(ixDim)%dimLength, meta_stateDims(ixDim)%dimId)
+  call def_dim(pioFileDesc, trim(meta_stateDims(ixDim)%dimName), meta_stateDims(ixDim)%dimLength, meta_stateDims(ixDim)%dimId)
   end associate
  end do
 
  ! ----------------------------------
  ! Define variable
  ! ----------------------------------
- call def_var(pioFileDescState, 'nNodes', ncd_int, ierr, cmessage, vdesc='Number of MPI tasks',  vunit='-' )
+ call def_var(pioFileDesc, 'nNodes', ncd_int, ierr, cmessage, vdesc='Number of MPI tasks',  vunit='-' )
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call def_var(pioFileDescState, 'nt', ncd_int, ierr, cmessage, vdesc='Number of current acculated time steps in history variable',  vunit='-' )
+ call def_var(pioFileDesc, 'nt', ncd_int, ierr, cmessage, vdesc='Number of current acculated time steps in history variable',  vunit='-' )
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call def_var(pioFileDescState, 'reachID', ncd_int, ierr, cmessage, pioDimId=[dim_seg], vdesc='reach ID',  vunit='-' )
+ call def_var(pioFileDesc, 'reachID', ncd_int, ierr, cmessage, pioDimId=[dim_seg], vdesc='reach ID',  vunit='-' )
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call def_var(pioFileDescState, 'restart_time', ncd_double, ierr, cmessage, vdesc='resatart time', vunit=trim(time_units), vcal=calendar)
+ call def_var(pioFileDesc, 'restart_time', ncd_double, ierr, cmessage, vdesc='resatart time', vunit=trim(time_units), vcal=calendar)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call def_var(pioFileDescState, 'history_time', ncd_double, ierr, cmessage, pioDimId=[dim_tbound], vdesc='history time', vunit=trim(time_units), vcal=calendar)
+ call def_var(pioFileDesc, 'history_time', ncd_double, ierr, cmessage, pioDimId=[dim_tbound], vdesc='history time', vunit=trim(time_units), vcal=calendar)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call def_var(pioFileDescState, 'time_bound', ncd_float, ierr, cmessage, pioDimId=[dim_tbound], vdesc='time bound at last time step', vunit='sec')
+ call def_var(pioFileDesc, 'time_bound', ncd_float, ierr, cmessage, pioDimId=[dim_tbound], vdesc='time bound at last time step', vunit='sec')
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call def_var(pioFileDescState, 'history_file', ncd_char, ierr, cmessage, pioDimId=[dim_nchars, dim_hist_fil], vdesc='history files that need to be read with this restart file', vunit='-')
+ call def_var(pioFileDesc, 'history_file', ncd_char, ierr, cmessage, pioDimId=[dim_nchars, dim_hist_fil], vdesc='history files that need to be read with this restart file', vunit='-')
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  end associate
@@ -370,7 +368,7 @@ CONTAINS
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! Finishing up definition -------
- call end_def(pioFileDescState, ierr, cmessage)
+ call end_def(pioFileDesc, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  CONTAINS
@@ -398,7 +396,7 @@ CONTAINS
        dim_basinQ(ixDim) = meta_stateDims(meta_basinQ(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, meta_basinQ(iVar)%varName, meta_basinQ(iVar)%varType, ierr, cmessage, &
+     call def_var(pioFileDesc, meta_basinQ(iVar)%varName, meta_basinQ(iVar)%varType, ierr, cmessage, &
                   pioDimId=dim_basinQ, vdesc=meta_basinQ(iVar)%varDesc, vunit=meta_basinQ(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
@@ -419,7 +417,7 @@ CONTAINS
 
    ierr=0; message1='define_IRFbas_state/'
 
-   call def_dim(pioFileDescState, meta_stateDims(ixStateDims%tdh)%dimName, meta_stateDims(ixStateDims%tdh)%dimLength, meta_stateDims(ixStateDims%tdh)%dimId)
+   call def_dim(pioFileDesc, meta_stateDims(ixStateDims%tdh)%dimName, meta_stateDims(ixStateDims%tdh)%dimLength, meta_stateDims(ixStateDims%tdh)%dimId)
    if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
 
    do iVar=1,nVarsIRFbas
@@ -433,7 +431,7 @@ CONTAINS
        dim_IRFbas(ixDim) = meta_stateDims(meta_irf_bas(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, meta_irf_bas(iVar)%varName, meta_irf_bas(iVar)%varType, ierr, cmessage, &
+     call def_var(pioFileDesc, meta_irf_bas(iVar)%varName, meta_irf_bas(iVar)%varType, ierr, cmessage, &
                   pioDimId=dim_IRFbas, vdesc=meta_irf_bas(iVar)%varDesc, vunit=meta_irf_bas(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
@@ -453,14 +451,14 @@ CONTAINS
 
    ierr=0; message1='define_IRF_state/'
 
-   call def_dim(pioFileDescState, meta_stateDims(ixStateDims%tdh_irf)%dimName, meta_stateDims(ixStateDims%tdh_irf)%dimLength, meta_stateDims(ixStateDims%tdh_irf)%dimId)
+   call def_dim(pioFileDesc, meta_stateDims(ixStateDims%tdh_irf)%dimName, meta_stateDims(ixStateDims%tdh_irf)%dimLength, meta_stateDims(ixStateDims%tdh_irf)%dimId)
    if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
 
    associate(dim_seg     => meta_stateDims(ixStateDims%seg)%dimId,     &
              dim_ens     => meta_stateDims(ixStateDims%ens)%dimId,     &
              dim_tdh_irf => meta_stateDims(ixStateDims%tdh_irf)%dimId)
 
-   call def_var(pioFileDescState, 'numQF', ncd_int, ierr, cmessage, pioDimId=[dim_seg,dim_ens], vdesc='number of future q time steps in a reach', vunit='-')
+   call def_var(pioFileDesc, 'numQF', ncd_int, ierr, cmessage, pioDimId=[dim_seg,dim_ens], vdesc='number of future q time steps in a reach', vunit='-')
    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
    do iVar=1,nVarsIRF
@@ -471,7 +469,7 @@ CONTAINS
        dim_set(ixDim) = meta_stateDims(meta_irf(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, meta_irf(iVar)%varName, meta_irf(iVar)%varType, ierr, cmessage, &
+     call def_var(pioFileDesc, meta_irf(iVar)%varName, meta_irf(iVar)%varType, ierr, cmessage, &
                   pioDimId=dim_set, vdesc=meta_irf(iVar)%varDesc, vunit=meta_irf(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
@@ -493,14 +491,14 @@ CONTAINS
    ierr=0; message1='define_KWT_state/'
 
    ! Define dimension needed for this routing specific state variables
-   call def_dim(pioFileDescState, meta_stateDims(ixStateDims%wave)%dimName, meta_stateDims(ixStateDims%wave)%dimLength, meta_stateDims(ixStateDims%wave)%dimId)
+   call def_dim(pioFileDesc, meta_stateDims(ixStateDims%wave)%dimName, meta_stateDims(ixStateDims%wave)%dimLength, meta_stateDims(ixStateDims%wave)%dimId)
    if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
 
    associate(dim_seg     => meta_stateDims(ixStateDims%seg)%dimId,     &
              dim_ens     => meta_stateDims(ixStateDims%ens)%dimId,     &
              dim_wave    => meta_stateDims(ixStateDims%wave)%dimId)
 
-   call def_var(pioFileDescState, 'numWaves', ncd_int, ierr, cmessage, pioDimId=[dim_seg,dim_ens], vdesc='number of waves in a reach', vunit='-')
+   call def_var(pioFileDesc, 'numWaves', ncd_int, ierr, cmessage, pioDimId=[dim_seg,dim_ens], vdesc='number of waves in a reach', vunit='-')
    if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
    do iVar=1,nVarsKWT
@@ -511,7 +509,7 @@ CONTAINS
        dim_set(ixDim) = meta_stateDims(meta_kwt(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, meta_kwt(iVar)%varName, meta_kwt(iVar)%varType, ierr, cmessage, &
+     call def_var(pioFileDesc, meta_kwt(iVar)%varName, meta_kwt(iVar)%varType, ierr, cmessage, &
                   pioDimId=dim_set, vdesc=meta_kwt(iVar)%varDesc, vunit=meta_kwt(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
@@ -532,7 +530,7 @@ CONTAINS
 
    ierr=0; message1='define_KW_state/'
 
-   call def_dim(pioFileDescState, meta_stateDims(ixStateDims%mol_kw)%dimName, meta_stateDims(ixStateDims%mol_kw)%dimLength, meta_stateDims(ixStateDims%mol_kw)%dimId)
+   call def_dim(pioFileDesc, meta_stateDims(ixStateDims%mol_kw)%dimName, meta_stateDims(ixStateDims%mol_kw)%dimLength, meta_stateDims(ixStateDims%mol_kw)%dimId)
    if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
 
    do iVar=1,nVarsKW
@@ -544,7 +542,7 @@ CONTAINS
        dim_set(ixDim) = meta_stateDims(meta_KW(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, meta_KW(iVar)%varName, meta_KW(iVar)%varType, ierr, cmessage, &
+     call def_var(pioFileDesc, meta_KW(iVar)%varName, meta_KW(iVar)%varType, ierr, cmessage, &
                   pioDimId=dim_set, vdesc=meta_KW(iVar)%varDesc, vunit=meta_KW(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
@@ -563,7 +561,7 @@ CONTAINS
 
    ierr=0; message1='define_MC_state/'
 
-   call def_dim(pioFileDescState, meta_stateDims(ixStateDims%mol_mc)%dimName, meta_stateDims(ixStateDims%mol_mc)%dimLength, meta_stateDims(ixStateDims%mol_mc)%dimId)
+   call def_dim(pioFileDesc, meta_stateDims(ixStateDims%mol_mc)%dimName, meta_stateDims(ixStateDims%mol_mc)%dimLength, meta_stateDims(ixStateDims%mol_mc)%dimId)
    if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
 
    do iVar=1,nVarsMC
@@ -575,7 +573,7 @@ CONTAINS
        dim_set(ixDim) = meta_stateDims(meta_mc(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, meta_mc(iVar)%varName, meta_mc(iVar)%varType, ierr, cmessage, &
+     call def_var(pioFileDesc, meta_mc(iVar)%varName, meta_mc(iVar)%varType, ierr, cmessage, &
                   pioDimId=dim_set, vdesc=meta_mc(iVar)%varDesc, vunit=meta_mc(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
@@ -594,7 +592,7 @@ CONTAINS
 
    ierr=0; message1='define_DW_state/'
 
-   call def_dim(pioFileDescState, meta_stateDims(ixStateDims%mol_dw)%dimName, meta_stateDims(ixStateDims%mol_dw)%dimLength, meta_stateDims(ixStateDims%mol_dw)%dimId)
+   call def_dim(pioFileDesc, meta_stateDims(ixStateDims%mol_dw)%dimName, meta_stateDims(ixStateDims%mol_dw)%dimLength, meta_stateDims(ixStateDims%mol_dw)%dimId)
    if(ierr/=0)then; ierr=20; message1=trim(message1)//'cannot define dimension'; return; endif
 
    do iVar=1,nVarsDW
@@ -606,7 +604,7 @@ CONTAINS
        dim_set(ixDim) = meta_stateDims(meta_dw(iVar)%varDim(ixDim))%dimId
      end do
 
-     call def_var(pioFileDescState, meta_dw(iVar)%varName, meta_dw(iVar)%varType, ierr, cmessage, &
+     call def_var(pioFileDesc, meta_dw(iVar)%varName, meta_dw(iVar)%varType, ierr, cmessage, &
                   pioDimId=dim_set, vdesc=meta_dw(iVar)%varDesc, vunit=meta_dw(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
@@ -627,7 +625,7 @@ CONTAINS
    do iVar=1,nVarsRFLX
      if (.not. meta_rflx(iVar)%varFile) cycle
      dim_set(1) = meta_stateDims(ixStateDims%seg)%dimId ! this should be seg dimension
-     call def_var(pioFileDescState, meta_rflx(iVar)%varName, ncd_double, ierr, cmessage, &
+     call def_var(pioFileDesc, meta_rflx(iVar)%varName, ncd_double, ierr, cmessage, &
                   pioDimId=dim_set, vdesc=meta_rflx(iVar)%varDesc, vunit=meta_rflx(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
@@ -635,7 +633,7 @@ CONTAINS
    do iVar=1,nVarsHFLX
      if (.not. meta_hflx(iVar)%varFile) cycle
      dim_set(1) = meta_stateDims(ixStateDims%hru)%dimId ! this should be hru dimension
-     call def_var(pioFileDescState, meta_hflx(iVar)%varName, ncd_double, ierr, cmessage, &
+     call def_var(pioFileDesc, meta_hflx(iVar)%varName, ncd_double, ierr, cmessage, &
                   pioDimId=dim_set, vdesc=meta_hflx(iVar)%varDesc, vunit=meta_hflx(iVar)%varUnit)
      if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
    end do
@@ -648,8 +646,9 @@ CONTAINS
  ! *********************************************************************
  ! public subroutine: writing routing state NetCDF file
  ! *********************************************************************
- SUBROUTINE write_state_nc(fname,                &   ! Input: state netcdf name
-                           ierr, message)            ! Output: error control
+ SUBROUTINE write_state_nc(fname,                &  ! Input: state netcdf name
+                           pioFileDesc,          &  ! inout: pio file descriptor
+                           ierr, message)           ! Output: error control
 
  USE public_var, ONLY: doesBasinRoute
  USE public_var, ONLY: impulseResponseFunc
@@ -678,21 +677,21 @@ CONTAINS
 
  implicit none
 
- ! input variables
- character(*),  intent(in)       :: fname             ! filename
- ! output variables
- integer(i4b), intent(out)       :: ierr              ! error code
- character(*), intent(out)       :: message           ! error message
+ ! Argument variables
+ character(*),      intent(in)    :: fname             ! filename
+ type(file_desc_t), intent(inout) :: pioFileDesc       ! pio file descriptor
+ integer(i4b), intent(out)        :: ierr              ! error code
+ character(*), intent(out)        :: message           ! error message
  ! local variables
- integer(i4b)                    :: iens              ! temporal
- integer(i4b)                    :: nRch_local        ! number of reach in each processors
- integer(i4b)                    :: nRch_root         ! number of reaches in root processors (including halo reaches)
- real(dp)                        :: timeVar_local     ! timeVar in simulation time unit converted from second
- type(STRFLX), allocatable       :: RCHFLX_local(:)   ! reordered reach flux data structure
- type(RCHTOPO),allocatable       :: NETOPO_local(:)   ! reordered topology data structure
- type(STRSTA), allocatable       :: RCHSTA_local(:)   ! reordered statedata structure
- logical(lgt)                    :: restartOpen       ! logical to indicate restart file is open
- character(len=strLen)           :: cmessage          ! error message of downwind routine
+ integer(i4b)                     :: iens              ! temporal
+ integer(i4b)                     :: nRch_local        ! number of reach in each processors
+ integer(i4b)                     :: nRch_root         ! number of reaches in root processors (including halo reaches)
+ real(dp)                         :: timeVar_local     ! timeVar in simulation time unit converted from second
+ type(STRFLX), allocatable        :: RCHFLX_local(:)   ! reordered reach flux data structure
+ type(RCHTOPO),allocatable        :: NETOPO_local(:)   ! reordered topology data structure
+ type(STRSTA), allocatable        :: RCHSTA_local(:)   ! reordered statedata structure
+ logical(lgt)                     :: restartOpen       ! logical to indicate restart file is open
+ character(len=strLen)            :: cmessage          ! error message of downwind routine
 
  ierr=0; message='write_state_nc/'
 
@@ -726,27 +725,27 @@ CONTAINS
    RCHSTA_local = RCHSTA_trib(iens,:)
  endif
 
- call openFile(pioSystem, pioFileDescState, trim(fname),pio_typename, ncd_write, restartOpen, ierr, cmessage)
+ call openFile(pioSystem, pioFileDesc, trim(fname),pio_typename, ncd_write, restartOpen, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! -- Write out to netCDF
- call write_scalar_netcdf(pioFileDescState, 'nNodes', nNodes, ierr, cmessage)
+ call write_scalar_netcdf(pioFileDesc, 'nNodes', nNodes, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call write_netcdf(pioFileDescState, 'reachID', reachID, [1], [nRch], ierr, cmessage)
+ call write_netcdf(pioFileDesc, 'reachID', reachID, [1], [nRch], ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call write_scalar_netcdf(pioFileDescState, 'restart_time', timeVar_local, ierr, cmessage)
+ call write_scalar_netcdf(pioFileDesc, 'restart_time', timeVar_local, ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call write_netcdf(pioFileDescState, 'time_bound', TSEC, [1], [2], ierr, cmessage)
+ call write_netcdf(pioFileDesc, 'time_bound', TSEC, [1], [2], ierr, cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
- call write_netcdf(pioFileDescState, 'history_file', hfileOut, &
+ call write_netcdf(pioFileDesc, 'history_file', hfileOut, &
                    iStart=1, ierr=ierr, message=cmessage)
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  if ( outputAtGage )then
-   call write_netcdf(pioFileDescState, 'history_file', hfileOut_gage, &
+   call write_netcdf(pioFileDesc, 'history_file', hfileOut_gage, &
                      iStart=2, ierr=ierr, message=cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
  end if
@@ -788,7 +787,7 @@ CONTAINS
  if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  ! close netCDF
- call closeFile(pioFileDescState, restartOpen)
+ call closeFile(pioFileDesc, restartOpen)
 
  CONTAINS
 
@@ -817,7 +816,7 @@ CONTAINS
               array_2d_dp(iSeg,iens) = RCHFLX_local(iSeg)%BASIN_QR(1)
             enddo
           enddo
-          call write_pnetcdf(pioFileDescState, meta_basinQ(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_basinQ(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
           deallocate(array_2d_dp)
         case default; ierr=20; message1=trim(message1)//'unable to identify basin runoff variable index'; return
       end select
@@ -852,7 +851,7 @@ CONTAINS
                array_3d_dp(iSeg,:,iens) = RCHFLX_local(iSeg)%QFUTURE
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_irf_bas(iVar)%varName, array_3d_dp, ioDesc_irf_bas_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_irf_bas(iVar)%varName, array_3d_dp, ioDesc_irf_bas_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case default; ierr=20; message1=trim(message1)//'unable to identify basin IRF state variable index'; return
       end select
@@ -890,7 +889,7 @@ CONTAINS
       end do
     end do
 
-    call write_pnetcdf(pioFileDescState, 'numQF', numQF, ioDesc_rch_int, ierr, cmessage)
+    call write_pnetcdf(pioFileDesc, 'numQF', numQF, ioDesc_rch_int, ierr, cmessage)
     if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
     do iVar=1,nVarsIRF
@@ -904,7 +903,7 @@ CONTAINS
               array_3d_dp(iSeg,numQF(iens,iSeg)+1:ntdh_irf,iens) = realMissing
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_irf(iVar)%varName, array_3d_dp, ioDesc_irf_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_irf(iVar)%varName, array_3d_dp, ioDesc_irf_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case(ixIRF%vol)
           allocate(array_3d_dp(nSeg,nTbound,nEns), stat=ierr, errmsg=cmessage)
@@ -914,7 +913,7 @@ CONTAINS
               array_3d_dp(iSeg,1:nTbound,iens) = RCHFLX_local(iSeg)%ROUTE(idxIRF)%REACH_VOL(0:1)
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_irf(iVar)%varName, array_3d_dp, ioDesc_vol_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_irf(iVar)%varName, array_3d_dp, ioDesc_vol_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc writing'; return
       end select
@@ -954,7 +953,7 @@ CONTAINS
       end do
     end do
 
-    call write_pnetcdf(pioFileDescState,'numWaves', numWaves, ioDesc_rch_int, ierr, cmessage)
+    call write_pnetcdf(pioFileDesc,'numWaves', numWaves, ioDesc_rch_int, ierr, cmessage)
     if(ierr/=0)then; message1=trim(message1)//trim(cmessage); return; endif
 
     do iVar=1,nVarsKWT
@@ -971,7 +970,7 @@ CONTAINS
               array_3d_int(iSeg,numWaves(iens,iSeg)+1:,iens) = integerMissing
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_kwt(iVar)%varName, array_3d_int, ioDesc_wave_int, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_kwt(iVar)%varName, array_3d_int, ioDesc_wave_int, ierr, cmessage)
           deallocate(array_3d_int)
         case(ixKWT%tentry)
           allocate(array_3d_dp(nSeg, nWave, nEns), stat=ierr, errmsg=cmessage)
@@ -982,7 +981,7 @@ CONTAINS
               array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_kwt(iVar)%varName, array_3d_dp, ioDesc_wave_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_kwt(iVar)%varName, array_3d_dp, ioDesc_wave_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case(ixKWT%texit)
           allocate(array_3d_dp(nSeg, nWave, nEns), stat=ierr, errmsg=cmessage)
@@ -993,7 +992,7 @@ CONTAINS
               array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_kwt(iVar)%varName, array_3d_dp, ioDesc_wave_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_kwt(iVar)%varName, array_3d_dp, ioDesc_wave_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case(ixKWT%qwave)
           allocate(array_3d_dp(nSeg, nWave, nEns), stat=ierr, errmsg=cmessage)
@@ -1004,7 +1003,7 @@ CONTAINS
               array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_kwt(iVar)%varName, array_3d_dp, ioDesc_wave_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_kwt(iVar)%varName, array_3d_dp, ioDesc_wave_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case(ixKWT%qwave_mod)
           allocate(array_3d_dp(nSeg, nWave, nEns), stat=ierr, errmsg=cmessage)
@@ -1015,7 +1014,7 @@ CONTAINS
               array_3d_dp(iSeg,numWaves(iens,iSeg)+1:,iens) = realMissing
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_kwt(iVar)%varName, array_3d_dp, ioDesc_wave_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_kwt(iVar)%varName, array_3d_dp, ioDesc_wave_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case(ixKWT%vol)
           allocate(array_2d_dp(nSeg, nEns), stat=ierr, errmsg=cmessage)
@@ -1025,7 +1024,7 @@ CONTAINS
               array_2d_dp(iSeg,iens) = RCHFLX_local(iSeg)%ROUTE(idxKWT)%REACH_VOL(1)
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_kwt(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_kwt(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
           deallocate(array_2d_dp)
         case default; ierr=20; message1=trim(message1)//'unable to identify KWT routing state variable index'; return
       end select
@@ -1063,7 +1062,7 @@ CONTAINS
               array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA_local(iSeg)%KW_ROUTE%molecule%Q(1:nMesh)
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_kw(iVar)%varName, array_3d_dp, ioDesc_mesh_kw_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_kw(iVar)%varName, array_3d_dp, ioDesc_mesh_kw_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case(ixKW%vol)
           allocate(array_2d_dp(nSeg, nEns), stat=ierr, errmsg=cmessage)
@@ -1073,7 +1072,7 @@ CONTAINS
               array_2d_dp(iSeg,iens) = RCHFLX_local(iSeg)%ROUTE(idxKW)%REACH_VOL(1)
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_kw(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_kw(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
           deallocate(array_2d_dp)
         case default; ierr=20; message1=trim(message1)//'unable to identify KW routing state variable index'; return
       end select
@@ -1110,7 +1109,7 @@ CONTAINS
               array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA_local(iSeg)%MC_ROUTE%molecule%Q(1:nMesh)
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_mc(iVar)%varName, array_3d_dp, ioDesc_mesh_mc_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_mc(iVar)%varName, array_3d_dp, ioDesc_mesh_mc_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case(ixMC%vol)
           allocate(array_2d_dp(nSeg, nEns),stat=ierr,errmsg=cmessage)
@@ -1120,7 +1119,7 @@ CONTAINS
               array_2d_dp(iSeg,iens) = RCHFLX_local(iSeg)%ROUTE(idxMC)%REACH_VOL(1)
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_mc(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_mc(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
           deallocate(array_2d_dp, stat=ierr)
         case default; ierr=20; message1=trim(message1)//'unable to identify MC routing state variable index'; return
       end select
@@ -1157,7 +1156,7 @@ CONTAINS
               array_3d_dp(iSeg,1:nMesh,iens) = RCHSTA_local(iSeg)%DW_ROUTE%molecule%Q(1:nMesh)
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_dw(iVar)%varName, array_3d_dp, ioDesc_mesh_dw_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_dw(iVar)%varName, array_3d_dp, ioDesc_mesh_dw_double, ierr, cmessage)
           deallocate(array_3d_dp)
         case(ixDW%vol)
           allocate(array_2d_dp(nSeg, nEns),stat=ierr,errmsg=cmessage)
@@ -1167,7 +1166,7 @@ CONTAINS
               array_2d_dp(iSeg,iens) = RCHFLX_local(iSeg)%ROUTE(idxDW)%REACH_VOL(1)
             end do
           end do
-          call write_pnetcdf(pioFileDescState, meta_dw(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
+          call write_pnetcdf(pioFileDesc, meta_dw(iVar)%varName, array_2d_dp, ioDesc_rch_double, ierr, cmessage)
           deallocate(array_2d_dp)
         case default; ierr=20; message1=trim(message1)//'unable to identify DW routing state variable index'; return
       end select
@@ -1205,86 +1204,86 @@ CONTAINS
 
     allocate(array_dp(nRch_local),stat=ierr, errmsg=cmessage)
 
-    call write_scalar_netcdf(pioFileDescState, 'nt', hVars%nt, ierr, cmessage)
+    call write_scalar_netcdf(pioFileDesc, 'nt', hVars%nt, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-    call write_netcdf(pioFileDescState, 'history_time', hVars%timeVar, [1], [2], ierr, cmessage)
+    call write_netcdf(pioFileDesc, 'history_time', hVars%timeVar, [1], [2], ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     if (meta_hflx(ixHFLX%basRunoff)%varFile) then
-      call write_pnetcdf(pioFileDescState, 'basRunoff', hVars%basRunoff, ioDesc_hru_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'basRunoff', hVars%basRunoff, ioDesc_hru_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     end if
 
     if (meta_rflx(ixRFLX%instRunoff)%varFile) then
       array_dp(1:nRch_local) = hVars%instRunoff(index_write)
-      call write_pnetcdf(pioFileDescState, 'instRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'instRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%dlayRunoff)%varFile) then
       array_dp(1:nRch_local) = hVars%dlayRunoff(index_write)
-      call write_pnetcdf(pioFileDescState, 'dlayRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'dlayRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%sumUpstreamRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxSUM)
-      call write_pnetcdf(pioFileDescState, 'sumUpstreamRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'sumUpstreamRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%KWTroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxKWT)
-      call write_pnetcdf(pioFileDescState, 'KWTroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'KWTroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%IRFroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxIRF)
-      call write_pnetcdf(pioFileDescState, 'IRFroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'IRFroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%KWroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxKW)
-      call write_pnetcdf(pioFileDescState, 'KWroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'KWroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%MCroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxMC)
-      call write_pnetcdf(pioFileDescState, 'MCroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'MCroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%DWroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxDW)
-      call write_pnetcdf(pioFileDescState, 'DWroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'DWroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%IRFvolume)%varFile) then
       array_dp = hVars%volume(index_write, idxIRF)
-      call write_pnetcdf(pioFileDescState, 'IRFvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'IRFvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%KWvolume)%varFile) then
       array_dp = hVars%volume(index_write, idxKW)
-      call write_pnetcdf(pioFileDescState, 'KWvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'KWvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%MCvolume)%varFile) then
       array_dp = hVars%volume(index_write, idxMC)
-      call write_pnetcdf(pioFileDescState, 'MCvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'MCvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%DWvolume)%varFile) then
       array_dp = hVars%volume(index_write, idxDW)
-      call write_pnetcdf(pioFileDescState, 'DWvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, 'DWvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -49,8 +49,6 @@ CONTAINS
     USE globalData, ONLY: nRch              !
     USE globalData, ONLY: nHRU              !
     USE globalData, ONLY: gage_data         !
-    USE globalData, ONLY: pioSystem
-
 
     implicit none
     ! Argument variables
@@ -72,7 +70,7 @@ CONTAINS
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       ! initialize and create history netcdfs
-      hist_all_network = histFile(hfileout, pioSys=pioSystem)
+      hist_all_network = histFile(hfileout)
 
       call hist_all_network%set_compdof(ioDesc_rch_float, ioDesc_hru_float)
 
@@ -87,7 +85,7 @@ CONTAINS
 
       if (outputAtGage) then
 
-        hist_gage = histFile(hfileout_gage, pioSys=pioSystem, gageOutput=.true.)
+        hist_gage = histFile(hfileout_gage, gageOutput=.true.)
 
         call hist_gage%set_compdof(ioDesc_gauge_float)
 
@@ -383,7 +381,6 @@ CONTAINS
 
    USE globalData,  ONLY: gage_data
    USE public_var,  ONLY: outputAtGage      ! ascii containing last restart and history files
-   USE globalData,  ONLY: pioSystem
 
    implicit none
    ! argument variables
@@ -399,7 +396,7 @@ CONTAINS
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    ! initialize and create history netcdfs
-   hist_all_network = histFile(hfileout, pioSys=pioSystem)
+   hist_all_network = histFile(hfileout)
 
    call hist_all_network%openNc(ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -407,7 +404,7 @@ CONTAINS
    call hist_all_network%set_compdof(ioDesc_rch_float, ioDesc_hru_float)
 
    if (outputAtGage) then
-     hist_gage = histFile(hfileout_gage, pioSys=pioSystem, gageOutput=.true.)
+     hist_gage = histFile(hfileout_gage, gageOutput=.true.)
 
      call hist_gage%openNC(ierr, message)
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -18,11 +18,14 @@ USE io_rpointfile,  ONLY: io_rpfile
 USE ascii_utils,    ONLY: lower
 USE pio_utils
 
+USE globalData,     ONLY: ioDesc_hru_float
+USE globalData,     ONLY: ioDesc_rch_float
+USE globalData,     ONLY: ioDesc_gauge_float
+
 implicit none
 type(histVars), save            :: hVars                 !
 type(histFile), save            :: hist_all_network      !
 type(histFile), save            :: hist_gage             !
-integer(i4b), allocatable, save :: index_write_gage(:)   !
 
 private
 public::hVars
@@ -30,7 +33,6 @@ public::main_new_file
 public::output
 public::close_all
 public::init_histFile
-public::get_compdof_all_network ! used in write_restart_pio
 
 CONTAINS
 
@@ -49,14 +51,12 @@ CONTAINS
     USE globalData, ONLY: gage_data         !
     USE globalData, ONLY: pioSystem
 
+
     implicit none
     ! Argument variables
     integer(i4b),   intent(out)     :: ierr             ! error code
     character(*),   intent(out)     :: message          ! error message
     ! local variables
-    integer(i4b), allocatable       :: compdof_rch(:)      !
-    integer(i4b), allocatable       :: compdof_rch_gage(:) !
-    integer(i4b), allocatable       :: compdof_hru(:)      !
     logical(lgt)                    :: createNewFile       ! logical to make alarm for restart writing
     character(len=strLen)           :: cmessage            ! error message of downwind routine
 
@@ -74,9 +74,7 @@ CONTAINS
       ! initialize and create history netcdfs
       hist_all_network = histFile(hfileout, pioSys=pioSystem)
 
-      call get_compdof_all_network(compdof_rch, compdof_hru)
-
-      call hist_all_network%set_compdof(compdof_rch, compdof_hru, nRch, nHRU)
+      call hist_all_network%set_compdof(ioDesc_rch_float, ioDesc_hru_float)
 
       call hist_all_network%createNC(ierr, cmessage, nRch_in=nRch, nHRU_in=nHRU)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -91,9 +89,7 @@ CONTAINS
 
         hist_gage = histFile(hfileout_gage, pioSys=pioSystem, gageOutput=.true.)
 
-        call get_compdof_gage(compdof_rch_gage, ierr, cmessage)
-
-        call hist_gage%set_compdof(compdof_rch_gage, gage_data%nGage)
+        call hist_gage%set_compdof(ioDesc_gauge_float)
 
         call hist_gage%createNC(ierr, cmessage, nRch_in=gage_data%nGage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -154,6 +150,7 @@ CONTAINS
    USE globalData, ONLY: rch_per_proc      ! number of reaches assigned to each proc (size = num of procs+1)
    USE globalData, ONLY: nRch_mainstem     ! number of mainstem reach
    USE globalData, ONLY: nTribOutlet       ! number of
+   USE globalData, ONLY: index_write_gage  ! reach index (w.r.t. global domain) corresponding gauge location
    USE nr_utils,   ONLY: arth
 
    implicit none
@@ -300,110 +297,6 @@ CONTAINS
  END SUBROUTINE get_proc_flux
 
  ! *********************************************************************
- ! private subroutine: get pio local-global mapping data
- ! *********************************************************************
- SUBROUTINE get_compdof_all_network(compdof_rch, compdof_hru)
-
-   USE globalData,        ONLY: hru_per_proc      ! number of hrus assigned to each proc (size = num of procs+1)
-   USE globalData,        ONLY: rch_per_proc      ! number of reaches assigned to each proc (size = num of procs+1)
-   USE nr_utils,          ONLY: arth
-
-   implicit none
-   ! Argument variables
-   integer(i4b), allocatable, intent(out) :: compdof_rch(:) !
-   integer(i4b), allocatable, intent(out) :: compdof_hru(:) !
-   ! Local variables
-   integer(i4b)                :: ix1, ix2               ! frst and last indices of global array for local array chunk
-
-   if (masterproc) then
-     allocate(compdof_rch(sum(rch_per_proc(-1:pid))))
-     allocate(compdof_hru(sum(hru_per_proc(-1:pid))))
-   else
-     allocate(compdof_rch(rch_per_proc(pid)))
-     allocate(compdof_hru(hru_per_proc(pid)))
-   end if
-
-   ! For reach flux/volume
-   if (masterproc) then
-     ix1 = 1
-   else
-     ix1 = sum(rch_per_proc(-1:pid-1))+1
-   endif
-   ix2 = sum(rch_per_proc(-1:pid))
-   compdof_rch = arth(ix1, 1, ix2-ix1+1)
-
-   ! For HRU flux/volume
-   if (masterproc) then
-     ix1 = 1
-   else
-     ix1 = sum(hru_per_proc(-1:pid-1))+1
-   endif
-   ix2 = sum(hru_per_proc(-1:pid))
-   compdof_hru = arth(ix1, 1, ix2-ix1+1)
-
- END SUBROUTINE get_compdof_all_network
-
-
- ! *********************************************************************
- ! private subroutine: get pio local-global mapping data
- ! *********************************************************************
- SUBROUTINE get_compdof_gage(compdof_rch, ierr, message)
-
-   USE globalData, ONLY: rch_per_proc        ! number of reaches assigned to each proc (size = num of procs+1)
-   USE globalData, ONLY: nRch_mainstem       ! number of mainstem reaches
-   USE globalData, ONLY: nTribOutlet         ! number of tributary outlets flowing to the mainstem
-   USE globalData, ONLY: NETOPO_main         ! mainstem Reach neteork
-   USE globalData, ONLY: NETOPO_trib         ! tributary Reach network
-   USE globalData, ONLY: gage_data
-   USE process_gage_meta, ONLY: reach_subset
-
-   implicit none
-   ! Argument variables
-   integer(i4b), allocatable, intent(out) :: compdof_rch(:)   !
-   integer(i4b), intent(out)              :: ierr             ! error code
-   character(*), intent(out)              :: message          ! error message
-   ! Local variables
-   integer(i4b)                           :: ix
-   integer(i4b)                           :: nRch_local
-   integer(i4b),allocatable               :: reachID_local(:) !
-   character(len=strLen)                  :: cmessage         ! error message of downwind routine
-
-   ierr=0; message='get_compdof_gage/'
-
-   ! Only For reach flux/volume
-   if (masterproc) then
-     nRch_local = nRch_mainstem+rch_per_proc(0)
-     allocate(reachID_local(nRch_local), stat=ierr, errmsg=cmessage)
-     if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [reachID_local]'; return; endif
-
-     if (nRch_mainstem>0)   reachID_local(1:nRch_mainstem) = NETOPO_main(1:nRch_mainstem)%REACHID
-     if (rch_per_proc(0)>0) reachID_local(nRch_mainstem+1:nRch_local) = NETOPO_trib(:)%REACHID
-   else
-     nRch_local = rch_per_proc(pid)
-     allocate(reachID_local(nRch_local), stat=ierr, errmsg=cmessage)
-     if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [reachID_local]'; return; endif
-     reachID_local = NETOPO_trib(:)%REACHID
-   endif
-
-   call reach_subset(reachID_local, gage_data, ierr, cmessage, compdof=compdof_rch, index2=index_write_gage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-   ! Need to adjust tributary indices in root processor
-   ! This is because RCHFLX has three components in the order: mainstem, halo, tributary
-   ! mainstem (1,2,..,nRch_mainstem),
-   ! halo(nRch_mainstem+1,..,nRch_mainstem+nTribOutlet), and
-   ! tributary(nRch_mainstem+nTribOutlet+1,...,nRch_total)
-   ! index_write_gage is computed based on reachID consisting of mainstem and tributary
-   if (masterproc) then
-     do ix=1,size(index_write_gage)
-       if (index_write_gage(ix)<=nRch_mainstem) cycle
-       index_write_gage(ix) = index_write_gage(ix) + nTribOutlet
-     end do
-   end if
-
- END SUBROUTINE get_compdof_gage
-
- ! *********************************************************************
  ! private subroutine: define history NetCDF file name
  ! *********************************************************************
  SUBROUTINE get_hfilename(inDatetime, ierr, message)
@@ -477,11 +370,9 @@ CONTAINS
    implicit none
    if (hist_all_network%fileOpen()) then
      call hist_all_network%closeNC()
-     call hist_all_network%cleanup()
    end if
    if (hist_gage%fileOpen()) then
      call hist_gage%closeNC()
-     call hist_gage%cleanup()
    end if
  END SUBROUTINE
 
@@ -490,7 +381,6 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE init_histFile(ierr, message)
 
-   USE globalData,  ONLY: nHRU, nRch        ! number of HRUs and river reaches
    USE globalData,  ONLY: gage_data
    USE public_var,  ONLY: outputAtGage      ! ascii containing last restart and history files
    USE globalData,  ONLY: pioSystem
@@ -500,9 +390,6 @@ CONTAINS
    integer(i4b),   intent(out)     :: ierr                ! error code
    character(*),   intent(out)     :: message             ! error message
    ! local variables
-   integer(i4b), allocatable       :: compdof_rch(:)      !
-   integer(i4b), allocatable       :: compdof_rch_gage(:) !
-   integer(i4b), allocatable       :: compdof_hru(:)      !
    character(len=strLen)           :: cmessage            ! error message of downwind routine
 
    ierr=0; message='init_histFile/'
@@ -517,9 +404,7 @@ CONTAINS
    call hist_all_network%openNc(ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-   call get_compdof_all_network(compdof_rch, compdof_hru)
-
-   call hist_all_network%set_compdof(compdof_rch, compdof_hru, nRch, nHRU)
+   call hist_all_network%set_compdof(ioDesc_rch_float, ioDesc_hru_float)
 
    if (outputAtGage) then
      hist_gage = histFile(hfileout_gage, pioSys=pioSystem, gageOutput=.true.)
@@ -527,10 +412,7 @@ CONTAINS
      call hist_gage%openNC(ierr, message)
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-     call get_compdof_gage(compdof_rch_gage, ierr, cmessage)
-     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-     call hist_gage%set_compdof(compdof_rch_gage, gage_data%nGage)
+     call hist_gage%set_compdof(ioDesc_gauge_float)
    end if
 
  END SUBROUTINE init_histFile


### PR DESCRIPTION
Move pio decomposition initialization to the model initialization (beginning of the model execution). Idea is to define decomposition data once and share pio system (which decomposition data is attached to) for all the history files and restart file, and avoid defining decomposition data every time the output files are created.

This does not change any science and should re-produce the results from the codes prior to this PR.

resolves #409
resolves #438