### PR TITLE
use mid-point of time step for time stamp of history file for cesm-coupling run 

### DIFF
--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -14,6 +14,8 @@ MODULE public_var
 
   ! physical constants
   real(dp),    parameter,public   :: pi=3.14159265359_dp    ! pi
+  real(dp),    parameter,public   :: Cw=4190.0_dp           ! heat capacity of water [J/kg/K]
+  real(dp),    parameter,public   :: RoW=0.99975_dp         ! density of water [kg/m³] at 10 C-degree
 
   ! some common constant variables (not likely to change value)
   real(dp),    parameter,public   :: secprmin=60._dp        ! number of seconds in a minute

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -203,6 +203,10 @@ CONTAINS
        index_write_all = arth(1,1,nRch_local)
      end if
 
+     if (trim(runMode)=='cesm-coupling') then
+       histTimeStamp_offset = (hVars%timeVar(2) - hVars%timeVar(1))*sec2tunit/2
+     end if
+
      ! write time variables (time and time bounds)
      call hist_all_network%write_time(hVars, histTimeStamp_offset, ierr, cmessage)
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -203,6 +203,7 @@ CONTAINS
        index_write_all = arth(1,1,nRch_local)
      end if
 
+     ! For cesm coupling mode, the timestamp of the average history output is the midpoint of time bounds
      if (trim(runMode)=='cesm-coupling') then
        histTimeStamp_offset = (hVars%timeVar(2) - hVars%timeVar(1))*sec2tunit/2
      end if


### PR DESCRIPTION
CESM will require the component uses the mid-point of the output time step if average is used for aggregation.

For now, all the history file uses average for output variable aggregation in the history file. 

This PR enforces time stamp in the history file is the mid-point of the time stamp if `cesm-coupling` is on

resolve #413 