### PR TITLE
Fixing overflow error coming from default large bankfull depth

### DIFF
--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -178,6 +178,7 @@ MODULE globalData
   real(dp),                        public :: wscale                     ! scaling factor for river width [-]
   real(dp),                        public :: dscale=0.000045            ! scaling factor for river bankful depth [-]
   real(dp),                        public :: floodplainSlope=1000       ! floodplain down slope h:v=slope:1 [-]
+  real(dp),                        public :: high_depth=100000._dp      ! very high river bankful depth [m]
 
   ! ---------- general structure information --------------------------------------------------------
 

--- a/route/build/src/hydraulic.f90
+++ b/route/build/src/hydraulic.f90
@@ -13,6 +13,7 @@ MODULE hydraulic
 ! channel is assumed to be unlimited bank depth.
 
 USE nrtype
+USE globalData, ONLY: bankDepth0 => high_depth
 
 implicit none
 
@@ -36,7 +37,6 @@ real(dp),     parameter :: const53=5._dp/3._dp          ! constant
 real(dp),     parameter :: const103=10._dp/3._dp        ! constant
 real(dp),     parameter :: err_thresh=0.005_dp          ! newton method convergence threshold
 real(dp),     parameter :: zf0=1000._dp                 ! default floodplain slope: horizontal:vertcal=zf:1 [-]
-real(dp),     parameter :: bankDepth0=huge(1.0_dp)      ! unlimited bankfull height
 
 CONTAINS
 

--- a/route/build/src/pio_utils.f90
+++ b/route/build/src/pio_utils.f90
@@ -334,8 +334,6 @@ CONTAINS
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     inquire(file=trim(fname), exist=lexist)
-    write(iulog,*) ' opening file: ', trim(fname)
-    flush(iulog)
     if ( .not. lexist )then
        ierr = 10
        message=trim(message)//'file does NOT exist'//trim(fname)

--- a/route/build/src/process_ntopo.f90
+++ b/route/build/src/process_ntopo.f90
@@ -72,6 +72,7 @@ CONTAINS
  USE globalData,   ONLY: wscale, dscale        ! spatial constant channel parameters for width and bankful depth
  USE globalData,   ONLY: floodplainSlope       ! spatial constant floodplain slope
  USE globalData,   ONLY: velo, diff            ! IRF routing parameters (Transfer function parameters)
+ USE globalData,   ONLY: high_depth            ! high bankful depth for no floodplain river geometry (just setting high bankful depth)
  USE public_var,   ONLY: floodplain            ! floodplain mode. F->only channel T-> channel with bankful depth and floodplain
  USE public_var,   ONLY: dt                    ! simulation time step [sec]
  USE hydraulic,    ONLY: storage               ! compute channel storage
@@ -231,7 +232,7 @@ CONTAINS
  ! replace depth with large values e.g., 10,000 [m] if floodplain mode is off
  if (.not.floodplain) then
    do iSeg=1,nSeg
-     structSEG(iSeg)%var(ixSEG%depth)%dat(1) = huge(1.0_dp) ! huge value [meter], so river water never top out.
+     structSEG(iSeg)%var(ixSEG%depth)%dat(1) = high_depth ! huge value [meter], so river water never top out.
    end do
  end if
 


### PR DESCRIPTION
Unlimited bankfull depth defined with huge function causes overflow error when computing hydraulic geometries in [hydraulic.f90](https://github.com/ESCOMP/mizuRoute/blob/cesm-coupling/route/build/src/hydraulic.f90). 

Use 100km height as a default huge depth.

Fix #492