### PR TITLE
mizuRoute_control.py change required

### DIFF
--- a/route/settings/mizuRoute_control.py
+++ b/route/settings/mizuRoute_control.py
@@ -14,8 +14,6 @@ sys.path.append( "../../../../cime/scripts/lib" );
 from CIME.XML.standard_module_setup import *
 from CIME.utils import expect, convert_to_string, convert_to_type, run_cmd_no_fail
 
-import six
-
 logger = logging.getLogger(__name__)
 
 class mizuRoute_control(object):


### PR DESCRIPTION
module called `six` is removed due to cime update.  