### PR TITLE
 makefile cleanups

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,17 +1,3 @@
-[cime]
-local_path = cime
-protocol = git
-repo_url = https://github.com/ESMCI/cime
-tag = cime6.0.156
-required = True
-
-[mct]
-tag = MCT_2.11.0
-protocol = git
-repo_url = https://github.com/MCSclimate/MCT
-local_path = libraries/mct
-required = True
-
 [parallelio]
 tag = pio2_6_2
 protocol = git

--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -32,7 +32,6 @@ LIBOPENMP =
 # define if should use external librarys (yes if used)
 # external librarys are: mpi-serial, Parallel-I/O, and GPTL timing library
 # define path to PNETCDF if you want to use it
-isMPISERIAL =
 isPIO = yes
 isGPTL = yes
 
@@ -246,7 +245,7 @@ all: compile install clean
 #========================================================================
 # External libaries that might need to be built
 #========================================================================
-LIBDIR       = $(F_MASTER)build/lib
+LIBDIR = $(F_MASTER)build/lib
 ifdef PIO_PATH
   PIOLIBDIR= $(PIO_PATH)/lib
   PIOINCDIR= $(PIO_PATH)/include
@@ -256,9 +255,6 @@ else
   PIOINCDIR    = $(LIBDIR)/piolib/include
   PIOLIB       = $(PIOLIBDIR)/libpiof.a $(PIOLIBDIR)/libpioc.a
 endif
-
-MPISERLIBDIR = $(LIBDIR)/mpi-seriallib
-MPISERLIB    = $(MPISERLIBDIR)/libmpi-serial.a
 
 ifeq "$(isPIO)" "yes"
   EXTINCLUDES += -I$(PIOINCDIR)
@@ -270,35 +266,18 @@ ifeq "$(isPIO)" "yes"
   endif
 endif
 
-ifeq "$(isMPISERIAL)" "yes"
-  EXTINCLUDES += -I$(MPISERLIBDIR)
-  EXTLIBS += $(MPISERLIB)
-  LDFLAGS += -L$(MPISERLIBDIR) -lmpi-serial
-  ifdef PNETCDF_PATH
-    undefine PNETCDF_PATH
-  endif
-  MPISERIAL = $(MPISERLIB)
-else
-  MPISERIAL =
-endif
-
 ifdef PNETCDF_PATH
         LDFLAGS    += -L$(PNETCDF_PATH)/lib -lpnetcdf
 endif
 
-$(PIOLIB): $(MPISERIAL)
+$(PIOLIB):
 	cd $(LIBDIR); \
 	$(MAKE) $(MFLAGS) F_MASTER=$(F_MASTER) FC=$(FC_EXE) FC_EXE=$(FC_EXE) FLAGS="$(FLAGS)" \
 	PIO_FILESYSTEM_HINTS=$(PIO_FILESYSTEM_HINTS) PNETCDF_PATH=$(PNETCDF_PATH) isPIO=yes isGPTL=$(isGPTL) \
 	MPIINC_PATHLIST=$(CPATH) NCDF_PATH=$(NCDF_PATH) MODE=$(MODE) $(PIOLIB)
 
-$(MPISERLIB):
-	cd $(LIBDIR); \
-	$(MAKE) $(MFLAGS) F_MASTER=$(F_MASTER) FC=$(FC_EXE) FC_EXE=$(FC_EXE) FLAGS="$(FLAGS)" isMPISERIAL=yes \
-	MODE=$(MODE) $(MPISERLIB)
-
 # Clean external libs
-cleanlibs: cleanpiolib cleanmpiseriallib
+cleanlibs: cleanpiolib
 	@echo "Clean the pio and mpi-serial external libraries"
 .PHONY : cleanlibs
 
@@ -306,11 +285,6 @@ cleanpiolib:
 	cd $(LIBDIR); \
 	$(MAKE) $(MFLAGS) F_MASTER=$(F_MASTER) cleanpiolib
 .PHONY : cleanpiolib
-
-cleanmpiseriallib:
-	cd $(LIBDIR); \
-	$(MAKE) $(MFLAGS) F_MASTER=$(F_MASTER) cleanmpiseriallib
-.PHONY : cleanmpiseriallib
 
 #========================================================================
 # Compile the puppy

--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -49,18 +49,26 @@ F_MASTER =
 # Define the NetCDF libraries and path to include files
 ifeq "$(FC)" "gnu"
  NCDF_PATH =
+ NCDF_C_PATH =
+ NCDF_FORTRAN_PATH =
  PNETCDF_PATH =
  PIO_PATH=        # NCAR HPC-> $(PIO)
 else ifeq "$(FC)" "intel"
  NCDF_PATH =
+ NCDF_C_PATH =
+ NCDF_FORTRAN_PATH =
  PNETCDF_PATH =
  PIO_PATH=        # NCAR HPC-> $(PIO)
 else ifeq "$(FC)" "nvidia"
  NCDF_PATH =
