### PR TITLE
Add capability to change lake type and bug fix

### DIFF
--- a/route/build/src/process_ntopo.f90
+++ b/route/build/src/process_ntopo.f90
@@ -380,6 +380,7 @@ END SUBROUTINE augment_ntopo
   USE public_var,    ONLY: min_slope          ! minimum slope
   USE public_var,    ONLY: dt                 ! simulation time step [sec]
   USE public_var,    ONLY: is_lake_sim        ! lake simulation option
+  USE public_var,    ONLY: lakeRegulate       ! lake type option: T-> lake type defined at lake indiviually, F-> all natural (use Doll)
   ! external subroutines
   USE process_param, ONLY: basinUH            ! construct basin unit hydrograph
 
@@ -396,6 +397,7 @@ END SUBROUTINE augment_ntopo
   character(len=strLen)                          :: cmessage         ! error message of downwind routine
   integer(i4b)                                   :: nUps             ! number of upstream segments for a segment
   integer(i4b)                                   :: iSeg,iUps        ! loop indices
+  integer(i4b), parameter                        :: doll=1
 
   ierr=0; message='put_data_struct/'
 
@@ -535,7 +537,11 @@ END SUBROUTINE augment_ntopo
    if (is_lake_sim) then
      NETOPO_in(iSeg)%isLake       = (structNTOPO(iSeg)%var(ixNTOPO%isLake)%dat(1)==true)
      NETOPO_in(iSeg)%LakeTargVol  = (structNTOPO(iSeg)%var(ixNTOPO%LakeTargVol)%dat(1)==true)
-     NETOPO_in(iSeg)%LakeModelType= structNTOPO(iSeg)%var(ixNTOPO%LakeModelType)%dat(1) ! type of the parameteric lake
+     if (.not. lakeRegulate) then ! if all lakes need to be natural
+       NETOPO_in(iSeg)%LakeModelType=doll
+     else
+       NETOPO_in(iSeg)%LakeModelType= structNTOPO(iSeg)%var(ixNTOPO%LakeModelType)%dat(1) ! type of the parameteric lake
+     endif
      NETOPO_in(iSeg)%LAKINLT      = (structNTOPO(iSeg)%var(ixNTOPO%isLakeInlet)%dat(1)==true)   ! .TRUE. if reach is lake inlet, .FALSE. otherwise
      ! NOT USED: lake parameters
 !     NETOPO_in(iSeg)%LAKE_IX = integerMissing  ! Lake index (0,1,2,...,nlak-1)

--- a/route/build/src/process_ntopo.f90
+++ b/route/build/src/process_ntopo.f90
@@ -397,7 +397,7 @@ END SUBROUTINE augment_ntopo
   character(len=strLen)                          :: cmessage         ! error message of downwind routine
   integer(i4b)                                   :: nUps             ! number of upstream segments for a segment
   integer(i4b)                                   :: iSeg,iUps        ! loop indices
-  integer(i4b), parameter                        :: doll=1
+  integer(i4b), parameter                        :: doll=1           ! lake model name and id for a natural lake
 
   ierr=0; message='put_data_struct/'
 
@@ -538,7 +538,7 @@ END SUBROUTINE augment_ntopo
      NETOPO_in(iSeg)%isLake       = (structNTOPO(iSeg)%var(ixNTOPO%isLake)%dat(1)==true)
      NETOPO_in(iSeg)%LakeTargVol  = (structNTOPO(iSeg)%var(ixNTOPO%LakeTargVol)%dat(1)==true)
      if (.not. lakeRegulate) then ! if all lakes need to be natural
-       NETOPO_in(iSeg)%LakeModelType=doll
+       NETOPO_in(iSeg)%LakeModelType=doll  ! set a doll model for all the lakes
      else
        NETOPO_in(iSeg)%LakeModelType= structNTOPO(iSeg)%var(ixNTOPO%LakeModelType)%dat(1) ! type of the parameteric lake
      endif

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -101,9 +101,7 @@ MODULE public_var
   logical(lgt)         ,public    :: floodplain           = .false.         ! logical if flood water is computed or not (floodplain is added)
   integer(i4b)         ,public    :: hw_drain_point       = 2               ! how to add inst. runoff in reach for headwater HRUs. 1->top of reach, 2->bottom of reach (default)
   logical(lgt)         ,public    :: is_lake_sim          = .false.         ! logical if lakes are activated in simulation
