### PR TITLE
implement generic output name for routing method specific variables

### DIFF
--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -96,6 +96,7 @@ MODULE public_var
   character(len=strLen),public    :: simEnd               = ''              ! date string defining the end of the simulation
   character(len=strLen),public    :: newFileFrequency     = 'yearly'        ! frequency for new output files (daily, monthly, yearly, single)
   character(len=strLen),public    :: outputFrequency      = '1'             ! output frequency (integer for multiple of simulation time step or daily, monthly or yearly)
+  character(len=strLen),public    :: outputNameOption     = 'specific'      ! option for routing method dependent output names (e.g., routedRunoff) - generic or specific (default)
   integer(i4b)         ,public    :: nOutFreq             = integerMissing  ! integer output frequency
   character(len=10)    ,public    :: routOpt              = '0'             ! routing scheme options  0: accum runoff, 1:IRF, 2:KWT, 3:KW, 4:MC, 5:DW
   integer(i4b)         ,public    :: doesBasinRoute       = 1               ! basin routing options   0-> no, 1->IRF, otherwise error

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -59,6 +59,7 @@ CONTAINS
  character(len=strLen)             :: cName,cData             ! name and data from cLines(iLine)
  character(len=strLen)             :: cLength,cTime           ! length and time units
  logical(lgt)                      :: isGeneric               ! temporal logical scalar
+ logical(lgt)                      :: onlyOneRouting          ! temporal logical scalar
  integer(i4b)                      :: ipos                    ! index of character string
  integer(i4b)                      :: ibeg_name               ! start index of variable name in string cLines(iLine)
  integer(i4b)                      :: iend_name               ! end index of variable name in string cLines(iLine)
@@ -590,7 +591,8 @@ CONTAINS
  ! Control routing method dependent variable name - routedRunoff, volume, elevation etc.
  ! use generic name if outputNameOption is set to 'generic' AND only one routing method is activated w or w/o accumRunoff
  isGeneric = trim(lower(outputNameOption))=='generic'
- if ((nRoutes<=2 .and. any(routeMethods==accumRunoff)) .and. isGeneric) then
+ onlyOneRouting = ((nRoutes==2 .and. any(routeMethods==accumRunoff) .or. nRoutes==1))
+ if (onlyOneRouting .and. isGeneric) then
    do iRoute = 1, nRoutes
      select case(routeMethods(iRoute))
        case(accumRunoff)

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -58,6 +58,7 @@ CONTAINS
  character(len=strLen),allocatable :: cLines(:)               ! vector of character strings
  character(len=strLen)             :: cName,cData             ! name and data from cLines(iLine)
  character(len=strLen)             :: cLength,cTime           ! length and time units
+ logical(lgt)                      :: isGeneric               ! temporal logical scalar
  integer(i4b)                      :: ipos                    ! index of character string
  integer(i4b)                      :: ibeg_name               ! start index of variable name in string cLines(iLine)
  integer(i4b)                      :: iend_name               ! end index of variable name in string cLines(iLine)
@@ -587,7 +588,9 @@ CONTAINS
  end do
 
  ! Control routing method dependent variable name - routedRunoff, volume, elevation etc.
