### PR TITLE
Pass through option and river length check

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -272,12 +272,12 @@ implicit none
   character(len=32),dimension(:),allocatable :: pfafCode     ! pfafstetter code
   integer(i4b)                               :: RHORDER      ! Processing sequence
   real(dp)    ,dimension(:),allocatable      :: UH           ! Unit hydrograph for upstream
-  integer(i4b)                               :: LAKE_IX      ! Lake index (1,2,...,nlak)
-  integer(i4b)                               :: LAKE_ID      ! Lake ID (REC code)
-  real(dp)                                   :: BASULAK      ! Area of basin under lake
-  real(dp)                                   :: RCHULAK      ! Length of reach under lake
+!  integer(i4b)                               :: LAKE_IX      ! Lake index (1,2,...,nlak)
+!  integer(i4b)                               :: LAKE_ID      ! Lake ID (REC code)
+!  real(dp)                                   :: BASULAK      ! Area of basin under lake
+!  real(dp)                                   :: RCHULAK      ! Length of reach under lake
+!  logical(lgt)                               :: USRTAKE      ! .TRUE. if user takes from reach, .FALSE. otherwise
   logical(lgt)                               :: LAKINLT      ! .TRUE. if reach is lake inlet, .FALSE. otherwise
-  logical(lgt)                               :: USRTAKE      ! .TRUE. if user takes from reach, .FALSE. otherwise
   logical(lgt)                               :: ISLAKE       ! .TRUE. if the object is a lake
   logical(lgt)                               :: LAKETARGVOL  ! .TRUE. if the lake follow a given target volume
   integer(i4b)                               :: LAKEMODELTYPE! 1=Doll, 2=Hanasaki, 3=HYPE else=non-parameteric

--- a/route/build/src/kwe_route.f90
+++ b/route/build/src/kwe_route.f90
@@ -15,6 +15,7 @@ USE public_var,    ONLY: dt              ! simulation time step [sec]
 USE public_var,    ONLY: is_flux_wm      ! logical water management components fluxes should be read
 USE public_var,    ONLY: qmodOption      ! qmod option (use 1==direct insertion)
 USE public_var,    ONLY: hw_drain_point  ! headwater catchment pour point (top_reach==1 or bottom_reach==2)
+USE public_var,    ONLY: min_length_route! minimum reach length for routing to be performed.
 USE globalData,    ONLY: idxKW           ! routing method index for kinematic wwave
 USE water_balance, ONLY: comp_reach_wb   ! compute water balance error
 USE base_route,    ONLY: base_route_rch  ! base (abstract) reach routing method class
@@ -249,6 +250,7 @@ CONTAINS
 
  if (.not. isHW .or. hw_drain_point==top_reach) then
 
+   if (rch_param%RLENGTH > min_length_route) then
    Q(1,1) = realMissing ! current time and outlet 4 (1,1)
 
    ! Get the reach parameters
@@ -309,7 +311,9 @@ CONTAINS
        if (absErr(imin) < critFactor*omega) exit
      end do
    endif
-
+   else ! length < min_length_route: length is short enough to just pass upstream to downstream
+      Q(1,1) = q_upstream
+   end if
  else ! if head-water and pour runnof to the bottom of reach
 
    Q(1,0) = 0._dp
@@ -321,9 +325,11 @@ CONTAINS
 
  endif
 
+ if (rch_param%RLENGTH > min_length_route) then
  ! For very low flow condition, outflow - inflow > current storage, so limit outflow and adjust Q(1,1)
  Q(1,1) = min(rflux%ROUTE(idxKW)%REACH_VOL(1)/dt + Q(1,0)*0.999, Q(1,1))
  rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(1) + (Q(1,0)-Q(1,1))*dt
+ end if
 
  ! add catchment flow
  rflux%ROUTE(idxKW)%REACH_Q = Q(1,1)+Qlat

--- a/route/build/src/kwe_route.f90
+++ b/route/build/src/kwe_route.f90
@@ -312,7 +312,8 @@ CONTAINS
      end do
    endif
    else ! length < min_length_route: length is short enough to just pass upstream to downstream
-      Q(1,1) = q_upstream
+     Q(1,0) = q_upstream
+     Q(1,1) = q_upstream
    end if
  else ! if head-water and pour runnof to the bottom of reach
 

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -344,7 +344,8 @@ CONTAINS
      Q(1,1) = 0._dp
    end if
    else ! length < min_length_route: length is short enough to just pass upstream to downstream
-      Q(1,1) = q_upstream
+     Q(1,0) = q_upstream
+     Q(1,1) = q_upstream
    end if
  else ! if head-water and pour runnof to the bottom of reach
 

--- a/route/build/src/process_ntopo.f90
+++ b/route/build/src/process_ntopo.f90
@@ -337,11 +337,11 @@ END SUBROUTINE augment_ntopo
   do iSeg = 1,nSeg
     associate(segId => structNTOPO(iSeg)%var(ixNTOPO%segId)%dat(1))
     ! Check reach length
-    if (structSEG(iSeg)%var(ixSEG%length)%dat(1) <= 0 )then
-     ierr=10
-     write(message,'(a,i0,a,1PG15.7)') trim(message)//'reach length for reach id ', segId, ' is negative:', structSEG(iSeg)%var(ixSEG%length)%dat(1)
-     return
-    endif
+    if (structSEG(iSeg)%var(ixSEG%length)%dat(1)<=0) then
+      write(iulog,'(a,i0,a,1PG15.7, a)') 'WARNING: length for reach id ',segId,' is ',structSEG(iSeg)%var(ixSEG%length)%dat(1),'<0. Corrected to 100 m'
+      structSEG(iSeg)%var(ixSEG%length)%dat(1)=100._dp
+    end if
+    ! Check reach slope
     end associate
   enddo
 