-  logical(lgt)         ,public    :: lake_model_D03       = .false.         ! logical if Doll 2003 model is used, specify as 1 in lake_model_type in network topology
-  logical(lgt)         ,public    :: lake_model_H06       = .false.         ! logical if Hanasaki 2006 model is used, specify as 2 in lake_model_type in network topology
-  logical(lgt)         ,public    :: lake_model_HYPE      = .false.         ! logical if HYPE model is used, specify as 3 in lake_model_type in network topology
+  logical(lgt)         ,public    :: lakeRegulate         = .true.          ! logical: F -> turn all the lakes into natural (lakeType=1) regardless of lakeModelType defined individually
   logical(lgt)         ,public    :: is_flux_wm           = .false.         ! logical if flow is added or removed from a reach
   logical(lgt)         ,public    :: is_vol_wm            = .false.         ! logical if target volume is considered for a lake
   logical(lgt)         ,public    :: is_vol_wm_jumpstart  = .false.         ! logical if true the volume is reset to target volume for the first time step of modeling

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -130,6 +130,7 @@ CONTAINS
    case('<floodplain>');           read(cData,*,iostat=io_error) floodplain            ! logical: floodwater is computed, otherwise, channel is unlimited bank depth
    case('<hw_drain_point>');       read(cData,*,iostat=io_error) hw_drain_point        ! integer: how to add inst. runoff in reach for headwater HRUs. 1->top of reach, 2->bottom of reach (default)
    case('<is_lake_sim>');          read(cData,*,iostat=io_error) is_lake_sim           ! logical; lakes are simulated
+   case('<lakeRegulate>');         read(cData,*,iostat=io_error) lakeRegulate          ! logical: F -> turn all the lakes into natural (lakeType=1) regardless of lakeModelType defined individually. T (default)
    case('<is_flux_wm>');           read(cData,*,iostat=io_error) is_flux_wm            ! logical; provided fluxes to or from seg/lakes should be considered
    case('<is_vol_wm>');            read(cData,*,iostat=io_error) is_vol_wm             ! logical; provided target volume for managed lakes are considered
    case('<is_vol_wm_jumpstart>');  read(cData,*,iostat=io_error) is_vol_wm_jumpstart   ! logical; jump to the first time step target volume is set to true

--- a/route/build/src/read_streamSeg.f90
+++ b/route/build/src/read_streamSeg.f90
@@ -413,19 +413,19 @@ SUBROUTINE mod_meta_varFile(ierr, message)
             end select
           else
             select case(LakeModelType_local(i))
-              case(0);                              number_Endorheic = number_Endorheic + 1; ! add number of Endorheic lakes
-              case(1); lake_model_D03     = .true.; number_Doll      = number_Doll      + 1; ! add number of Doll lakes
-              case(2); lake_model_H06     = .true.; number_Hanasaki  = number_Hanasaki  + 1; ! add number of Hanasaki lakes
-              case(3); lake_model_HYPE    = .true.; number_HYPE      = number_HYPE      + 1; ! add number of HYPE lakes
+              case(0); number_Endorheic = number_Endorheic + 1; ! add number of Endorheic lakes
+              case(1); number_Doll      = number_Doll      + 1; ! add number of Doll lakes
+              case(2); number_Hanasaki  = number_Hanasaki  + 1; ! add number of Hanasaki lakes
+              case(3); number_HYPE      = number_HYPE      + 1; ! add number of HYPE lakes
               case default; ierr=20; message=trim(message)//'unable to identify the lake model type'; return
             end select
           endif
         else
           select case(LakeModelType_local(i))
