### PR TITLE
history file time stamp flexibility

### DIFF
--- a/route/build/src/historyFile.f90
+++ b/route/build/src/historyFile.f90
@@ -13,6 +13,7 @@ MODULE historyFile
   USE globalData,        ONLY: pioSystem
   USE public_var,        ONLY: pio_netcdf_format
   USE public_var,        ONLY: pio_typename
+  USE globalData,        ONLY: sec2tunit           ! seconds per time unit
   USE globalData,        ONLY: version
   USE globalData,        ONLY: gitBranch
   USE globalData,        ONLY: gitHash
@@ -310,13 +311,13 @@ MODULE historyFile
     ! ---------------------------------
     ! writing time variables
     ! ---------------------------------
-    SUBROUTINE write_time(this, hVars_local, time_stamp_Local, ierr, message)
+    SUBROUTINE write_time(this, hVars_local, timeStampOffset, ierr, message)
 
       implicit none
       ! Argument variables
       class(histFile),           intent(inout) :: this
       type(histVars),            intent(in)    :: hVars_local      ! history variable structure
-      character(len=strLen),     intent(in)    :: time_stamp_local ! time stamp for time variable: front, end, or middle
+      real(dp),                  intent(in)    :: timeStampOffset  ! time stamp offset from start of time step [sec]
       integer(i4b),              intent(out)   :: ierr             ! error code
       character(*),              intent(out)   :: message          ! error message
       ! local variables
@@ -328,11 +329,7 @@ MODULE historyFile
       this%iTime = this%iTime + 1 ! this is only line to increment time step index
 
       ! write time -- note time is just carried across from the input