- if ((nRoutes<=2 .and. (routeMethods(1)==0 .or. routeMethods(2)==0)) .and. trim(lower(outputNameOption))=='generic') then
+ ! use generic name if outputNameOption is set to 'generic' AND only one routing method is activated w or w/o accumRunoff
+ isGeneric = trim(lower(outputNameOption))=='generic'
+ if ((nRoutes<=2 .and. any(routeMethods==accumRunoff)) .and. isGeneric) then
    do iRoute = 1, nRoutes
      select case(routeMethods(iRoute))
        case(accumRunoff)

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -1235,85 +1235,91 @@ CONTAINS
 
     if (meta_rflx(ixRFLX%KWTroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxKWT)
-      call write_pnetcdf(pioFileDesc, 'KWTroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%KWTroutedRunoff)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%IRFroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxIRF)
-      call write_pnetcdf(pioFileDesc, 'IRFroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%IRFroutedRunoff)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%KWroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxKW)
-      call write_pnetcdf(pioFileDesc, 'KWroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%KWroutedRunoff)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%MCroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxMC)
-      call write_pnetcdf(pioFileDesc, 'MCroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%MCroutedRunoff)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%DWroutedRunoff)%varFile) then
       array_dp = hVars%discharge(index_write, idxDW)
-      call write_pnetcdf(pioFileDesc, 'DWroutedRunoff', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%DWroutedRunoff)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+    endif
+
+    if (meta_rflx(ixRFLX%KWTvolume)%varFile) then
+      array_dp = hVars%volume(index_write, idxKWT)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%KWTvolume)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%IRFvolume)%varFile) then
       array_dp = hVars%volume(index_write, idxIRF)
-      call write_pnetcdf(pioFileDesc, 'IRFvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%IRFvolume)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%KWvolume)%varFile) then
       array_dp = hVars%volume(index_write, idxKW)
-      call write_pnetcdf(pioFileDesc, 'KWvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%KWvolume)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%MCvolume)%varFile) then
       array_dp = hVars%volume(index_write, idxMC)
-      call write_pnetcdf(pioFileDesc, 'MCvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%MCvolume)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%DWvolume)%varFile) then
       array_dp = hVars%volume(index_write, idxDW)
-      call write_pnetcdf(pioFileDesc, 'DWvolume', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%DWvolume)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%KWTinflow)%varFile) then
       array_dp = hVars%inflow(index_write, idxKWT)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-      call write_pnetcdf(pioFileDesc, 'KWTinflow', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%KWTinflow)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
     endif
 
     if (meta_rflx(ixRFLX%IRFinflow)%varFile) then
       array_dp = hVars%inflow(index_write, idxIRF)
-      call write_pnetcdf(pioFileDesc, 'IRFinflow', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%IRFinflow)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%KWinflow)%varFile) then
       array_dp = hVars%inflow(index_write, idxKW)
-      call write_pnetcdf(pioFileDesc, 'KWinflow', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%KWinflow)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%MCinflow)%varFile) then
       array_dp = hVars%inflow(index_write, idxMC)
-      call write_pnetcdf(pioFileDesc, 'MCinflow', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%MCinflow)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 
     if (meta_rflx(ixRFLX%DWinflow)%varFile) then
       array_dp = hVars%inflow(index_write, idxDW)
-      call write_pnetcdf(pioFileDesc, 'DWinflow', array_dp, ioDesc_hist_rch_double, ierr, cmessage)
+      call write_pnetcdf(pioFileDesc, meta_rflx(ixRFLX%DWinflow)%varName, array_dp, ioDesc_hist_rch_double, ierr, cmessage)
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
     endif
 

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -7,15 +7,18 @@
 !       lines starting with <xxx> are read till "!"
 !       Do not inclue empty line without !
 !
-!       Followings are example of control options.  if valid variables are inserted, they are default values.
+!       Please see route/build/src/read_control.f90 for complete options 
+!
+!       Any control variables not in this example use default values defined in public_var.f90.
 !
 ! ****************************************************************************************************************************
 ! RUN CONTROL 
 ! --------------------------------------------
 <case_name>             CASE_NAME                  ! name of simulation
-<route_opt>             1                          ! option for routing schemes (only one-option allowed) 1->IRF, 2->KWT, 3-> KW, 4->MC, 5->DW 
+<route_opt>             5                          ! option for routing schemes (only one-option allowed) 1->IRF, 2->KWT, 3-> KW, 4->MC, 5->DW 
 <doesBasinRoute>        1                          ! basin routing options   0-> no, 1->IRF, otherwise error
 <is_flux_wm>            T                          ! switch for water abstraction/injection
+<hw_drain_point>        2                          ! how lateral flow is put into a headwater reach 1-> top of headwater, 2-> bottom of headwater
 <fname_state_in>        STATE_IN_NC                ! input restart netCDF name. remove for run without any particular initial channel states
 <newFileFrequency>      monthly                    ! frequency for new output files (daily, monthly, yearly, single)
 <outputFrequency>       monthly                    ! time frequency used for temporal aggregation of output variables - numeric or daily, monthyly, or yearly
@@ -70,6 +73,7 @@
 ! NOTE:  discharge and volume output options
 !        Routing options not chosen (see <route_opt>) will be ignored.
 ! ---------------------------