-            case(0);                              number_Endorheic = number_Endorheic + 1; ! add number of Endorheic lakes
-            case(1); lake_model_D03     = .true.; number_Doll      = number_Doll      + 1; ! add number of Doll lakes
-            case(2); lake_model_H06     = .true.; number_Hanasaki  = number_Hanasaki  + 1; ! add number of Hanasaki lakes
-            case(3); lake_model_HYPE    = .true.; number_HYPE      = number_HYPE      + 1; ! add number of HYPE lakes
+            case(0); number_Endorheic = number_Endorheic + 1; ! add number of Endorheic lakes
+            case(1); number_Doll      = number_Doll      + 1; ! add number of Doll lakes
+            case(2); number_Hanasaki  = number_Hanasaki  + 1; ! add number of Hanasaki lakes
+            case(3); number_HYPE      = number_HYPE      + 1; ! add number of HYPE lakes
             case default; ierr=20; message=trim(message)//'unable to identify the lake model type'; return
           end select
         endif
@@ -467,14 +467,14 @@ SUBROUTINE mod_meta_varFile(ierr, message)
       end if
     endif
 
-    if (lake_model_D03) then
+    if (number_Doll>0) then
       meta_SEG(ixSEG%D03_MaxStorage)%varFile    = .true.    ! Doll parameter
       meta_SEG(ixSEG%D03_coefficient)%varFile   = .true.    ! Doll parameter
       meta_SEG(ixSEG%D03_power)%varFile         = .true.    ! Doll parameter
       meta_SEG(ixSEG%D03_S0)%varFile            = .true.    ! Doll parameter
     endif
 
-    if (lake_model_HYPE) then
+    if (number_HYPE>0) then
       meta_SEG(ixSEG%HYP_E_emr)%varFile         = .true.    ! HYPE parameter
       meta_SEG(ixSEG%HYP_E_lim)%varFile         = .true.    ! HYPE parameter
       meta_SEG(ixSEG%HYP_E_min)%varFile         = .true.    ! HYPE parameter
@@ -488,7 +488,7 @@ SUBROUTINE mod_meta_varFile(ierr, message)
       meta_SEG(ixSEG%HYP_A_avg)%varFile         = .true.    ! HYPE parameter
     endif
 
-    if (lake_model_H06) then
+    if (number_Hanasaki>0) then
       meta_SEG(ixSEG%H06_Smax)%varFile          = .true.    ! Hanasaki parameter
       meta_SEG(ixSEG%H06_alpha)%varFile         = .true.    ! Hanasaki parameter
       meta_SEG(ixSEG%H06_envfact)%varFile       = .true.    ! Hanasaki parameter

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -51,6 +51,7 @@
 ! Define options for lake handling
 ! ----------------------------------------------------
 <is_lake_sim>              F                       ! Switch lake simulation on/off (T=on/F=off)
+<lakeRegulate>             F                       ! Switch reservoir on/off (T=on/F=off). F-> all the lakes are natural (use Doll model) 
 <varname_D03_MaxStorage>   S_max                   ! Maximum lake volume (for Doll 2003 parametrisation)
 <varname_D03_Coefficient>  Coeff                   ! name of varibale holding the coefficnet of stage-discharge relatioship for lake
 <varname_D03_Power>        power                   ! name of varibale holding the coefficnet of stage-discharge relatioship for lake


### PR DESCRIPTION
Added control variable `<lakeRegulate>` with default T. 
`<lakeRegulate>` = `T`  Use `LakeModelType` defined in the input network data. 
`<lakeRegulate>` = `F`  Turn all the reservoir lakes into natural lake (using Doll to compute discharge).

If all the lakes are natural lakes (`LakeModelType`=1), no effect.
This does not affect endorheic lakes.

Also some public variables are not needed so removed

Also, found a bug in  subroutine `flow_depth` in hydraulic.f90. Flow depth computation needs to be performed only if input Q is greater than zero. Otherwise, flow depth is zero. Since `coef1` computation use division by input Q, so if Q is zero, error due to "divided by zero" happens when trying to compute the equations.

related to #476 