-      select case(trim(time_stamp_local))
-        case('front');  timeVar_write = hVars_local%timeVar(1)
-        case('end');    timeVar_write = hVars_local%timeVar(2)
-        case('middle'); timeVar_write = (hVars_local%timeVar(1)+hVars_local%timeVar(2))/2.0
-      end select
+      timeVar_write = hVars_local%timeVar(1)+timeStampOffset/sec2tunit
 
       call write_netcdf(this%pioFileDesc, 'time', [timeVar_write], [this%iTime], [1], ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -139,7 +139,7 @@ MODULE public_var
   real(dp)             ,public    :: input_fillvalue      = realMissing     ! fillvalue used for input variables (runoff, precipitation, evaporation)
   character(len=strLen),public    :: ro_time_units        = charMissing     ! time units used in ro netcdf. format should be <unit> since yyyy-mm-dd (hh:mm:ss). () can be omitted
   character(len=strLen),public    :: ro_calendar          = charMissing     ! calendar used in ro netcdf
-  character(len=strLen),public    :: ro_time_stamp        = 'front'         ! time stamp used for I/O - front (default), middle, or end, otherwise error
+  character(len=strLen),public    :: ro_time_stamp        = 'start'         ! time stamp used in runoff input - start (default), middle, or end, otherwise error
   ! Water-management input netCDF - water abstraction/infjection or lake target volume
   character(len=strLen),public    :: fname_wm             = ''              ! the txt file name that includes nc files holesing the abstraction, injection, target volume values
   character(len=strLen),public    :: vname_flux_wm        = ''              ! variable name for abstraction or injection from or to a river segment
@@ -180,6 +180,7 @@ MODULE public_var
   character(len=strLen),public    :: dname_gageTime       = ''              ! dimension name for time
   integer(i4b)         ,public    :: strlen_gageSite      = 30              ! maximum character length for site name
   ! OUTPUT OPTIONS
+  real(dp)             ,public    :: histTimeStamp_offset = 0._dp           ! time stamp offset [second] from a start of time step
   logical(lgt)         ,public    :: outputInflow         = .false.         ! logical; T-> write upstream inflow in history file output
   ! USER OPTIONS
   integer(i4b)         ,public    :: qmodOption           = 0               ! option for streamflow modification

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -160,7 +160,7 @@ CONTAINS
    case('<input_fillvalue>');      read(cData,*,iostat=io_error) input_fillvalue       ! fillvalue used for input variable
    case('<ro_calendar>');          ro_calendar  = trim(cData)                          ! name of calendar used in runoff input netcdfs
    case('<ro_time_units>');        ro_time_units = trim(cData)                         ! time units used in runoff input netcdfs
-   case('<ro_time_stamp>');        ro_time_stamp = trim(cData)                         ! time stamp used input - front, middle, or end, otherwise error
+   case('<ro_time_stamp>');        ro_time_stamp = trim(cData)                         ! time stamp used input - start, middle, or end, otherwise error
    ! Water-management input netCDF - water abstraction/infjection or lake target volume
    case('<fname_wm>');             fname_wm        = trim(cData)                       ! name of text file containing ordered nc file names
    case('<vname_flux_wm>');        vname_flux_wm   = trim(cData)                       ! name of varibale for fluxes to and from seg (reachs/lakes)
@@ -218,6 +218,7 @@ CONTAINS
    case('<time_units>');           time_units = trim(cData)                            ! time units used in history file output. format should be <unit> since yyyy-mm-dd (hh:mm:ss). () can be omitted
    case('<newFileFrequency>');     newFileFrequency = trim(cData)                      ! frequency for new history files (daily, monthly, yearly, single)
    case('<outputFrequency>');      outputFrequency  = trim(cData)                      ! output frequency (integer for multiple of simulation time step or daily, monthly or yearly)
+   case('<histTimeStamp_offset>'); read(cData,*,iostat=io_error) histTimeStamp_offset  ! time stamp offset [second] from a start of time step
    case('<basRunoff>');            read(cData,*,iostat=io_error) meta_hflx(ixHFLX%basRunoff        )%varFile  ! default: true
    case('<instRunoff>');           read(cData,*,iostat=io_error) meta_rflx(ixRFLX%instRunoff       )%varFile  ! default: false
    case('<dlayRunoff>');           read(cData,*,iostat=io_error) meta_rflx(ixRFLX%dlayRunoff       )%varFile  ! default: false
@@ -442,10 +443,10 @@ CONTAINS
  if (masterproc) then
    write(iulog,'(2a)') new_line('a'), '---- input time stamp --- '
    write(iulog,'(2A)')      '  Input time stamp <ro_time_stamp>:  ', trim(ro_time_stamp)
-   if (trim(ro_time_stamp)=='front' .or. trim(ro_time_stamp)=='end' .or. trim(ro_time_stamp)=='middle') then
+   if (trim(ro_time_stamp)=='start' .or. trim(ro_time_stamp)=='end' .or. trim(ro_time_stamp)=='middle') then
      write(iulog,'(2A)')      '  The same time stamp is used for history output'
    else
-     write(message, '(2A)') trim(message), 'ERROR: Input time stamp <ro_time_stamp> must be front, end, or middle'
+     write(message, '(2A)') trim(message), 'ERROR: Input time stamp <ro_time_stamp> must be start, end, or middle'
      err=81; return
    end if
  end if

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -444,7 +444,7 @@ CONTAINS
   ! datetime of runoff time at front of the 1st time step:  roBegDatetime (global data)
   ! datetime of runoff time at end of last time step: roDatetime_end (local data)
   select case(trim(ro_time_stamp))
-    case('front')
+    case('start')
       roBegDatetime  = roCal(1)
       roDatetime_end = roCal(nTime)%add_sec(dt_ro, ierr, cmessage)
     case('end')

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -134,7 +134,7 @@ CONTAINS
    USE public_var, ONLY: outputAtGage                 ! ascii containing last restart and history files
    USE public_var, ONLY: nOutFreq                     ! integer output frequency, i.e, written at every "nOutFreq" of simulation step
    USE public_var, ONLY: outputFrequency              ! writing frequency
-   USE public_var, ONLY: time_stamp => ro_time_stamp  !
+   USE public_var, ONLY: histTimeStamp_offset         ! history time stamp offset from the start of time step [sec]
    USE globalData, ONLY: simDatetime                  ! previous,current and next model datetime
    USE globalData, ONLY: timeVar                      ! current simulation time variable
    USE globalData, ONLY: sec2tunit                    ! seconds per time unit
@@ -204,7 +204,7 @@ CONTAINS
      end if
 
      ! write time variables (time and time bounds)
-     call hist_all_network%write_time(hVars, time_stamp, ierr, cmessage)
+     call hist_all_network%write_time(hVars, histTimeStamp_offset, ierr, cmessage)
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
      ! write out output variables in history files
@@ -221,7 +221,7 @@ CONTAINS
 
      if (outputAtGage) then
        ! write time variables (time and time bounds)
-       call hist_gage%write_time(hVars, time_stamp, ierr, cmessage)
+       call hist_gage%write_time(hVars, histTimeStamp_offset, ierr, cmessage)
        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
        call hist_gage%write_flux_rch(hVars, ioDesc_gauge_float, index_write_gage, ierr, cmessage)


### PR DESCRIPTION
Added new control variable `<histTimeStamp_offset>`: time stamp offset [second] from a start of output time step (specified in `time_bounds` in history netCDF). Default is zero, meaning a time stamp in `time` variable in the history netCDF is at beginning of the output time step.

This can be used for cesm coupling run to make the time stamp convention consistent with cesm's convention (not implemented yet).

This is optional and backward compatible.