### PR TITLE
Adding datetime in rpointer file with backward compatibility

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -811,6 +811,7 @@ CONTAINS
     USE RtmFileUtils, ONLY: relavu, getavu, opnfil
     USE RtmVar,       ONLY: inst_suffix
     USE public_var,   ONLY: rpntfil
+    USE public_var,   ONLY: secprmin, secprhour
     USE globalData,   ONLY: simDatetime
 
     implicit none
@@ -831,8 +832,8 @@ CONTAINS
 
     nio = getavu() ! get available unit number
 
-    ! construct rpoint file name with datetime - simDatetime has three datetime at previous(0), current(1) and next(2) time stamp
-    sec_in_day = simDatetime(1)%hour()*60*60+simDatetime(1)%minute()*60+nint(simDatetime(1)%sec())
+    ! construct rpointer file name with datetime - simDatetime has three datetime at previous(0), current(1) and next(2) time stamp
+    sec_in_day = simDatetime(1)%hour()*nint(secprhour)+simDatetime(1)%minute()*nint(secprmin)+nint(simDatetime(1)%sec())
     write(timestamp,'(".",I4.4,"-",I2.2,"-",I2.2,"-",I5.5)') &
           simDatetime(1)%year(),simDatetime(1)%month(),simDatetime(1)%day(),sec_in_day
     locfn = './'// trim(rpntfil)//trim(inst_suffix)//timestamp

--- a/route/build/src/io_rpointfile.f90
+++ b/route/build/src/io_rpointfile.f90
@@ -4,6 +4,7 @@ USE nrtype
 USE public_var,  ONLY: outputAtGage             ! ascii containing last restart and history files
 USE public_var,  ONLY: restart_dir              ! restart directory
 USE public_var,  ONLY: rpntfil                  !
+USE public_var,  ONLY: secprmin, secprhour
 USE globalData,  ONLY: masterproc
 USE globalData,  ONLY: hfileout, hfileout_gage
 USE globalData,  ONLY: rfileout
@@ -34,7 +35,7 @@ CONTAINS
     ierr=0; message='io_rpfile/'
 
     if (present(curDatetime)) then
-      sec_in_day = curDatetime%hour()*60*60+curDatetime%minute()*60+nint(curDatetime%sec())
+      sec_in_day = curDatetime%hour()*nint(secprhour)+curDatetime%minute()*nint(secprmin)+nint(curDatetime%sec())
       write(timestamp,'(".",I4.4,"-",I2.2,"-",I2.2,"-",I5.5)') &
             curDatetime%year(),curDatetime%month(),curDatetime%day(),sec_in_day
       rpntfil_path = trim(restart_dir)//trim(rpntfil)//timestamp

--- a/route/build/src/io_rpointfile.f90
+++ b/route/build/src/io_rpointfile.f90
@@ -7,6 +7,7 @@ USE public_var,  ONLY: rpntfil                  !
 USE globalData,  ONLY: masterproc
 USE globalData,  ONLY: hfileout, hfileout_gage
 USE globalData,  ONLY: rfileout
+USE datetime_data, ONLY: datetime               ! datetime data class
 
 implicit none
 
@@ -18,20 +19,33 @@ CONTAINS
   ! *********************************************************************
   ! public subroutine: main routine to define new output file
   ! *********************************************************************
-  SUBROUTINE io_rpfile(mode, ierr, message)
+  SUBROUTINE io_rpfile(mode, ierr, message, curDatetime)
 
     implicit none
     ! argument variables
-    character(1),   intent(in)     :: mode        ! io mode: 'r' or 'w'
-    integer(i4b),   intent(out)    :: ierr        ! error code
-    character(*),   intent(out)    :: message     ! error message
+    character(1),   intent(in)           :: mode          ! io mode: 'r' or 'w'
+    integer(i4b),   intent(out)          :: ierr          ! error code
+    character(*),   intent(out)          :: message       ! error message
+    type(datetime), intent(in), optional :: curDatetime   ! current datetime
+    integer                              :: sec_in_day    ! time in second
+    character(len=17)                    :: timestamp     ! datetime string in yyyy-mm-dd-sssss
+    character(len=strLen)                :: rpntfil_path  ! rpointer file path
 
     ierr=0; message='io_rpfile/'
+
+    if (present(curDatetime)) then
+      sec_in_day = curDatetime%hour()*60*60+curDatetime%minute()*60+nint(curDatetime%sec())
+      write(timestamp,'(".",I4.4,"-",I2.2,"-",I2.2,"-",I5.5)') &
+            curDatetime%year(),curDatetime%month(),curDatetime%day(),sec_in_day
+      rpntfil_path = trim(restart_dir)//trim(rpntfil)//timestamp
+    else
+      rpntfil_path = trim(restart_dir)//trim(rpntfil)
+    end if
 
     select case(mode)
       case("w")
         if (masterproc) then
-          open(1, file = trim(restart_dir)//trim(rpntfil), status='replace', action='write')
+          open(1, file = trim(rpntfil_path), status='replace', action='write')
           write(1,'(a)') trim(rfileout)
           write(1,'(a)') trim(hfileout)
           if (outputAtGage) then
@@ -40,7 +54,7 @@ CONTAINS
           close(1)
         end if
       case("r")
-        open(1, file = trim(restart_dir)//trim(rpntfil), status='old', action='read')
+        open(1, file = trim(rpntfil_path), status='old', action='read')
         read(1, '(A)') rfileout
         read(1, '(A)') hfileout
         if (outputAtGage) then

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -167,6 +167,8 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE restart_output(ierr, message)
 
+  USE globalData,    ONLY: simDatetime    ! previous and current model time
+  USE globalData,    ONLY: runMode        ! run options: standalone or cesm-coupling
   USE io_rpointfile, ONLY: io_rpfile
 
   implicit none
@@ -188,7 +190,11 @@ CONTAINS
   call write_state_nc(rfileout, pioFileDescState, ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-  call io_rpfile('w', ierr, cmessage)
+  if (trim(runMode)=='cesm-coupling') then
+    call io_rpfile('w', ierr, cmessage, curDatetime=simDatetime(1))
+  else
+    call io_rpfile('w', ierr, cmessage)
+  end if
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
  END SUBROUTINE restart_output


### PR DESCRIPTION
Adding string of datetime (`yyyy-mm-dd-sssss` format) to the end of `rpointer.rof` for only cesm-coupling mode. This is the backward compatibility. standalone does not use this for now.

Resolve #484 