+ NCDF_C_PATH =
+ NCDF_FORTRAN_PATH =
  PNETCDF_PATH =
  PIO_PATH=        # NCAR HPC-> $(PIO)
 else ifeq "$(FC)" "cray"
  NCDF_PATH =
+ NCDF_C_PATH =
+ NCDF_FORTRAN_PATH =
  PNETCDF_PATH =
  PIO_PATH=        # NCAR HPC-> $(PIO)
 else

--- a/route/build/lib/Makefile
+++ b/route/build/lib/Makefile
@@ -11,32 +11,16 @@
 # Library definitions
 #=-====================================
 CPPDEFS      = -DUSE_MPI_ISEND_FOR_FC
-CIMEROOT     = $(F_MASTER)../cime
-MCTDIR       = $(F_MASTER)../libraries/mct/
-MPISERIALDIR = $(MCTDIR)/mpi-serial
 PIO2DIR      = $(F_MASTER)../libraries/parallelio
 LIBDIR       = $(F_MASTER)build/lib
 PIOLIBDIR    = $(F_MASTER)build/lib/piolib
 PIOLIB       = $(PIOLIBDIR)/lib/libpiof.a $(PIOLIBDIR)/lib/libpioc.a
 PIOLIBMAKE   = $(PIOLIBDIR)/Makefile
-MPISERLIBDIR = $(F_MASTER)build/lib/mpi-seriallib
-MPISERLIB    = $(MPISERLIBDIR)/libmpi-serial.a
-MPISERCONF   = $(MPISERLIBDIR)/Makefile.conf
 MPIINC_PATHLIST  = $(CPATH)
 INCLDIR      = -I.
 CMAKE_OPTS   =
 
-all: $(CIMEROOT) $(MCTDIR) $(MPISERIALDIR) $(PIO2DIR)
-
-$(CIMEROOT):
-	@echo "Run manage_externals/checkout_externals in the root directory (cd ../../..) first in order to create the cime root directory"
-	@echo "CIMEROOT being looked for: $(CIMEROOT)"
-
-$(MCTDIR):
-	@echo "MCTDIR does not exist: $(MCTDIR)"
-
-$(MPISERIALDIR):
-	@echo "MPISERIALDIR does not exist: $(MPISERIALDIR)"
+all: $(PIO2DIR)
 
 $(PIO2DIR):
 	@echo "PIO2DIR does not exist: $(PIO2DIR)"
@@ -46,29 +30,13 @@ ifeq "$(isPIO)" "yes"
   CPPDEFS += -DPIO2
 endif
 
-ifeq "$(isMPISERIAL)" "yes"
-  MPISERIAL = $(MPISERLIB)
-  CPPDEFS += -DNO_MPI2
-  INCLDIR += -I$(MPISERIALDIR) -I$(MPISERLIBDIR)
-  ifdef PNETCDF_PATH
-    undefine PNETCDF_PATH
-  endif
-  CMAKE_OPTS += -DMPI_C_INCLUDE_PATH=$(PIOLIBDIR)/include \
-      -DMPI_Fortran_INCLUDE_PATH=$(PIOLIBDIR)/include \
-      -DMPI_C_LIBRARIES=$(MPISERLIB) \
-      -DMPI_Fortran_LIBRARIES=$(MPISERLIB)
-  CMAKE_OPTS += -D PIO_USE_MPISERIAL=TRUE -D MPISERIAL_PATH=$(MPISERLIBDIR)
-  CMAKE_OPTS += -DCMAKE_Fortran_COMPILER=$(FC)
-else
-  # Change colon delimited list to space with a -I in front of each
-  ifdef MPIINC_PATHLIST
-    MPIINC   = $(subst :, -I,$(MPIINC_PATHLIST))
-    INCLDIR += -I$(MPIINC)
-  endif
-  CPPDEFS += -DHAVE_MPI
-  MPISERIAL =
-  CMAKE_OPTS += -DCMAKE_Fortran_COMPILER=mpif90
+# Change colon delimited list to space with a -I in front of each
+ifdef MPIINC_PATHLIST
+  MPIINC   = $(subst :, -I,$(MPIINC_PATHLIST))
+  INCLDIR += -I$(MPIINC)
 endif
+CPPDEFS += -DHAVE_MPI
+CMAKE_OPTS += -DCMAKE_Fortran_COMPILER=mpif90
 
 ifeq "$(isGPTL)" "yes"
   PIO_ENABLE_TIMING = ON
@@ -84,7 +52,7 @@ CMAKE_OPTS += -Wno-dev -D CMAKE_Fortran_FLAGS:STRING="$(FLAGS) $(CPPDEFS) $(INCL
               -D PIO_ENABLE_TESTS:BOOL=OFF \
               -D CMAKE_INSTALL_PREFIX:PATH=$(PIOLIBDIR) \
               -D PIO_ENABLE_TIMING:BOOL=$(PIO_ENABLE_TIMING) \
