### PR TITLE
Diffusive wave equation bug fix

### DIFF
--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -369,7 +369,7 @@ CONTAINS
        diagonal(nMolecule%DW_ROUTE-1,3)     = -1._dp
      end if
 
-     ! populate left-hand side
+     ! populate right-hand side
      ! upstream boundary condition
      b(1)             = Qlocal(1,1)
      ! downstream boundary condition
@@ -380,9 +380,9 @@ CONTAINS
        b(nMolecule%DW_ROUTE)     = Sbc
      end if
      ! internal node points
-     b(2:nMolecule%DW_ROUTE-1) = ((1._dp-wck)*Ca+2._dp*(1._dp-wdk))*Cd*Qlocal(1:nMolecule%DW_ROUTE-2,0)  &
+     b(2:nMolecule%DW_ROUTE-1) = ((1._dp-wck)*Ca+2._dp*(1._dp-wdk)*Cd)*Qlocal(1:nMolecule%DW_ROUTE-2,0)  &
                       + (2._dp-4._dp*(1._dp-wdk)*Cd)*Qlocal(2:nMolecule%DW_ROUTE-1,0)           &
-                      - ((1._dp-wck)*Ca - (1._dp-wdk)*Cd)*Qlocal(3:nMolecule%DW_ROUTE,0)
+                      - ((1._dp-wck)*Ca - 2._dp*(1._dp-wdk)*Cd)*Qlocal(3:nMolecule%DW_ROUTE,0)
 
      ! solve matrix equation - get updated Qlocal
      call TDMA(nMolecule%DW_ROUTE, diagonal, b, Qsolved)


### PR DESCRIPTION
fix the error on the discretization of diffusive wave equation. 

This error is no currently not affecting the results (if using fully implicit method for solution)

If using the other method (e.g., Crank-Nicolson), the results are affected. Currently the dfw routine produces incorrect solution, this bugfix should correct it.