@@ -520,11 +520,11 @@ END SUBROUTINE augment_ntopo
      NETOPO_in(iSeg)%LakeModelType= structNTOPO(iSeg)%var(ixNTOPO%LakeModelType)%dat(1) ! type of the parameteric lake
      NETOPO_in(iSeg)%LAKINLT      = (structNTOPO(iSeg)%var(ixNTOPO%isLakeInlet)%dat(1)==true)   ! .TRUE. if reach is lake inlet, .FALSE. otherwise
      ! NOT USED: lake parameters
-     NETOPO_in(iSeg)%LAKE_IX = integerMissing  ! Lake index (0,1,2,...,nlak-1)
-     NETOPO_in(iSeg)%LAKE_ID = integerMissing  ! Lake ID (REC code?)
-     NETOPO_in(iSeg)%BASULAK = realMissing     ! Area of basin under lake
-     NETOPO_in(iSeg)%RCHULAK = realMissing     ! Length of reach under lake
-     NETOPO_in(iSeg)%USRTAKE = .false.         ! .TRUE. if user takes from reach, .FALSE. otherwise
+!     NETOPO_in(iSeg)%LAKE_IX = integerMissing  ! Lake index (0,1,2,...,nlak-1)
+!     NETOPO_in(iSeg)%LAKE_ID = integerMissing  ! Lake ID (REC code?)
+!     NETOPO_in(iSeg)%BASULAK = realMissing     ! Area of basin under lake
+!     NETOPO_in(iSeg)%RCHULAK = realMissing     ! Length of reach under lake
+!     NETOPO_in(iSeg)%USRTAKE = .false.         ! .TRUE. if user takes from reach, .FALSE. otherwise
    end if
 
    ! reach unit hydrograph

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -114,6 +114,7 @@ MODULE public_var
   logical(lgt)         ,public    :: is_Ep_upward_negative= .false.         ! set to true when convention of upward evaporation is negative
   real(dp)             ,public    :: scale_factor_prec    = realMissing     ! float scale to scale the precipitation
   real(dp)             ,public    :: offset_value_prec    = realMissing     ! float offset for precipitation
+  real(dp)             ,public    :: min_length_route     = 0.0_dp          ! float; minimum reach length for routing to be performed. pass-through is performed for length less than this threshold
   logical(lgt)         ,public    :: compWB               = .false.         ! logical if entire domain water balance is computed
   real(dp)             ,public    :: dt                   = realMissing     ! simulation time step (seconds)
   ! RIVER NETWORK TOPOLOGY

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -526,12 +526,10 @@ CONTAINS
  end do
 
  if (masterproc) then
+   write(iulog,'(2a)') new_line('a'), '---- mis. routing options --- '
    if (min_length_route>0._dp)then
-     write(iulog,'(2a)') new_line('a'), '---- mis. routing options --- '
      write(iulog,'(a,F6.1,a)') '  pass-through is activated for <', min_length_route, ' m reaches only for IRF, KWE, MC, DW'
    end if
- end if
- if (masterproc) then
    if (hw_drain_point==1)then
      write(iulog,'(a)') '  Lateral flow drains at the top of headwater reaches only for IRF, KWE, MC, DW'
    end if

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -137,6 +137,7 @@ CONTAINS
    case('<is_Ep_upward_negative>'); read(cData,*,iostat=io_error) is_Ep_upward_negative ! logical; flip evaporation in case upward direction is negative in input values convention
    case('<scale_factor_prec>');    read(cData,*,iostat=io_error) scale_factor_prec     ! float; factor to scale the precipitation values
    case('<offset_value_prec>');    read(cData,*,iostat=io_error) offset_value_prec     ! float; offset for precipitation values
+   case('<min_length_route>');     read(cData,*,iostat=io_error) min_length_route      ! float; minimum reach length for routing to be performed. pass-through is performed for length less than this threshold
    ! RIVER NETWORK TOPOLOGY
    case('<fname_ntopOld>');        fname_ntopOld = trim(cData)                         ! name of file containing stream network topology information
    case('<ntopAugmentMode>');      read(cData,*,iostat=io_error) ntopAugmentMode       ! option for river network augmentation mode. terminate the program after writing augmented ntopo.
@@ -503,6 +504,7 @@ CONTAINS
    end if
  end if
 
+ ! 5. routing options
  ! ---- routing methods
  ! Assign index for each active routing method
  ! Make sure to turn off write option for routines not used
@@ -522,6 +524,18 @@ CONTAINS
        message=trim(message)//'routOpt may include invalid digits; expect digits 1-5 in routOpt'; err=81; return
    end select
  end do
+
+ if (masterproc) then
+   if (min_length_route>0._dp)then
+     write(iulog,'(2a)') new_line('a'), '---- mis. routing options --- '
+     write(iulog,'(a,F6.1,a)') '  pass-through is activated for <', min_length_route, ' m reaches only for IRF, KWE, MC, DW'
+   end if
+ end if
+ if (masterproc) then
+   if (hw_drain_point==1)then
+     write(iulog,'(a)') '  Lateral flow drains at the top of headwater reaches only for IRF, KWE, MC, DW'
+   end if
+ end if
 
  ! ---- history Output variables
  if (outputInflow) then


### PR DESCRIPTION
A user can specify minimum river length in a control file (control variable is `min_length_route` with default is 0.0 m) so that for very short river reach, actual routing(s) is skipped and inflow is just "passed" to downstream. 

This should be used for standalone use, not for cesm coupling purpose, because river volume is not computed and set to 0 for now (i.e, cause water in-balance).

Also, if non-physical river length is found in the river network data, it is set to 100 m and give WARNING message to the user.  -> resolve #221

No answer changes occur by this PR unless `min_length_route` is set to > 0 meter.
