### PR TITLE
allow more flexible time stamp in forcing input

### DIFF
--- a/route/build/src/historyFile.f90
+++ b/route/build/src/historyFile.f90
@@ -13,6 +13,7 @@ MODULE historyFile
   USE globalData,        ONLY: pioSystem
   USE public_var,        ONLY: pio_netcdf_format
   USE public_var,        ONLY: pio_typename
+  USE public_var,        ONLY: time_stamp => ro_time_stamp
   USE globalData,        ONLY: version
   USE globalData,        ONLY: gitBranch
   USE globalData,        ONLY: gitHash
@@ -319,6 +320,7 @@ MODULE historyFile
       integer(i4b),              intent(out)   :: ierr             ! error code
       character(*),              intent(out)   :: message          ! error message
       ! local variables
+      real(dp)                                 :: timeVar_write    ! time variable [time_unit]
       character(len=strLen)                    :: cmessage         ! error message of downwind routine
 
       ierr=0; message='write_time/'
@@ -326,7 +328,13 @@ MODULE historyFile
       this%iTime = this%iTime + 1 ! this is only line to increment time step index
 
       ! write time -- note time is just carried across from the input
-      call write_netcdf(this%pioFileDesc, 'time', [hVars_local%timeVar(1)], [this%iTime], [1], ierr, cmessage)
+      select case(trim(time_stamp))
+        case('front');  timeVar_write = hVars_local%timeVar(1)
+        case('end');    timeVar_write = hVars_local%timeVar(2)
+        case('middle'); timeVar_write = (hVars_local%timeVar(1)+hVars_local%timeVar(2))/2.0
+      end select
+
+      call write_netcdf(this%pioFileDesc, 'time', [timeVar_write], [this%iTime], [1], ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
       call write_netcdf(this%pioFileDesc, 'time_bounds', hVars_local%timeVar, [1,this%iTime], [2,1], ierr, cmessage)

--- a/route/build/src/historyFile.f90
+++ b/route/build/src/historyFile.f90
@@ -13,7 +13,6 @@ MODULE historyFile
   USE globalData,        ONLY: pioSystem
   USE public_var,        ONLY: pio_netcdf_format
   USE public_var,        ONLY: pio_typename
-  USE public_var,        ONLY: time_stamp => ro_time_stamp
   USE globalData,        ONLY: version
   USE globalData,        ONLY: gitBranch
   USE globalData,        ONLY: gitHash
@@ -311,12 +310,13 @@ MODULE historyFile
     ! ---------------------------------
     ! writing time variables
     ! ---------------------------------
-    SUBROUTINE write_time(this, hvars_local, ierr, message)
+    SUBROUTINE write_time(this, hVars_local, time_stamp_Local, ierr, message)
 
       implicit none
       ! Argument variables
       class(histFile),           intent(inout) :: this
-      type(histVars),            intent(in)    :: hVars_local
+      type(histVars),            intent(in)    :: hVars_local      ! history variable structure
+      character(len=strLen),     intent(in)    :: time_stamp_local ! time stamp for time variable: front, end, or middle
       integer(i4b),              intent(out)   :: ierr             ! error code
       character(*),              intent(out)   :: message          ! error message
       ! local variables
@@ -328,7 +328,7 @@ MODULE historyFile
       this%iTime = this%iTime + 1 ! this is only line to increment time step index
 
       ! write time -- note time is just carried across from the input
-      select case(trim(time_stamp))
+      select case(trim(time_stamp_local))
         case('front');  timeVar_write = hVars_local%timeVar(1)
         case('end');    timeVar_write = hVars_local%timeVar(2)
         case('middle'); timeVar_write = (hVars_local%timeVar(1)+hVars_local%timeVar(2))/2.0

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -302,7 +302,7 @@ CONTAINS
      C2 = (1-X-Cn*Y)/(1-X+Cn*(1-Y))
 
      QoutLocal(ix) = C0* QinLocal(ix)+ C1* QinLocal(ix-1)+ C2* QoutLocal(ix-1)
-     QoutLocal(ix) = max(0.0, QoutLocal(ix))
+     QoutLocal(ix) = max(0.0_dp, QoutLocal(ix))
 
      ! -- EBK 06/26/2023 -- comment out isnan check, doesn't seem to be needed.
      !if (isnan(QoutLocal(ix))) then

--- a/route/build/src/nr_utils.f90
+++ b/route/build/src/nr_utils.f90
@@ -365,7 +365,7 @@ CONTAINS
    integer(i4b),allocatable,intent(out) :: idx(:)               ! integer array including unique element index
    ! local
    integer(i4b)                         :: ranked(size(array))  !
-   integer(i4b)                         :: unq_tmp(size(array)) !
+   integer(i8b)                         :: unq_tmp(size(array)) !
    logical(lgt)                         :: flg_tmp(size(array)) !
    integer(i4b)                         :: ix                   ! loop index, counter
    integer(i8b)                         :: last_unique          ! last unique element

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -137,6 +137,7 @@ MODULE public_var
   real(dp)             ,public    :: input_fillvalue      = realMissing     ! fillvalue used for input variables (runoff, precipitation, evaporation)
   character(len=strLen),public    :: ro_time_units        = charMissing     ! time units used in ro netcdf. format should be <unit> since yyyy-mm-dd (hh:mm:ss). () can be omitted
   character(len=strLen),public    :: ro_calendar          = charMissing     ! calendar used in ro netcdf
+  character(len=strLen),public    :: ro_time_stamp        = 'front'         ! time stamp used for I/O - front (default), middle, or end, otherwise error
   ! Water-management input netCDF - water abstraction/infjection or lake target volume
   character(len=strLen),public    :: fname_wm             = ''              ! the txt file name that includes nc files holesing the abstraction, injection, target volume values
   character(len=strLen),public    :: vname_flux_wm        = ''              ! variable name for abstraction or injection from or to a river segment

--- a/route/build/src/standalone/get_basin_runoff.f90
+++ b/route/build/src/standalone/get_basin_runoff.f90
@@ -70,7 +70,7 @@ CONTAINS
     runoff_data%basinRunoff = 0._dp ! replacing with zeros
   else
     ! time step mapping from runoff time step to simulation time step
-    call timeMap_sim_forc(tmap_sim_ro, begDatetime, robegDatetime, dt_ro, iTime, inFileInfo_ro, ierr, cmessage)
+    call timeMap_sim_forc(tmap_sim_ro, begDatetime, roBegDatetime, dt_ro, iTime, inFileInfo_ro, ierr, cmessage)
     if(ierr/=0) then; message=trim(message)//trim(cmessage); return; endif
 
     ! get the simulated runoff for the current time step - runoff_data%sim(:) or %sim2D(:,:)

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -131,20 +131,21 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE output(ierr, message)
 
-   USE public_var, ONLY: outputAtGage      ! ascii containing last restart and history files
-   USE public_var, ONLY: nOutFreq          !
-   USE public_var, ONLY: outputFrequency   !
-   USE globalData, ONLY: simDatetime       ! previous,current and next model datetime
-   USE globalData, ONLY: timeVar           ! current simulation time variable
-   USE globalData, ONLY: sec2tunit         ! seconds per time unit
-   USE globalData, ONLY: RCHFLX_trib       ! reach flux data structure containing current flux variables
-   USE globalData, ONLY: rch_per_proc      ! number of reaches assigned to each proc (size = num of procs+1)
-   USE globalData, ONLY: nRch_mainstem     ! number of mainstem reach
-   USE globalData, ONLY: nTribOutlet       ! number of
-   USE globalData, ONLY: index_write_gage  ! reach index (w.r.t. global domain) corresponding gauge location
-   USE globalData, ONLY: ioDesc_hru_float   ! pio decomposition descriptor for hru
-   USE globalData, ONLY: ioDesc_rch_float   ! pio decomposition descriptor for reaches
-   USE globalData, ONLY: ioDesc_gauge_float ! pio decomposition descriptor for gauges
+   USE public_var, ONLY: outputAtGage                 ! ascii containing last restart and history files
+   USE public_var, ONLY: nOutFreq                     ! integer output frequency, i.e, written at every "nOutFreq" of simulation step
+   USE public_var, ONLY: outputFrequency              ! writing frequency
+   USE public_var, ONLY: time_stamp => ro_time_stamp  !
+   USE globalData, ONLY: simDatetime                  ! previous,current and next model datetime
+   USE globalData, ONLY: timeVar                      ! current simulation time variable
+   USE globalData, ONLY: sec2tunit                    ! seconds per time unit
+   USE globalData, ONLY: RCHFLX_trib                  ! reach flux data structure containing current flux variables
+   USE globalData, ONLY: rch_per_proc                 ! number of reaches assigned to each proc (size = num of procs+1)
+   USE globalData, ONLY: nRch_mainstem                ! number of mainstem reach
+   USE globalData, ONLY: nTribOutlet                  ! number of
+   USE globalData, ONLY: index_write_gage             ! reach index (w.r.t. global domain) corresponding gauge location
+   USE globalData, ONLY: ioDesc_hru_float             ! pio decomposition descriptor for hru
+   USE globalData, ONLY: ioDesc_rch_float             ! pio decomposition descriptor for reaches
+   USE globalData, ONLY: ioDesc_gauge_float           ! pio decomposition descriptor for gauges
    USE nr_utils,   ONLY: arth
 
    implicit none
@@ -203,7 +204,7 @@ CONTAINS
      end if
 
      ! write time variables (time and time bounds)
-     call hist_all_network%write_time(hVars, ierr, cmessage)
+     call hist_all_network%write_time(hVars, time_stamp, ierr, cmessage)
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
      ! write out output variables in history files
@@ -220,7 +221,7 @@ CONTAINS
 
      if (outputAtGage) then
        ! write time variables (time and time bounds)
-       call hist_gage%write_time(hVars, ierr, cmessage)
+       call hist_gage%write_time(hVars, time_stamp, ierr, cmessage)
        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
        call hist_gage%write_flux_rch(hVars, ioDesc_gauge_float, index_write_gage, ierr, cmessage)


### PR DESCRIPTION
**For Stand-alone** 

Runoff input may use `front`, `middle`, or `end` of time period for runoff input.  A user has to specify which one in control variable `<ro_time_stamp>`.  Default is `front` for now. 

History output use consistent time stamp for input.

**For cesm-coupling** 

This is setting up to implement required time stamp rule in cesm coupling (see #413)

history output use middle of time step for average values. For instantaneous, time stamp should be the time at that point. 
