### PR TITLE
no need to use read function to get string

### DIFF
--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -236,8 +236,7 @@ CONTAINS
   do iFile=1,nFile
 
     ! set forcing file name
-    read(dataLines(iFile),*,iostat=ierr) inputFileInfo(iFile)%infilename
-    if(ierr/=0)then; message=trim(message)//'problem reading a line of data from file ['//trim(infilename)//']'; return; end if
+    inputFileInfo(iFile)%infilename = dataLines(iFile)
 
     ! get the time units. if not exsit in netcdfs, provided from the control file
     existAttr = check_attr(trim(dir_name)//trim(inputFileInfo(iFile)%infilename), time_var_name, 'units')


### PR DESCRIPTION
**Some background**

A text file listing input runoff netcdf(s) can include relative path to an input directory specified in <input_dir> tag in a control file. 

For example, <input_dir> is specified as `/home/mizukami/mizuRoute/input`, and `runoff.txt` located there lists `../runoff_input/runoff_1980.nc`.  In this way, mizuRoute can locate `runoff_1980.nc` correctly if `runoff_1980.nc` is saved in `/home/mizukami/mizuRoute/runoff_input/`.

**small bug**
However, If a text file listing runoff netcdfs includes relative path (e.g., dir1/dir2/runoff.nc), `read` statement does not store a string `inputFileInfo(iFile)%infilename` properly. it cuts at slash (`/`).  

**bug fix**
Since `dataLines` already stores a string correctly, just need to copy into `inputFileInfo(iFile)%infilename`.