+<outputNameOption>      generic                    ! "generic": routing method dependet output does not include routing schem name
 <basRunoff>             T                          ! HRU average runoff depth at HRU [L/T]
 <instRunoff>            F                          ! intantaneou runoff volume from Local HRUs at reach [L3/T]
 <dlayRunoff>            F                          ! delayed runoff voluem (discharge) from local HRUsi at reach [L3/T] 
@@ -79,11 +83,11 @@
 <MCroutedRunoff>        T                          ! kinematic wave routed discharge at reach [L3/T]
 <KWroutedRunoff>        T                          ! muskingum-cunge routed discharge at reach [L3/T]
 <DWroutedRunoff>        T                          ! diffusive wave routed discharge at reach [L3/T]
-<KWTvolume>             F                          ! kinematic wave tracking volume at the end of time step at reach [L3]
-<IRFvolume>             F                          ! impulse response function volume at the end of time step at reach [L3]
-<KWvolume>              F                          ! Euler kinematic wave volume at the end of time step at reach [L3]
-<MCvolume>              F                          ! muskingum-cunge volume at the end of time step at reach [L3]
-<DWvolume>              F                          ! diffusive wave volume at the end of time step at reach [L3]
+<KWTvolume>             T                          ! kinematic wave tracking volume at the end of time step at reach [L3]
+<IRFvolume>             T                          ! impulse response function volume at the end of time step at reach [L3]
+<KWvolume>              T                          ! Euler kinematic wave volume at the end of time step at reach [L3]
+<MCvolume>              T                          ! muskingum-cunge volume at the end of time step at reach [L3]
+<DWvolume>              T                          ! diffusive wave volume at the end of time step at reach [L3]
 ! ****************************************************************************************************************************
 ! cesm-coupler: negative flow (qgwl and excess irrigation demand) handling option
 ! ---------------------------

--- a/route/settings/SAMPLE.control
+++ b/route/settings/SAMPLE.control
@@ -18,7 +18,7 @@
 <sim_start>               yyyy-mm-dd hh:mm:ss        ! time of simulation start. hh:mm:ss can be omitted
 <sim_end>                 yyyy-mm-dd hh:mm:ss        ! time of simulation end. hh:mm:ss can be omitted
 !-- routing control
-<route_opt>               5                          ! options for routing schemes (multiple options allowed): 1->IRF 2->KWT 3->KW 4->MC 5->DW
+<route_opt>               5                          ! options for routing schemes (multiple options allowed - e.g, 12345-no spaces/commas between routing ids): 1->IRF 2->KWT 3->KW 4->MC 5->DW
 <doesBasinRoute>          1                          ! basin routing options: 0-> no, 1->IRF, otherwise error
 <dt_qsim>                 86400                      ! simulation time interval [sec] e.g., 86400 sec for daily step
 <hw_drain_point>          2                          ! how to add lateral runoff to headwater reaches. 1->top of reach, 2->bottom of reach 

--- a/route/settings/SAMPLE.control
+++ b/route/settings/SAMPLE.control
@@ -7,9 +7,9 @@
 !       lines starting with <xxx> are read till "!"
 !       Do not inclue empty line without !
 !
-!       Followings are example of control options.  if valid variables are inserted, they are default values.
-!       
 !       Please see route/build/src/read_control.f90 for complete options 
+!       
+!       Any control variables not in this example use default values defined in public_var.f90.
 !
 ! ****************************************************************************************************************************
 ! RUN CONTROL 
@@ -17,14 +17,17 @@
 <case_name>               CASE_NAME                  ! name of simulation
 <sim_start>               yyyy-mm-dd hh:mm:ss        ! time of simulation start. hh:mm:ss can be omitted
 <sim_end>                 yyyy-mm-dd hh:mm:ss        ! time of simulation end. hh:mm:ss can be omitted
-<route_opt>               1                          ! options for routing schemes (multiple options allowed): 1->IRF 2->KWT 3->KW 4->MC 5->DW
+!-- routing control
+<route_opt>               5                          ! options for routing schemes (multiple options allowed): 1->IRF 2->KWT 3->KW 4->MC 5->DW
 <doesBasinRoute>          1                          ! basin routing options: 0-> no, 1->IRF, otherwise error