-              -D USER_CMAKE_MODULE_PATH:LIST="$(CIMEROOT)/src/CMake;$(PIO2DIR)/cmake"
+              -D USER_CMAKE_MODULE_PATH:LIST="$(PIO2DIR)/cmake"
 CMAKE_OPTS += -D NetCDF_PATH:PATH=$(NCDF_PATH)
 
 ifdef PNETCDF_PATH
@@ -105,29 +73,15 @@ ifeq "$(MODE)" "debug"
    CMAKE_OPTS += -DCMAKE_BUILD_TYPE=Debug
 endif
 
-$(MPISERCONF):
-	cp -p $(MPISERIALDIR)/*.h $(MPISERLIBDIR)/.
-	cd $(MPISERLIBDIR) && $(MPISERIALDIR)/configure FC=$(FC) MPIFC=$(FC_EXE) FCFLAGS="$(FLAGS) \
-                                              -I$(MPISERIALDIR)" MCT_PATH=$(MPISERIALDIR) --srcdir $(MPISERIALDIR) \
-                                              $(MODEARGS)
-	ln -sf $(MPISERIALDIR)/Makefile $(MPISERLIBDIR)/Makefile
-
-$(MPISERLIB): $(MPISERCONF)
-	$(MAKE) $(MFLAGS) -C $(MPISERLIBDIR) SRCDIR=$(MCTDIR)
-
-cleanlibs: cleanmpiseriallib cleanpiolib
+cleanlibs: cleanpiolib
 	@echo "Clean the libraries"
 .PHONY : cleanlibs
-
-cleanmpiseriallib:
-	rm $(MPISERLIBDIR)/*.h $(MPISERLIB) $(MPISERCONF) $(MPISERLIBDIR)/Makefile
-.PHONY : cleanmpiseriallib
 
 cleanpiolib:
 	rm -rf $(PIOLIBDIR)/CMake* $(PIOLIBDIR)/*.cmake $(PIOLIBDIR)/*.h $(PIOLIB) $(PIOLIBDIR)/include/* $(PIOLIBMAKE)
 .PHONY : cleanpiolib
 
-$(PIOLIBMAKE): $(MPISERIAL)
+$(PIOLIBMAKE):
 	cd $(PIOLIBDIR); \
 	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(MODEARGS) $(PIO2DIR)
 
@@ -137,15 +91,10 @@ $(PIOLIB): $(PIOLIBMAKE)
 	$(MAKE) $(MFLAGS) -C $(PIOLIBDIR) install
 
 db_extlibs:
-	@echo "CIMEROOT:  "       $(CIMEROOT)
 	@echo "libdir:    "       $(LIBDIR)
 	@echo "CPP-DEFS:  "       $(CPPDEFS)
-	@echo "mpi-serial:"       $(MPISERIALDIR)
 	@echo "pio2dir:   "       $(PIO2DIR)
-	@echo "mpi-seriallibdir:" $(MPISERLIBDIR)
 	@echo "piolibdir: "       $(PIOLIBDIR)
-	@echo "mpi-seriallib:   " $(MPISERLIB)
-	@echo "mpi-serialconf:  " $(MPISERCONF)
 	@echo "piolib:    "       $(PIOLIB)
 	@echo "piolib:Make"       $(PIOLIBMAKE)
 	@echo "MPIINC_PATHLIST: " $(MPIINC_PATHLIST)

--- a/route/build/lib/Makefile
+++ b/route/build/lib/Makefile
@@ -53,7 +53,16 @@ CMAKE_OPTS += -Wno-dev -D CMAKE_Fortran_FLAGS:STRING="$(FLAGS) $(CPPDEFS) $(INCL
               -D CMAKE_INSTALL_PREFIX:PATH=$(PIOLIBDIR) \
               -D PIO_ENABLE_TIMING:BOOL=$(PIO_ENABLE_TIMING) \
               -D USER_CMAKE_MODULE_PATH:LIST="$(PIO2DIR)/cmake"
-CMAKE_OPTS += -D NetCDF_PATH:PATH=$(NCDF_PATH)
+
+# Allow for separate installations of the NetCDF C and Fortran libraries
+ifdef NCDF_PATH
+  CMAKE_OPTS += -D NetCDF_PATH:PATH=$(NCDF_PATH)
+else
+# NETCDF_Fortran_DIR points to the separate
+# installation of Fortran NetCDF for PIO
+  CMAKE_OPTS += -D NetCDF_C_PATH:PATH=$(NCDF_C_PATH) \
+                -D NetCDF_Fortran_PATH:PATH=$(NCDF_FORTRAN_PATH)
+endif
 
 ifdef PNETCDF_PATH
         CMAKE_OPTS += -D PnetCDF_PATH:STRING="$(PNETCDF_PATH)"


### PR DESCRIPTION
Removed unnecessary libraries - cime, mct, mpi-serieal for makefile and externals.cfs. 