### PR TITLE
Change in stand-alone runoff (and water management) input specification in control file 

### DIFF
--- a/route/build/src/standalone/get_basin_runoff.f90
+++ b/route/build/src/standalone/get_basin_runoff.f90
@@ -20,7 +20,6 @@ CONTAINS
 
  ! get forcing data at current step at all the hrus
 
-  USE public_var,           ONLY: input_dir           ! directory containing input data
   USE public_var,           ONLY: vname_qsim          ! varibale runoff in netCDF file
   USE public_var,           ONLY: vname_evapo         ! varibale actual evaporation in netCDF file
   USE public_var,           ONLY: vname_precip        ! varibale precipitation in netCDF file
@@ -74,8 +73,7 @@ CONTAINS
     if(ierr/=0) then; message=trim(message)//trim(cmessage); return; endif
 
     ! get the simulated runoff for the current time step - runoff_data%sim(:) or %sim2D(:,:)
-    call read_forcing_data(input_dir,             & ! input: directory
-                          inFileInfo_ro,          & ! input: meta for forcing input files
+    call read_forcing_data(inFileInfo_ro,          & ! input: meta for forcing input files
                           vname_qsim,             & ! input: varname
                           tmap_sim_ro,            & ! input: ro-sim time mapping at current simulation step
                           runoff_data,            & ! inout: forcing data structure
@@ -113,8 +111,7 @@ CONTAINS
       runoff_data%basinEvapo  = 0._dp ! set evaporation to zero
     else
       ! get the actual evaporation - runoff_data%sim(:) or %sim2D(:,:)
-      call read_forcing_data(input_dir,              & ! input: directory
-                             inFileInfo_ro,          & ! input: meta for forcing input files
+      call read_forcing_data(inFileInfo_ro,          & ! input: meta for forcing input files
                              vname_evapo,            & ! input: varname
                              tmap_sim_ro,            & ! input: ro-sim time mapping at current simulation step
                              runoff_data,            & ! inout: forcing data structure
@@ -149,8 +146,7 @@ CONTAINS
       runoff_data%basinPrecip  = 0._dp ! set precipitation to zero
     else
       ! get the precepitation - runoff_data%sim(:) or %sim2D(:,:)
-      call read_forcing_data(input_dir,              & ! input: directory
-                             inFileInfo_ro,          & ! input: meta for forcing input files
+      call read_forcing_data(inFileInfo_ro,          & ! input: meta for forcing input files
                              vname_precip,           & ! input: varname
                              tmap_sim_ro,            & ! input: ro-sim time mapping at current simulation step
                              runoff_data,            & ! inout: forcing data structure
@@ -180,8 +176,7 @@ CONTAINS
     if (is_vol_wm) then
 
       ! get the added or subtracted discharge from river segments
-      call read_forcing_data(input_dir,          & ! input: input directory
-                             inFileInfo_wm,      & ! input: meta for water-management input files
+      call read_forcing_data(inFileInfo_wm,      & ! input: meta for water-management input files
                              vname_vol_wm,       & ! input: varname
                              tmap_sim_wm,        & ! input: wm-sim time mapping at current simulation step
                              wm_data,            & ! inout: water management data structure
@@ -203,8 +198,7 @@ CONTAINS
   ! Optional: reading water abstraction and subtraction
   if (is_flux_wm) then
     ! get the added or subtracted discharge from river segments
-    call read_forcing_data(input_dir,             & ! input: input directory
-                           inFileInfo_wm,         & ! input: meta for water-management input files
+    call read_forcing_data(inFileInfo_wm,         & ! input: meta for water-management input files
                            vname_flux_wm,         & ! input: varname
                            tmap_sim_wm,           & ! input: wm-sim time mapping at current simulation step
                            wm_data,               & ! inout: water management data structure

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -221,7 +221,7 @@ CONTAINS
   ! build filename and its path containing list of NetCDF files
   infilename = trim(dir_name)//trim(file_name)
   tmp_file_list = trim(dir_name)//'tmp'
-  call system("ls "//infilename//" > "//trim(tmp_file_list))
+  call execute_command_line("ls "//infilename//" > "//trim(tmp_file_list))
 
   call file_open(tmp_file_list,funit,ierr,cmessage) ! open the text file
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; end if
@@ -315,7 +315,7 @@ CONTAINS
   close(unit=funit,iostat=ierr) ! close ascii file
   if(ierr/=0)then;message=trim(message)//'problem closing forcing file list'; return; end if
 
-  call system("rm -r "//trim(tmp_file_list))
+  call execute_command_line("rm -r "//trim(tmp_file_list))
 
  END SUBROUTINE inFile_pop
 

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -122,7 +122,7 @@ CONTAINS
  SUBROUTINE init_inFile_pop(ierr, message)
 
   USE public_var, ONLY: input_dir               ! directory containing the text files of fname_qsim and fname_wm
-  USE public_var, ONLY: fname_qsim              ! simulated runoff txt file that includes the NetCDF file names
+  USE public_var, ONLY: fname_qsim              ! runoff netcdf file name. multiple files can be expressed with wildcard
   USE public_var, ONLY: vname_time              ! variable name for time
   USE public_var, ONLY: dname_time              ! dimension name for time
   USE public_var, ONLY: fname_wm                ! simulated runoff txt file that includes the NetCDF file names
@@ -205,6 +205,7 @@ CONTAINS
   character(*),          intent(out)                :: message          ! error message
   ! local varibales
   integer(i4b)                                      :: funit            ! file unit (free unit output from file_open)
+  character(len=strLen)                             :: tmp_file_list    ! temporal text listing all the input netcdf(s)
   character(len=7)                                  :: t_unit           ! time units. "<time_step> since yyyy-MM-dd hh:mm:ss"
   integer(i4b)                                      :: iFile            ! counter for forcing files
   integer(i4b)                                      :: nFile            ! number of nc files identified in the text file
@@ -219,8 +220,10 @@ CONTAINS
 
   ! build filename and its path containing list of NetCDF files
   infilename = trim(dir_name)//trim(file_name)
+  tmp_file_list = trim(dir_name)//'tmp'
+  call system("ls "//infilename//" > "//trim(tmp_file_list))
 
-  call file_open(infilename,funit,ierr,cmessage) ! open the text file
+  call file_open(tmp_file_list,funit,ierr,cmessage) ! open the text file
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; end if
 
   ! get a list of character strings from non-commented lines
@@ -239,9 +242,9 @@ CONTAINS
     inputFileInfo(iFile)%infilename = dataLines(iFile)
 
     ! get the time units. if not exsit in netcdfs, provided from the control file
-    existAttr = check_attr(trim(dir_name)//trim(inputFileInfo(iFile)%infilename), time_var_name, 'units')
+    existAttr = check_attr(trim(inputFileInfo(iFile)%infilename), time_var_name, 'units')
     if (existAttr) then
-      call get_var_attr(trim(dir_name)//trim(inputFileInfo(iFile)%infilename), &
+      call get_var_attr(trim(inputFileInfo(iFile)%infilename), &
                         time_var_name, 'units', inputFileInfo(iFile)%unit, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     else
@@ -253,9 +256,9 @@ CONTAINS
     end if
 
     ! get the calendar. if not exsit in netcdfs, provided from the control file
-    existAttr = check_attr(trim(dir_name)//trim(inputFileInfo(iFile)%infilename), time_var_name, 'calendar')
+    existAttr = check_attr(trim(inputFileInfo(iFile)%infilename), time_var_name, 'calendar')
     if (existAttr) then
-      call get_var_attr(trim(dir_name)//trim(inputFileInfo(iFile)%infilename), &
+      call get_var_attr(trim(inputFileInfo(iFile)%infilename), &
                         time_var_name, 'calendar', inputFileInfo(iFile)%calendar, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     else
@@ -267,7 +270,7 @@ CONTAINS
     end if
 
     ! get the dimension of the time to populate nTime and pass it to the get_nc file
-    call get_nc_dim_len(trim(dir_name)//trim(inputFileInfo(iFile)%infilename), &
+    call get_nc_dim_len(trim(inputFileInfo(iFile)%infilename), &
                         time_dim_name, inputFileInfo(iFile)%nTime, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
@@ -278,7 +281,7 @@ CONTAINS
     if(ierr/=0)then; ierr=20; message=trim(message)//'problem allocating space for inputFileInfo(:)%timeVar'; return; end if
 
     ! get the time varibale
-    call get_nc(trim(dir_name)//trim(inputFileInfo(iFile)%infilename), &
+    call get_nc(trim(inputFileInfo(iFile)%infilename), &
                 time_var_name, inputFileInfo(iFile)%timeVar, 1, nTime, ierr, cmessage) ! does it needs timeVar(:)
 
     ! get the time multiplier needed to convert time to units of days for each nc file
@@ -311,6 +314,8 @@ CONTAINS
 
   close(unit=funit,iostat=ierr) ! close ascii file
   if(ierr/=0)then;message=trim(message)//'problem closing forcing file list'; return; end if
+
+  call system("rm -r "//trim(tmp_file_list))
 
  END SUBROUTINE inFile_pop
 
@@ -662,7 +667,7 @@ CONTAINS
    ierr=0; message='init_forc_data/'
 
    ! passing the first nc file as global file name to read
-   fname = trim(input_dir)//trim(inFileInfo_ro(1)%infilename)
+   fname = trim(inFileInfo_ro(1)%infilename)
 
    if (trim(vname_hruid)==charMissing) then
      ! get runoff metadata for simulated runoff, evaporation and precipitation
@@ -774,7 +779,7 @@ CONTAINS
    if ((is_flux_wm).or.((is_vol_wm).and.(is_lake_sim))) then
 
      ! passing the first netCDF as global file meta to read
-     fname = trim(input_dir)//trim(inFileInfo_wm(1)%infilename)
+     fname = trim(inFileInfo_wm(1)%infilename)
 
      call read_forcing_metadata(fname,                         & ! input: filename
                                vname_flux_wm,                 & ! input: varibale name for simulated runoff

--- a/route/build/src/standalone/read_runoff.f90
+++ b/route/build/src/standalone/read_runoff.f90
@@ -230,15 +230,13 @@ CONTAINS
 ! *********************************************************************
 ! public subroutine: main interface for forcing data reading
 ! *********************************************************************
-  SUBROUTINE read_forcing_data(indir,            &  ! input: forcing input directory
-                               inFileInfo_in,    &  ! input: forcing input file metadata
+  SUBROUTINE read_forcing_data(inFileInfo_in,    &  ! input: forcing input file metadata
                                var_name,         &  ! input: varibale name
                                tmap_sim_forc_in, &  ! input: time-step mapping between model and forcing
                                forcing_data_in,  &  ! inout: forcing data structure
                                ierr, message)       ! output: error control
   implicit none
   ! argument variables
-  character(*),     intent(in)      :: indir              ! forcing input directory
   type(inFileInfo), intent(in)      :: inFileInfo_in(:)   ! input file (forcing or water-management) metadata
   character(*),     intent(in)      :: var_name           ! variable name
   type(map_time),   intent(in)      :: tmap_sim_forc_in   ! time-step mapping between model and forcing
@@ -251,10 +249,10 @@ CONTAINS
   ierr=0; message='read_forcing_data/'
 
   if (forcing_data_in%nSpace(2) == integerMissing) then
-   call read_1D_forcing(indir, inFileInfo_in, var_name, tmap_sim_forc_in, forcing_data_in%nSpace(1), forcing_data_in, ierr, cmessage)
+   call read_1D_forcing(inFileInfo_in, var_name, tmap_sim_forc_in, forcing_data_in%nSpace(1), forcing_data_in, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   else
-   call read_2D_forcing(indir, inFileInfo_in, var_name, tmap_sim_forc_in, forcing_data_in%nSpace, forcing_data_in, ierr, cmessage)
+   call read_2D_forcing(inFileInfo_in, var_name, tmap_sim_forc_in, forcing_data_in%nSpace, forcing_data_in, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   endif
 
@@ -263,8 +261,7 @@ CONTAINS
  ! *********************************************************************
  ! private subroutine: read 1D forcing data
  ! *********************************************************************
- SUBROUTINE read_1D_forcing(indir,            &  ! input: forcing input directory
-                            inFileInfo_in,    &  ! input: forcing input file metadata
+ SUBROUTINE read_1D_forcing(inFileInfo_in,    &  ! input: forcing input file metadata
                             var_name,         &  ! input: variable name
                             tmap_sim_forc_in, &  ! input: time-step mapping between model and forcing
                             nSpace,           &  ! input: size of spatial elements (e.g., HRU or reach)
@@ -275,7 +272,6 @@ CONTAINS
 
  implicit none
  ! Argument variables
- character(*),       intent(in)    :: indir             ! input directory
  type(inFileInfo),   intent(in)    :: inFileInfo_in(:)  ! input file (forcing or water-management) metadata
  character(*),       intent(in)    :: var_name          ! variable name
  type(map_time),     intent(in)    :: tmap_sim_forc_in  ! time-step mapping between model and forcing
@@ -303,7 +299,7 @@ CONTAINS
  ! get the forcing data
  forc_data_in%sim(1:nSpace) = 0._dp
  do it = 1, nTime
-   fname = trim(indir)//trim(inFileInfo_in(tmap_sim_forc_in%iFile(it))%infilename)
+   fname = trim(inFileInfo_in(tmap_sim_forc_in%iFile(it))%infilename)
 
    iStart = [1, tmap_sim_forc_in%iTime(it)]
    iCount = [nSpace,1]
@@ -333,8 +329,7 @@ CONTAINS
  ! *********************************************************************
  ! private subroutine: read 2D forcing data
  ! *********************************************************************
- SUBROUTINE read_2D_forcing(indir,            &  ! input: input directory
-                            inFileInfo_in,    &  ! input: meta for input file
+ SUBROUTINE read_2D_forcing(inFileInfo_in,    &  ! input: meta for input file
                             var_name,         &  ! input: variable name
                             tmap_sim_forc_in, &  ! input: time-step mapping between model and forcing
                             nSpace,           &  ! input: size of HRUs
@@ -345,7 +340,6 @@ CONTAINS
 
  implicit none
  ! Argument variables
- character(*),       intent(in)      :: indir             ! input directory
  type(inFileInfo),   intent(in)      :: inFileInfo_in(:)  ! input file (forcing or water-management) meta data
  character(*),       intent(in)      :: var_name          ! variable name
  type(map_time),     intent(in)      :: tmap_sim_forc_in  ! time-step mapping between model and forcing
@@ -372,7 +366,7 @@ CONTAINS
 
  ! get the forcing data
  do it = 1, nTime
-   fname = trim(indir)//trim(inFileInfo_in(tmap_sim_forc_in%iFile(it))%infilename)
+   fname = trim(inFileInfo_in(tmap_sim_forc_in%iFile(it))%infilename)
 
    iStart = [1,1,tmap_sim_forc_in%iTime(it)]
    iCount = [nSpace(2),nSpace(1),1]


### PR DESCRIPTION
Current: user needs to have a text file listing input netcdf(s)

This PR changes a way of specifying the input netcdf(s) in the control file from the text file name to netcdf name including wildcard if there are multiple netcdfs.

This is not backward compatibility in cesm-coupling branch (only for stand-alone use). Users need to update <fname_qsim> if they are specifying the text file.