+<dt_qsim>                 86400                      ! simulation time interval [sec] e.g., 86400 sec for daily step
+<hw_drain_point>          2                          ! how to add lateral runoff to headwater reaches. 1->top of reach, 2->bottom of reach 
+
+!-- restart controls
 <restart_write>           last                       ! restart write options: never, daily, monthly, yearly, last, specified
 <restart_date>            yyyy-mm-dd hh:mm:ss        ! restart date.  activated only if <restart_write> is "specified"
 <fname_state_in>          INPUT_RESTART_NC           ! input restart netCDF name. remove or 'coldstart' for run without any particular restart file
-<newFileFrequency>        monthly                    ! output netcdf frequency: single, daily, monthly, yearly
-<dt_qsim>                 86400                      ! simulation time interval [sec] e.g., 86400 sec for daily step
-! lake and water management (wm) mode
+!-- lake and water management (wm) mode
 <is_lake_sim>             T                          ! switch on (T) or off (F) lake simulation
 <is_flux_wm>              T                          ! switch on (T) or off (F) abstraction from or injection to seg/lakes
 <is_vol_wm>               T                          ! switch on (T) or off (F) target volume (threshold lake volume where water release is trigerred)
@@ -122,13 +125,31 @@
 ! ****************************************************************************************************************************
 ! output options
 ! ---------------------------
+! NOTE:  discharge and volume output options
+!        Routing options not chosen (see <route_opt>) will be ignored.
+! ---------------------------
+!-- histrory file controls
+<newFileFrequency>        monthly                    ! output netcdf frequency: single, daily, monthly, yearly
+<outputFrequency>         daily                      ! output frequency (integer for multiple of simulation time step or daily, monthly or yearly)
+<histTimeStamp_offset>    0                          ! time stamp offset [second] from a start of time step
+! -- non routing option specific variables 
 <basRunoff>               T                          ! HRU average runoff depth at HRU [L/T]
 <instRunoff>              T                          ! intantaneou runoff volume from Local HRUs at reach [L3/T]
 <dlayRunoff>              T                          ! delayed runoff voluem (discharge) from local HRUsi at reach [L3/T]
 <sumUpstreamRunoff>       T                          ! accumulated total upstream discharge at reach [L3/T]
+!-- routing option specific variables
 <KWTroutedRunoff>         T                          ! kinematic wave tracking routed discharge at reach [L3/T]
 <IRFroutedRunoff>         T                          ! impulse response function routed discharge at reach [L3/T]
 <MCroutedRunoff>          T                          ! kinematic wave routed discharge at reach [L3/T]
 <KWroutedRunoff>          T                          ! muskingum-cunge routed discharge at reach [L3/T]
 <DWroutedRunoff>          T                          ! diffusive wave routed discharge at reach [L3/T]
-<volume>                  F                          ! volume at the end of time step at reach [L3] - currently only IRF
+<KWTvolume>               F                          ! volume at the end of time step at reach [L3] - kinematic wave tracking
+<IRFvolume>               F                          ! volume at the end of time step at reach [L3] - impulse response function
+<KWvolume>                F                          ! volume at the end of time step at reach [L3] - kinematic wave
+<MCvolume>                F                          ! volume at the end of time step at reach [L3] - muskingum-cunge
+<DWvolume>                F                          ! volume at the end of time step at reach [L3] - diffusive wave 
+<KWTinflow>               F                          ! inflow into reach [L3] - kinematic wave tracking
+<IRFinflow>               F                          ! inflow into reach [L3] - impulse response function
+<KWinflow>                F                          ! inflow into reach [L3] - kinematic wave 
+<MCinflow>                F                          ! inflow into reach [L3] - muskingum-cunge 
+<DWinflow>                F                          ! inflow into reach [L3] - diffusive wave 


### PR DESCRIPTION
Currently routed runoff, volume, inflow history variable names add routing method abbreviation in front of variables (== routing specific name)

For example, if you run Muskingum Cunge method, routed runoff name is MCroutedRunoff. This name convention may be ok if users run multiple routing schemes at the same time to distinguish.

However, if users run only with one method, users may want to just use more generic names, routedRunoff, volume, or inflow etc., 

This PR enables this option. The default still uses routing specific name. 

CESM-coupled run typically uses only one method, and for testing purpose, we want to use generic name to compare the history files among different versions and cases.  

resolve #481