### PR TITLE
solver for advection diffusion equation

### DIFF
--- a/netcdf_test/Makefile
+++ b/netcdf_test/Makefile
@@ -6,42 +6,57 @@
 # Change library path HDF, NCDF, LOCAL, SZIP, ZLIB
 
 # Define the Fortran Compiler
+FC=
 
-CC=pgf90
+FC_EXE=
 
-ifeq "$(CC)" "gfortran"
-NCDF_PATH=/opt/netcdf4-gcc
-LIBNETCDF = -Wl,-rpath,$(NCDF_PATH)/lib \
+MODE=debug
+
+ifeq "$(FC)" "gnu"
+  NCDF_PATH=
+  LIBNETCDF = -Wl,-rpath,$(NCDF_PATH)/lib \
             -L$(NCDF_PATH)/lib -lnetcdff -lnetcdf
-INCNETCDF = -I$(NCDF_PATH)/include
+  INCNETCDF = -I$(NCDF_PATH)/include
 endif
 
-ifeq "$(CC)" "ifort"
-NCDF_PATH = /opt/netcdf4-intel
-LIBNETCDF = -Wl,-rpath,$(NCDF_PATH)/lib \
- 	-L$(NCDF_PATH)/lib -lnetcdff -lnetcdf
-INCNETCDF = -I$(NCDF_PATH)/include
+ifeq "$(FC)" "intel"
+  NCDF_PATH =
+  LIBNETCDF = -L$(NCDF_PATH)/lib -lnetcdff -lnetcdf
+  INCNETCDF = -I$(NCDF_PATH)/include
 endif
 
-ifeq "$(CC)" "pgf90"
- NCDF_PATH = /opt/netcdf4-pgi
+ifeq "$(FC)" "nvidia"
+ NCDF_PATH =
  LIBNETCDF = -L$(NCDF_PATH)/lib -lnetcdff -lnetcdf
  INCNETCDF = -I$(NCDF_PATH)/include
 endif
- 
+
 # define flags
-ifeq "$(CC)" "gfortran"
- FLAGS = -Wall -g -ffree-line-length-none
+ifeq "$(FC)" "gnu"
+  ifeq "$(MODE)" "fast"
+    FLAGS = -O3 -fmax-errors=0 -ffree-line-length-none
+  endif
+  ifeq "$(MODE)" "debug"
+    FLAGS = -g -Wall -fmax-errors=0 -fbacktrace -fcheck=all -ffpe-trap=zero -ffree-line-length-none
+  endif
 endif
 
-ifeq "$(CC)" "ifort"
-  FLAGS = -debug -warn all -check all -FR -O0 -auto -WB -traceback -g -fltconsistency -fpe0
+ifeq "$(FC)" "intel"
+  ifeq "$(MODE)" "fast"
+    FLAGS = -O3 -FR -auto -fltconsistency -fpe0
+  endif
+  ifeq "$(MODE)" "debug"
+    FLAGS = -g -debug all -warn all -check all,nouninit -FR -O0 -auto -WB -fpe0 -traceback -fltconsistency
+  endif
 endif
 
-ifeq "$(CC)" "pgf90"
- FLAGS1 = -Bstatic -Mbackslash -g -Mchkptr -Mchkstk -Mpgicoff -Minform=inform -Ktrap=divz,inv -Mprof=lines,time
- #FLAGS = -Bstatic -Mbackslash -g -Mchkptr -Mchkstk -Mpgicoff -Minform=inform -Ktrap=divz,inv
- FLAGS = -Mbackslash -g -Mchkptr -Mchkstk -Mpgicoff -Minform=inform -Ktrap=divz,inv
+ifeq "$(FC)" "nvidia"
+  ifeq "$(MODE)" "fast"
+    FLAGS = -fast -O3 -Mdclchk $(FLAGS_OMP)
+  endif
+  ifeq "$(MODE)" "debug"
+    FLAGS = -g -Mbounds -Mlist -Minfo -Mdclchk
+  endif
 endif
 
 # define program
@@ -51,8 +66,6 @@ PROGRAM = test_netcdf.f90
 # define executable
 EX = test_netcdf.exe
 
-#FLAGS = -O3 -W -v
-
 #.SUFFIXES: .f .o .f90
 
 # Compile
@@ -60,11 +73,11 @@ all: compile link clean
 
 # compile
 compile:
-	$(CC) $(FLAGS) -c $(SUBROUTINE) $(PROGRAM) $(INCNETCDF)
+	$(FC_EXE) $(FLAGS) -c $(SUBROUTINE) $(PROGRAM) $(INCNETCDF)
 
 # link routines
 link:
-	$(CC) *.o $(LIBNETCDF) -o $(EX)
+	$(FC_EXE) *.o $(LIBNETCDF) -o $(EX)
 
 # Remove object files
 clean:

--- a/netcdf_test/README
+++ b/netcdf_test/README
@@ -1,0 +1,31 @@
+# Objective: to test for netcdf library being correctly recognized
+# 
+# Please try compiling using Make to create the executable 
+# if successful, you will see test_netcdf.exe, then please try running this exe to see if you can generate a netcdf. if you can, you are good to go.
+#
+# Note on compiling
+# Though the below is for NCAR HPC, the same buiding process is likely to be used for other machines with environmental variable names specific to the machine
+#
+# For gnu 
+module purge
+module load gcc
+module load netcdf
+module load ncarcompilers
+
+gmake FC=gnu FC_EXE=gfortran NCDF_PATH=$NETCDF MODE=fast
+
+# For intel oneAPI 
+module purge
+module load intel-oneapi
+module load netcdf
+module load ncarcompilers
+
+gmake FC=intel FC_EXE=ifx NCDF_PATH=$NETCDF MODE=fast
+
+# For nvida  
+module purge
+module load nvhpc
+module load netcdf
+module load ncarcompilers
+
+gmake FC=nvidia FC_EXE=nvfortran NCDF_PATH=$NETCDF MODE=fast

--- a/netcdf_test/example_netcdf.f90
+++ b/netcdf_test/example_netcdf.f90
@@ -3,7 +3,6 @@ module example_netcdf_module
 USE netcdf                                  ! use netCDF libraries
 contains
 
-
 subroutine example_netcdf()
 
 ! error code
@@ -56,7 +55,6 @@ ierr = nf90_create(trim(filename),nf90_clobber,ncid); call handle_err(ierr)
 ierr = nf90_enddef(ncid); call handle_err(ierr)
 ierr = nf90_close(ncid); call handle_err(ierr)
 
-
 end subroutine example_netcdf
 
 subroutine handle_err(err)
@@ -70,7 +68,5 @@ if (err/=nf90_noerr) then
  stop '[fatal error in netcdf]'
 endif
 end subroutine handle_err
-
-
 
 end module example_netcdf_module

--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -212,6 +212,7 @@ IO = \
     write_restart_pio.f90
 # CORE
 CORE = \
+    advection_diffusion.f90 \
     accum_runoff.f90 \
     basinUH.f90 \
     water_balance.f90 \

--- a/route/build/src/advection_diffusion.f90
+++ b/route/build/src/advection_diffusion.f90
@@ -18,7 +18,7 @@ CONTAINS
  ! *********************************************************************
  ! subroutine: solve advection-diffuision equation (ade)
  ! *********************************************************************
- SUBROUTINE solve_ade(rch_param,     & ! input: river parameter data structure
+ SUBROUTINE solve_ade(reach_length,  & ! input: Reach length [m]
                       nMolecule,     & ! input: number of sub-segments
                       dt_local,      & ! input: time_step [sec]
                       Qupstream,     & ! input: quantity from upstream [unit of quantity]
@@ -53,11 +53,11 @@ CONTAINS
  !  Since A is a tridiagonal matrix, the code stores only three diagnoal elements - upper, diagonal, and lower
  !  solving the matrix equation use thomas algorithm
  !
- !  if dk = 0, this equation becomes advection equation and solved with central difference for advection term 
+ !  if dk = 0, this equation becomes advection equation and solved with central difference for advection term
  ! ----------------------------------------------------------------------------------------
  implicit none
  ! Argument variables
- type(RCHPRP), intent(in)      :: rch_param                 ! River reach parameter
+ real(dp),     intent(in)      :: reach_length              ! River reach length [m]
  integer(i4b), intent(in)      :: nMolecule                 ! number of sub-segments
  real(dp),     intent(in)      :: dt_local                  ! time inteval for time-step [sec]
  real(dp),     intent(in)      :: Qupstream                 ! quantity at top of the reach being processed
@@ -97,13 +97,11 @@ CONTAINS
 
  Nx = nMolecule - 1  ! Nx: number of internal reach segments
 
- associate(L => rch_param%RLENGTH)      ! channel length
-
  ! Get the reach parameters
-  dx = L/(Nx-1) ! one extra sub-segment beyond outlet
+  dx = reach_length/(Nx-1) ! one extra sub-segment beyond outlet
 
   if (verbose) then
-    write(iulog,'(A,1X,G12.5)') ' length [m]     =',L
+    write(iulog,'(A,1X,G12.5)') ' length [m]     =',reach_length
     write(iulog,'(A,1X,G12.5)') ' time-step [sec]=',dt_local
   end if
 
@@ -174,8 +172,6 @@ CONTAINS
    write(iulog,fmt1) ' diagonal(:,3)= ', diagonal(:,3)
    write(iulog,fmt1) ' b= ', b(1:nMolecule)
  end if
-
- end associate
 
  END SUBROUTINE solve_ade
 

--- a/route/build/src/advection_diffusion.f90
+++ b/route/build/src/advection_diffusion.f90
@@ -1,0 +1,235 @@
+MODULE advection_diffusion
+
+! solving advection-diffusion equation
+
+USE nrtype
+USE dataTypes,     ONLY: RCHPRP          ! Reach parameter
+USE public_var,    ONLY: iulog           ! i/o logical unit number
+USE public_var,    ONLY: realMissing     ! missing value for real number
+USE public_var,    ONLY: integerMissing  ! missing value for integer number
+
+implicit none
+
+private
+public::solve_ade    ! solve advection-diffusion equation
+
+CONTAINS
+
+ ! *********************************************************************
+ ! subroutine: solve advection-diffuision equation (ade)
+ ! *********************************************************************
+ SUBROUTINE solve_ade(rch_param,     & ! input: river parameter data structure
+                      nMolecule,     & ! input: number of sub-segments
+                      dt_local,      & ! input: time_step [sec]
+                      Qupstream,     & ! input: quantity from upstream [unit of quantity]
+                      ck,            & ! input: velocity [m/s]
+                      dk,            & ! input: diffusivity [m2/s]
+                      Qlat,          & ! input: lateral quantity into chaneel [unit of quantity]
+                      Qprev,         & ! input: quantity at previous time step [unit of quantity]
+                      Qlocal,        & ! inout: quantity soloved at current time step [unit of quantity]
+                      verbose,       & ! input: reach index to be examined
+                      ierr,message)
+ ! ----------------------------------------------------------------------------------------
+ ! Solve linearlized advection diffusive equation per reach and time step.
+ !  dQ/dt + ck*dQ/dx = dk*d2Q/dx2 + Qlat - a)
+ !
+ !  ck (velocity) and dk (diffusivity) are given by input argument
+ !
+ !  1) dQ/dt   = (Q(t,x) - Q(t-1,x))/dt
+ !  2) dQ/dx   = [(1-wck)(Q(t-1,x+1)-Q(t-1,x-1)) + wck*(Q(t,x+1)-Q(t,x-1))]/2dx  (using central difference)
+ !  3) d2Q/dx2 = [(1-wdk)(Q(t-1,x+1)-2Q(t-1,x)+Q(t-1,x-1)) + wdk*(Q(t,x+1)-2Q(t,x)+Q(t,x-1))]/2dx
+ !
+ !  upstream B.C:   Dirchlet BC with inflow at current time-step,t, from upstream basin
+ !  downstream B.C: Neumann BC with prescribed quantity gradient (Sbc)
+ !                  dQ/dx|x=N = Sbc ->  4) Q(t,N)-Q(t,N-1)) = Sbc*dx
+ !  Another downstream B.C option is absorbing boundary condition
+ !                  dQ/dt|x=N + ck*dQ/dx|x=N = 0
+ !
+ !  Inserting 1), 2), 3) and 4) into a) and moving Q(t,*) terms to left-hand side and Q(t-1,*) terms to the righ-hand side
+ !  results in tridiagonal matrix equation A*Q = b
+ !  where A is [N x N] matrix, Q is [N x 1] vector to be solved (next time step Q) and b is [N x 1] vector
+ !  N (nMolecule is used in the code) is the number of internal nodes including upstream and downstream boundaries
+ !
+ !  Since A is a tridiagonal matrix, the code stores only three diagnoal elements - upper, diagonal, and lower
+ !  solving the matrix equation use thomas algorithm
+ !
+ !  if dk = 0, this equation becomes advection equation and solved with central difference for advection term 
+ ! ----------------------------------------------------------------------------------------
+ implicit none
+ ! Argument variables
+ type(RCHPRP), intent(in)      :: rch_param                 ! River reach parameter
+ integer(i4b), intent(in)      :: nMolecule                 ! number of sub-segments
+ real(dp),     intent(in)      :: dt_local                  ! time inteval for time-step [sec]
+ real(dp),     intent(in)      :: Qupstream                 ! quantity at top of the reach being processed
+ real(dp),     intent(in)      :: ck                        ! velocity [m/s]
+ real(dp),     intent(in)      :: dk                        ! diffusivity [m2/s]
+ real(dp),     intent(in)      :: Qlat                      ! lateral quantity into chaneel [m3/s]
+ real(dp),     intent(in)      :: Qprev(nMolecule)          ! sub-reach quantity at previous time step [m3/s]
+ real(dp),     intent(out)     :: Qlocal(nMolecule,0:1)     ! sub-reach & sub-time step quantity at previous and current time step [m3/s]
+ logical(lgt), intent(in)      :: verbose                   ! reach index to be examined
+ integer(i4b), intent(out)     :: ierr                      ! error code
+ character(*), intent(out)     :: message                   ! error message
+ ! Local variables
+ real(dp)                      :: Cd                        ! Fourier number
+ real(dp)                      :: Ca                        ! Courant number
+ real(dp)                      :: dx                        ! length of segment [m]
+ real(dp)                      :: Sbc                       ! neumann BC slope
+ real(dp)                      :: diagonal(nMolecule,3)     ! diagonal part of matrix - diagonal(:,1)=upper, diagonal(:,2)=middle, diagonal(:,3)=lower
+ real(dp)                      :: b(nMolecule)              ! right-hand side of the matrix equation
+ real(dp)                      :: Qsolved(nMolecule)        ! solved Q at sub-reach at current time step [m3/s]
+ real(dp)                      :: wck                       ! weight for advection
+ real(dp)                      :: wdk                       ! weight for diffusion
+ integer(i4b)                  :: ix                        ! loop index
+ integer(i4b)                  :: Nx                        ! number of internal reach segments
+ integer(i4b)                  :: downstreamBC              ! method of B.C condition - absorbing or Neumann
+ character(len=strLen)         :: fmt1                      ! format string
+ character(len=strLen)         :: cmessage                  ! error message from subroutine
+ ! Local parameters
+ integer(i4b), parameter                :: absorbingBC=1
+ integer(i4b), parameter                :: neumannBC=2      ! flux derivative w.r.t. distance at downstream boundary
+
+ ierr=0; message='solve_ade/'
+
+ ! hard-coded parameters
+ downstreamBC = neumannBC  ! downstream boundary condition
+ wck = 1.0                 ! weight in advection term
+ wdk = 1.0                 ! weight in diffusion term 0.0-> fully explicit, 0.5-> Crank-Nicolson, 1.0 -> fully implicit
+
+ Nx = nMolecule - 1  ! Nx: number of internal reach segments
+
+ associate(L => rch_param%RLENGTH)      ! channel length
+
+ ! Get the reach parameters
+  dx = L/(Nx-1) ! one extra sub-segment beyond outlet
+
+  if (verbose) then
+    write(iulog,'(A,1X,G12.5)') ' length [m]     =',L
+    write(iulog,'(A,1X,G12.5)') ' time-step [sec]=',dt_local
+  end if
+
+ Qlocal(1:nMolecule, 0) = Qprev ! previous time step
+ Qlocal(1:nMolecule, 1) = realMissing ! initialize current time step part
+ Qlocal(1,1)  = Qupstream     ! quantity from upstream at current time step
+
+ ! Fourier number and Courant number
+ Cd = dk*dt_local/dx**2
+ Ca = ck*dt_local/dx
+
+ ! create a matrix - current time step
+ ! populate tridiagonal elements
+ ! diagonal
+ diagonal(1,2)             = 1._dp
+ diagonal(2:nMolecule-1,2) = 2._dp + 4*wdk*Cd
+ if (downstreamBC == absorbingBC) then
+   diagonal(nMolecule,2)     = 1._dp + wck*Ca
+ else if (downstreamBC == neumannBC) then
+   diagonal(nMolecule,2)     = 1._dp
+ end if
+
+ ! upper
+ diagonal(:,1)           = 0._dp
+ diagonal(3:nMolecule,1) = wck*Ca - 2._dp*wdk*Cd
+
+ ! lower
+ diagonal(:,3)             = 0._dp
+ diagonal(1:nMolecule-2,3) = -wck*Ca - 2._dp*wdk*Cd
+ if (downstreamBC == absorbingBC) then
+   diagonal(nMolecule-1,3)   = -wck*Ca
+ else if (downstreamBC == neumannBC) then
+   diagonal(nMolecule-1,3)     = -1._dp
+ end if
+
+ ! populate right-hand side
+ ! upstream boundary condition
+ b(1)             = Qlocal(1,1)
+ ! downstream boundary condition
+ if (downstreamBC == absorbingBC) then
+   b(nMolecule) = (1._dp-(1._dp-wck)*Ca)*Qlocal(nMolecule,0) + (1-wck)*Ca*Qlocal(nMolecule-1,0)
+ else if (downstreamBC == neumannBC) then
+   Sbc = (Qlocal(nMolecule,0)-Qlocal(nMolecule-1,0))
+   b(nMolecule)     = Sbc
+ end if
+ ! internal node points
+ b(2:nMolecule-1) = ((1._dp-wck)*Ca +2._dp*(1._dp-wdk)*Cd)*Qlocal(1:nMolecule-2,0)  &
+                  + (2._dp-4._dp*(1._dp-wdk)*Cd)*Qlocal(2:nMolecule-1,0)           &
+                  - ((1._dp-wck)*Ca -2._dp*(1._dp-wdk)*Cd)*Qlocal(3:nMolecule,0)
+
+ ! solve matrix equation - get updated Qlocal
+ call TDMA(nMolecule, diagonal, b, Qsolved)
+
+ if (verbose) then
+   write(fmt1,'(A,I5,A)') '(A,1X',nMolecule,'(1X,G15.4))'
+   write(iulog,fmt1) ' Q sub_reqch=', (Qsolved(ix), ix=1,nMolecule)
+ end if
+
+ Qlocal(:,1) = Qsolved
+
+ if (verbose) then
+   write(fmt1,'(A,I5,A)') '(A,1X',nMolecule,'(1X,G15.4))'
+   write(iulog,fmt1) ' Qprev(1:nMolecule)= ', Qprev(1:nMolecule)
+   write(iulog,'(A,3(1X,G12.5))') ' ck, dk= ',ck, dk
+   write(iulog,'(A,2(1X,G12.5))') ' Cd, Ca= ', Cd, Ca
+   write(iulog,fmt1) ' diagonal(:,1)= ', diagonal(:,1)
+   write(iulog,fmt1) ' diagonal(:,2)= ', diagonal(:,2)
+   write(iulog,fmt1) ' diagonal(:,3)= ', diagonal(:,3)
+   write(iulog,fmt1) ' b= ', b(1:nMolecule)
+ end if
+
+ end associate
+
+ END SUBROUTINE solve_ade
+
+ SUBROUTINE TDMA(NX,MAT,b,T)
+ ! Solve tridiagonal matrix system of linear equation
+ ! NX is the number of unknowns (gridblocks minus boundaries)
+ ! Solve system of linear equations, A*T = b where A is tridiagonal matrix
+ ! MAT = NX x 3 array holding tri-diagonal portion of A
+ ! MAT(NX,1) - uppder diagonals for matrix A
+ ! MAT(NX,2) - diagonals for matrix A
+ ! MAT(NX,3) - lower diagonals for matrix A
+ ! b(NX) - vector of the right hand coefficients b
+ ! T(NX) - The solution matrix
+ !
+ ! example, A
+ ! d u 0 0 0
+ ! l d u 0 0
+ ! 0 l d u 0
+ ! 0 0 l d u
+ ! 0 0 0 l d
+ !
+ ! MAT(:,1) = [0, u, u, u, u]
+ ! MAT(:,2) = [d, d, d, d, d]
+ ! MAT(:,3) = [l, l, l, l, 0]
+
+   implicit none
+   ! Argument variables
+   integer(i4b),  intent(in)     :: NX     ! number of unknown (= number of matrix size, grid point minus two end points)
+   real(dp),      intent(in)     :: MAT(NX,3)
+   real(dp),      intent(in)     :: b(NX)
+   real(dp),      intent(inout)  :: T(NX)
+   ! Local variables
+   integer(i4b)                  :: ix
+   real(dp)                      :: U(NX)
+   real(dp)                      :: D(NX)
+   real(dp)                      :: L(NX)
+   real(dp)                      :: b1(NX)
+   real(dp)                      :: coef
+
+   U(1:NX) = MAT(1:NX,1)
+   D(1:NX) = MAT(1:NX,2)
+   L(1:NX) = MAT(1:NX,3)
+   b1(1:NX) = b(1:NX)
+   do ix = 2, NX
+     coef  = L(ix-1)/D(ix-1)
+     D(ix) = D(ix)-coef*U(ix)
+     b1(ix) = b1(ix)-coef*b1(ix-1)
+   end do
+
+   T(NX) = b1(NX)/D(NX) ! Starts the countdown of answers
+   do ix = NX-1, 1, -1
+       T(ix) = (b1(ix) - U(ix+1)*T(ix+1))/D(ix)
+   end do
+
+ END SUBROUTINE TDMA
+
+END MODULE advection_diffusion

--- a/route/build/src/advection_diffusion.f90
+++ b/route/build/src/advection_diffusion.f90
@@ -3,10 +3,8 @@ MODULE advection_diffusion
 ! solving advection-diffusion equation
 
 USE nrtype
-USE dataTypes,     ONLY: RCHPRP          ! Reach parameter
 USE public_var,    ONLY: iulog           ! i/o logical unit number
 USE public_var,    ONLY: realMissing     ! missing value for real number
-USE public_var,    ONLY: integerMissing  ! missing value for integer number
 
 implicit none
 
@@ -15,89 +13,89 @@ public::solve_ade    ! solve advection-diffusion equation
 
 CONTAINS
 
- ! *********************************************************************
- ! subroutine: solve advection-diffuision equation (ade)
- ! *********************************************************************
- SUBROUTINE solve_ade(reach_length,  & ! input: Reach length [m]
-                      nMolecule,     & ! input: number of sub-segments
-                      dt_local,      & ! input: time_step [sec]
-                      Qupstream,     & ! input: quantity from upstream [unit of quantity]
-                      ck,            & ! input: velocity [m/s]
-                      dk,            & ! input: diffusivity [m2/s]
-                      Qlat,          & ! input: lateral quantity into chaneel [unit of quantity]
-                      Qprev,         & ! input: quantity at previous time step [unit of quantity]
-                      Qlocal,        & ! inout: quantity soloved at current time step [unit of quantity]
-                      verbose,       & ! input: reach index to be examined
-                      ierr,message)
- ! ----------------------------------------------------------------------------------------
- ! Solve linearlized advection diffusive equation per reach and time step.
- !  dQ/dt + ck*dQ/dx = dk*d2Q/dx2 + Qlat - a)
- !
- !  ck (velocity) and dk (diffusivity) are given by input argument
- !
- !  1) dQ/dt   = (Q(t,x) - Q(t-1,x))/dt
- !  2) dQ/dx   = [(1-wck)(Q(t-1,x+1)-Q(t-1,x-1)) + wck*(Q(t,x+1)-Q(t,x-1))]/2dx  (using central difference)
- !  3) d2Q/dx2 = [(1-wdk)(Q(t-1,x+1)-2Q(t-1,x)+Q(t-1,x-1)) + wdk*(Q(t,x+1)-2Q(t,x)+Q(t,x-1))]/2dx
- !
- !  upstream B.C:   Dirchlet BC with inflow at current time-step,t, from upstream basin
- !  downstream B.C: Neumann BC with prescribed quantity gradient (Sbc)
- !                  dQ/dx|x=N = Sbc ->  4) Q(t,N)-Q(t,N-1)) = Sbc*dx
- !  Another downstream B.C option is absorbing boundary condition
- !                  dQ/dt|x=N + ck*dQ/dx|x=N = 0
- !
- !  Inserting 1), 2), 3) and 4) into a) and moving Q(t,*) terms to left-hand side and Q(t-1,*) terms to the righ-hand side
- !  results in tridiagonal matrix equation A*Q = b
- !  where A is [N x N] matrix, Q is [N x 1] vector to be solved (next time step Q) and b is [N x 1] vector
- !  N (nMolecule is used in the code) is the number of internal nodes including upstream and downstream boundaries
- !
- !  Since A is a tridiagonal matrix, the code stores only three diagnoal elements - upper, diagonal, and lower
- !  solving the matrix equation use thomas algorithm
- !
- !  if dk = 0, this equation becomes advection equation and solved with central difference for advection term
- ! ----------------------------------------------------------------------------------------
- implicit none
- ! Argument variables
- real(dp),     intent(in)      :: reach_length              ! River reach length [m]
- integer(i4b), intent(in)      :: nMolecule                 ! number of sub-segments
- real(dp),     intent(in)      :: dt_local                  ! time inteval for time-step [sec]
- real(dp),     intent(in)      :: Qupstream                 ! quantity at top of the reach being processed
- real(dp),     intent(in)      :: ck                        ! velocity [m/s]
- real(dp),     intent(in)      :: dk                        ! diffusivity [m2/s]
- real(dp),     intent(in)      :: Qlat                      ! lateral quantity into chaneel [m3/s]
- real(dp),     intent(in)      :: Qprev(nMolecule)          ! sub-reach quantity at previous time step [m3/s]
- real(dp),     intent(out)     :: Qlocal(nMolecule,0:1)     ! sub-reach & sub-time step quantity at previous and current time step [m3/s]
- logical(lgt), intent(in)      :: verbose                   ! reach index to be examined
- integer(i4b), intent(out)     :: ierr                      ! error code
- character(*), intent(out)     :: message                   ! error message
- ! Local variables
- real(dp)                      :: Cd                        ! Fourier number
- real(dp)                      :: Ca                        ! Courant number
- real(dp)                      :: dx                        ! length of segment [m]
- real(dp)                      :: Sbc                       ! neumann BC slope
- real(dp)                      :: diagonal(nMolecule,3)     ! diagonal part of matrix - diagonal(:,1)=upper, diagonal(:,2)=middle, diagonal(:,3)=lower
- real(dp)                      :: b(nMolecule)              ! right-hand side of the matrix equation
- real(dp)                      :: Qsolved(nMolecule)        ! solved Q at sub-reach at current time step [m3/s]
- real(dp)                      :: wck                       ! weight for advection
- real(dp)                      :: wdk                       ! weight for diffusion
- integer(i4b)                  :: ix                        ! loop index
- integer(i4b)                  :: Nx                        ! number of internal reach segments
- integer(i4b)                  :: downstreamBC              ! method of B.C condition - absorbing or Neumann
- character(len=strLen)         :: fmt1                      ! format string
- character(len=strLen)         :: cmessage                  ! error message from subroutine
- ! Local parameters
- integer(i4b), parameter                :: absorbingBC=1
- integer(i4b), parameter                :: neumannBC=2      ! flux derivative w.r.t. distance at downstream boundary
+  ! *********************************************************************
+  ! subroutine: solve advection-diffuision equation (ade)
+  ! *********************************************************************
+  SUBROUTINE solve_ade(reach_length,  & ! input: Reach length [m]
+                       nMolecule,     & ! input: number of sub-segments
+                       dt_local,      & ! input: time_step [sec]
+                       Qupstream,     & ! input: quantity from upstream [unit of quantity]
+                       ck,            & ! input: velocity [m/s]
+                       dk,            & ! input: diffusivity [m2/s]
+                       Qlat,          & ! input: lateral quantity into chaneel [unit of quantity]
+                       Qprev,         & ! input: quantity at previous time step [unit of quantity]
+                       Qlocal,        & ! inout: quantity soloved at current time step [unit of quantity]
+                       verbose,       & ! input: reach index to be examined
+                       ierr,message)
+  ! ----------------------------------------------------------------------------------------
+  ! Solve linearlized advection diffusive equation per reach and time step.
+  !  dQ/dt + ck*dQ/dx = dk*d2Q/dx2 + Qlat - a)
+  !
+  !  ck (velocity) and dk (diffusivity) are given by input argument
+  !
+  !  1) dQ/dt   = (Q(t,x) - Q(t-1,x))/dt
+  !  2) dQ/dx   = [(1-wck)(Q(t-1,x+1)-Q(t-1,x-1)) + wck*(Q(t,x+1)-Q(t,x-1))]/2dx  (using central difference)
+  !  3) d2Q/dx2 = [(1-wdk)(Q(t-1,x+1)-2Q(t-1,x)+Q(t-1,x-1)) + wdk*(Q(t,x+1)-2Q(t,x)+Q(t,x-1))]/2dx
+  !
+  !  upstream B.C:   Dirchlet BC with inflow at current time-step,t, from upstream basin
+  !  downstream B.C: Neumann BC with prescribed quantity gradient (Sbc)
+  !                  dQ/dx|x=N = Sbc ->  4) Q(t,N)-Q(t,N-1)) = Sbc*dx
+  !  Another downstream B.C option is absorbing boundary condition
+  !                  dQ/dt|x=N + ck*dQ/dx|x=N = 0
+  !
+  !  Inserting 1), 2), 3) and 4) into a) and moving Q(t,*) terms to left-hand side and Q(t-1,*) terms to the righ-hand side
+  !  results in tridiagonal matrix equation A*Q = b
+  !  where A is [N x N] matrix, Q is [N x 1] vector to be solved (next time step Q) and b is [N x 1] vector
+  !  N (nMolecule is used in the code) is the number of internal nodes including upstream and downstream boundaries
+  !
+  !  Since A is a tridiagonal matrix, the code stores only three diagnoal elements - upper, diagonal, and lower
+  !  solving the matrix equation use thomas algorithm
+  !
+  !  if dk = 0, this equation becomes advection equation and solved with central difference for advection term
+  ! ----------------------------------------------------------------------------------------
+  implicit none
+  ! Argument variables
+  real(dp),     intent(in)      :: reach_length              ! River reach length [m]
+  integer(i4b), intent(in)      :: nMolecule                 ! number of sub-segments
+  real(dp),     intent(in)      :: dt_local                  ! time inteval for time-step [sec]
+  real(dp),     intent(in)      :: Qupstream                 ! quantity at top of the reach being processed
+  real(dp),     intent(in)      :: ck                        ! velocity [m/s]
+  real(dp),     intent(in)      :: dk                        ! diffusivity [m2/s]
+  real(dp),     intent(in)      :: Qlat                      ! lateral quantity into chaneel [m3/s]
+  real(dp),     intent(in)      :: Qprev(nMolecule)          ! sub-reach quantity at previous time step [m3/s]
+  real(dp),     intent(out)     :: Qlocal(nMolecule,0:1)     ! sub-reach & sub-time step quantity at previous and current time step [m3/s]
+  logical(lgt), intent(in)      :: verbose                   ! reach index to be examined
+  integer(i4b), intent(out)     :: ierr                      ! error code
+  character(*), intent(out)     :: message                   ! error message
+  ! Local variables
+  real(dp)                      :: Cd                        ! Fourier number
+  real(dp)                      :: Ca                        ! Courant number
+  real(dp)                      :: dx                        ! length of segment [m]
+  real(dp)                      :: Sbc                       ! neumann BC slope
+  real(dp)                      :: diagonal(nMolecule,3)     ! diagonal part of matrix - diagonal(:,1)=upper, diagonal(:,2)=middle, diagonal(:,3)=lower
+  real(dp)                      :: b(nMolecule)              ! right-hand side of the matrix equation
+  real(dp)                      :: Qsolved(nMolecule)        ! solved Q at sub-reach at current time step [m3/s]
+  real(dp)                      :: wck                       ! weight for advection
+  real(dp)                      :: wdk                       ! weight for diffusion
+  integer(i4b)                  :: ix                        ! loop index
+  integer(i4b)                  :: Nx                        ! number of internal reach segments
+  integer(i4b)                  :: downstreamBC              ! method of B.C condition - absorbing or Neumann
+  character(len=strLen)         :: fmt1                      ! format string
+  character(len=strLen)         :: cmessage                  ! error message from subroutine
+  ! Local parameters
+  integer(i4b), parameter       :: absorbingBC=1             ! downstream B.C.
+  integer(i4b), parameter       :: neumannBC=2               ! downstream B.C. flux derivative w.r.t. distance at downstream boundary
 
- ierr=0; message='solve_ade/'
+  ierr=0; message='solve_ade/'
 
- ! hard-coded parameters
- downstreamBC = neumannBC  ! downstream boundary condition
- wck = 1.0                 ! weight in advection term
- wdk = 1.0                 ! weight in diffusion term 0.0-> fully explicit, 0.5-> Crank-Nicolson, 1.0 -> fully implicit
+  ! hard-coded parameters
+  downstreamBC = neumannBC  ! downstream boundary condition
+  wck = 1.0                 ! weight in advection term
+  wdk = 1.0                 ! weight in diffusion term 0.0-> fully explicit, 0.5-> Crank-Nicolson, 1.0 -> fully implicit
 
- Nx = nMolecule - 1  ! Nx: number of internal reach segments
+  Nx = nMolecule - 1  ! Nx: number of internal reach segments
 
- ! Get the reach parameters
+  ! Get the reach parameters
   dx = reach_length/(Nx-1) ! one extra sub-segment beyond outlet
 
   if (verbose) then
@@ -105,127 +103,122 @@ CONTAINS
     write(iulog,'(A,1X,G12.5)') ' time-step [sec]=',dt_local
   end if
 
- Qlocal(1:nMolecule, 0) = Qprev ! previous time step
- Qlocal(1:nMolecule, 1) = realMissing ! initialize current time step part
- Qlocal(1,1)  = Qupstream     ! quantity from upstream at current time step
+  Qlocal(1:nMolecule, 0) = Qprev ! previous time step
+  Qlocal(1:nMolecule, 1) = realMissing ! initialize current time step part
+  Qlocal(1,1)  = Qupstream     ! quantity from upstream at current time step
 
- ! Fourier number and Courant number
- Cd = dk*dt_local/dx**2
- Ca = ck*dt_local/dx
+  ! Fourier number and Courant number
+  Cd = dk*dt_local/dx**2
+  Ca = ck*dt_local/dx
 
- ! create a matrix - current time step
- ! populate tridiagonal elements
- ! diagonal
- diagonal(1,2)             = 1._dp
- diagonal(2:nMolecule-1,2) = 2._dp + 4*wdk*Cd
- if (downstreamBC == absorbingBC) then
-   diagonal(nMolecule,2)     = 1._dp + wck*Ca
- else if (downstreamBC == neumannBC) then
-   diagonal(nMolecule,2)     = 1._dp
- end if
+  ! create a matrix - current time step
+  ! populate tridiagonal elements
+  ! diagonal
+  diagonal(1,2)             = 1._dp
+  diagonal(2:nMolecule-1,2) = 2._dp + 4*wdk*Cd
+  if (downstreamBC == absorbingBC) then
+    diagonal(nMolecule,2)     = 1._dp + wck*Ca
+  else if (downstreamBC == neumannBC) then
+    diagonal(nMolecule,2)     = 1._dp
+  end if
 
- ! upper
- diagonal(:,1)           = 0._dp
- diagonal(3:nMolecule,1) = wck*Ca - 2._dp*wdk*Cd
+  ! upper
+  diagonal(:,1)           = 0._dp
+  diagonal(3:nMolecule,1) = wck*Ca - 2._dp*wdk*Cd
 
- ! lower
- diagonal(:,3)             = 0._dp
- diagonal(1:nMolecule-2,3) = -wck*Ca - 2._dp*wdk*Cd
- if (downstreamBC == absorbingBC) then
-   diagonal(nMolecule-1,3)   = -wck*Ca
- else if (downstreamBC == neumannBC) then
-   diagonal(nMolecule-1,3)     = -1._dp
- end if
+  ! lower
+  diagonal(:,3)             = 0._dp
+  diagonal(1:nMolecule-2,3) = -wck*Ca - 2._dp*wdk*Cd
+  if (downstreamBC == absorbingBC) then
+    diagonal(nMolecule-1,3)   = -wck*Ca
+  else if (downstreamBC == neumannBC) then
+    diagonal(nMolecule-1,3)     = -1._dp
+  end if
 
- ! populate right-hand side
- ! upstream boundary condition
- b(1)             = Qlocal(1,1)
- ! downstream boundary condition
- if (downstreamBC == absorbingBC) then
-   b(nMolecule) = (1._dp-(1._dp-wck)*Ca)*Qlocal(nMolecule,0) + (1-wck)*Ca*Qlocal(nMolecule-1,0)
- else if (downstreamBC == neumannBC) then
-   Sbc = (Qlocal(nMolecule,0)-Qlocal(nMolecule-1,0))
-   b(nMolecule)     = Sbc
- end if
- ! internal node points
- b(2:nMolecule-1) = ((1._dp-wck)*Ca +2._dp*(1._dp-wdk)*Cd)*Qlocal(1:nMolecule-2,0)  &
-                  + (2._dp-4._dp*(1._dp-wdk)*Cd)*Qlocal(2:nMolecule-1,0)           &
-                  - ((1._dp-wck)*Ca -2._dp*(1._dp-wdk)*Cd)*Qlocal(3:nMolecule,0)
+  ! populate right-hand side
+  ! upstream boundary condition
+  b(1)             = Qlocal(1,1)
+  ! downstream boundary condition
+  if (downstreamBC == absorbingBC) then
+    b(nMolecule) = (1._dp-(1._dp-wck)*Ca)*Qlocal(nMolecule,0) + (1-wck)*Ca*Qlocal(nMolecule-1,0)
+  else if (downstreamBC == neumannBC) then
+    Sbc = (Qlocal(nMolecule,0)-Qlocal(nMolecule-1,0))
+    b(nMolecule)     = Sbc
+  end if
+  ! internal node points
+  b(2:nMolecule-1) = ((1._dp-wck)*Ca +2._dp*(1._dp-wdk)*Cd)*Qlocal(1:nMolecule-2,0)  &
+                    + (2._dp-4._dp*(1._dp-wdk)*Cd)*Qlocal(2:nMolecule-1,0)           &
+                    - ((1._dp-wck)*Ca -2._dp*(1._dp-wdk)*Cd)*Qlocal(3:nMolecule,0)
+  ! solve matrix equation - get updated Qlocal
+  call TDMA(nMolecule, diagonal, b, Qsolved)
 
- ! solve matrix equation - get updated Qlocal
- call TDMA(nMolecule, diagonal, b, Qsolved)
+  Qlocal(:,1) = Qsolved
 
- if (verbose) then
-   write(fmt1,'(A,I5,A)') '(A,1X',nMolecule,'(1X,G15.4))'
-   write(iulog,fmt1) ' Q sub_reqch=', (Qsolved(ix), ix=1,nMolecule)
- end if
+  if (verbose) then
+    write(fmt1,'(A,I5,A)') '(A,1X',nMolecule,'(1X,G15.4))'
+    write(iulog,fmt1) ' Qprev(1:nMolecule)= ', Qprev(1:nMolecule)
+    write(iulog,'(A,3(1X,G12.5))') ' ck, dk= ',ck, dk
+    write(iulog,'(A,2(1X,G12.5))') ' Cd, Ca= ', Cd, Ca
+    write(iulog,fmt1) ' diagonal(:,1)= ', diagonal(:,1)
+    write(iulog,fmt1) ' diagonal(:,2)= ', diagonal(:,2)
+    write(iulog,fmt1) ' diagonal(:,3)= ', diagonal(:,3)
+    write(iulog,fmt1) ' b= ', b(1:nMolecule)
+    write(iulog,fmt1) ' Q sub_reqch=', (Qsolved(ix), ix=1,nMolecule)
+  end if
 
- Qlocal(:,1) = Qsolved
+  END SUBROUTINE solve_ade
 
- if (verbose) then
-   write(fmt1,'(A,I5,A)') '(A,1X',nMolecule,'(1X,G15.4))'
-   write(iulog,fmt1) ' Qprev(1:nMolecule)= ', Qprev(1:nMolecule)
-   write(iulog,'(A,3(1X,G12.5))') ' ck, dk= ',ck, dk
-   write(iulog,'(A,2(1X,G12.5))') ' Cd, Ca= ', Cd, Ca
-   write(iulog,fmt1) ' diagonal(:,1)= ', diagonal(:,1)
-   write(iulog,fmt1) ' diagonal(:,2)= ', diagonal(:,2)
-   write(iulog,fmt1) ' diagonal(:,3)= ', diagonal(:,3)
-   write(iulog,fmt1) ' b= ', b(1:nMolecule)
- end if
+  SUBROUTINE TDMA(NX,MAT,b,T)
+  ! Solve tridiagonal matrix system of linear equation
+  ! NX is the number of unknowns (gridblocks minus boundaries)
+  ! Solve system of linear equations, A*T = b where A is tridiagonal matrix
+  ! MAT = NX x 3 array holding tri-diagonal portion of A
+  ! MAT(NX,1) - uppder diagonals for matrix A
+  ! MAT(NX,2) - diagonals for matrix A
+  ! MAT(NX,3) - lower diagonals for matrix A
+  ! b(NX) - vector of the right hand coefficients b
+  ! T(NX) - The solution matrix
+  !
+  ! example, A
+  ! d u 0 0 0
+  ! l d u 0 0
+  ! 0 l d u 0
+  ! 0 0 l d u
+  ! 0 0 0 l d
+  !
+  ! MAT(:,1) = [0, u, u, u, u]
+  ! MAT(:,2) = [d, d, d, d, d]
+  ! MAT(:,3) = [l, l, l, l, 0]
 
- END SUBROUTINE solve_ade
+    implicit none
+    ! Argument variables
+    integer(i4b),  intent(in)     :: NX     ! number of unknown (= number of matrix size, grid point minus two end points)
+    real(dp),      intent(in)     :: MAT(NX,3)
+    real(dp),      intent(in)     :: b(NX)
+    real(dp),      intent(inout)  :: T(NX)
+    ! Local variables
+    integer(i4b)                  :: ix
+    real(dp)                      :: U(NX)
+    real(dp)                      :: D(NX)
+    real(dp)                      :: L(NX)
+    real(dp)                      :: b1(NX)
+    real(dp)                      :: coef
 
- SUBROUTINE TDMA(NX,MAT,b,T)
- ! Solve tridiagonal matrix system of linear equation
- ! NX is the number of unknowns (gridblocks minus boundaries)
- ! Solve system of linear equations, A*T = b where A is tridiagonal matrix
- ! MAT = NX x 3 array holding tri-diagonal portion of A
- ! MAT(NX,1) - uppder diagonals for matrix A
- ! MAT(NX,2) - diagonals for matrix A
- ! MAT(NX,3) - lower diagonals for matrix A
- ! b(NX) - vector of the right hand coefficients b
- ! T(NX) - The solution matrix
- !
- ! example, A
- ! d u 0 0 0
- ! l d u 0 0
- ! 0 l d u 0
- ! 0 0 l d u
- ! 0 0 0 l d
- !
- ! MAT(:,1) = [0, u, u, u, u]
- ! MAT(:,2) = [d, d, d, d, d]
- ! MAT(:,3) = [l, l, l, l, 0]
+    U(1:NX) = MAT(1:NX,1)
+    D(1:NX) = MAT(1:NX,2)
+    L(1:NX) = MAT(1:NX,3)
+    b1(1:NX) = b(1:NX)
+    do ix = 2, NX
+      coef  = L(ix-1)/D(ix-1)
+      D(ix) = D(ix)-coef*U(ix)
+      b1(ix) = b1(ix)-coef*b1(ix-1)
+    end do
 
-   implicit none
-   ! Argument variables
-   integer(i4b),  intent(in)     :: NX     ! number of unknown (= number of matrix size, grid point minus two end points)
-   real(dp),      intent(in)     :: MAT(NX,3)
-   real(dp),      intent(in)     :: b(NX)
-   real(dp),      intent(inout)  :: T(NX)
-   ! Local variables
-   integer(i4b)                  :: ix
-   real(dp)                      :: U(NX)
-   real(dp)                      :: D(NX)
-   real(dp)                      :: L(NX)
-   real(dp)                      :: b1(NX)
-   real(dp)                      :: coef
+    T(NX) = b1(NX)/D(NX) ! Starts the countdown of answers
+    do ix = NX-1, 1, -1
+        T(ix) = (b1(ix) - U(ix+1)*T(ix+1))/D(ix)
+    end do
 
-   U(1:NX) = MAT(1:NX,1)
-   D(1:NX) = MAT(1:NX,2)
-   L(1:NX) = MAT(1:NX,3)
-   b1(1:NX) = b(1:NX)
-   do ix = 2, NX
-     coef  = L(ix-1)/D(ix-1)
-     D(ix) = D(ix)-coef*U(ix)
-     b1(ix) = b1(ix)-coef*b1(ix-1)
-   end do
-
-   T(NX) = b1(NX)/D(NX) ! Starts the countdown of answers
-   do ix = NX-1, 1, -1
-       T(ix) = (b1(ix) - U(ix+1)*T(ix+1))/D(ix)
-   end do
-
- END SUBROUTINE TDMA
+  END SUBROUTINE TDMA
 
 END MODULE advection_diffusion

--- a/route/build/src/advection_diffusion.f90
+++ b/route/build/src/advection_diffusion.f90
@@ -81,7 +81,6 @@ CONTAINS
   integer(i4b)                  :: Nx                        ! number of internal reach segments
   integer(i4b)                  :: downstreamBC              ! method of B.C condition - absorbing or Neumann
   character(len=strLen)         :: fmt1                      ! format string
-  character(len=strLen)         :: cmessage                  ! error message from subroutine
   ! Local parameters
   integer(i4b), parameter       :: absorbingBC=1             ! downstream B.C.
   integer(i4b), parameter       :: neumannBC=2               ! downstream B.C. flux derivative w.r.t. distance at downstream boundary

--- a/route/build/src/ascii_utils.f90
+++ b/route/build/src/ascii_utils.f90
@@ -61,7 +61,6 @@ CONTAINS
  ! declare local variables
  logical(lgt)                         :: xist        ! .TRUE. if the file exists
  logical(lgt)                         :: xopn        ! .TRUE. if the file is already open
- character(len=256)                   :: cmessage    ! error message of downwind routine
  ! initialize errors
  err=0; message="f-file_open/"
  ! check if the file exists

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -235,9 +235,8 @@ CONTAINS
  real(dp), allocatable           :: Qprev(:)       ! sub-reach discharge at previous time step [m3/s]
  real(dp)                        :: dTsub          ! time inteval for sub time-step [sec]
  real(dp)                        :: pcntReduc      ! flow profile adjustment based on storage [-]
- integer(i4b)                    :: ix,it          ! loop index
+ integer(i4b)                    :: it             ! loop index
  integer(i4b)                    :: ntSub          ! number of sub time-step
- character(len=strLen)           :: fmt1           ! format string
  character(len=strLen)           :: cmessage       ! error message from subroutine
 
  ierr=0; message='diffusive_wave/'

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -73,8 +73,8 @@ CONTAINS
  integer(i4b)                              :: iRch_ups          ! index of upstream reach in NETOPO
  real(dp)                                  :: Qlat              ! lateral flow into channel [m3/s]
  real(dp)                                  :: Qabs              ! maximum allowable water abstraction rate [m3/s]
- real(dp)                                  :: q_upstream        ! total discharge at top of the reach [m3/s]
- real(dp)                                  :: q_upstream_mod    ! total discharge at top of the reach after water abstraction [m3/s]
+ real(dp)                                  :: Qupstream        ! total discharge at top of the reach [m3/s]
+ real(dp)                                  :: Qupstream_mod    ! total discharge at top of the reach after water abstraction [m3/s]
  character(len=strLen)                     :: cmessage          ! error message from subroutine
 
  ierr=0; message='dfw_rch/'
@@ -87,7 +87,7 @@ CONTAINS
  ! get discharge coming from upstream
  nUps = count(NETOPO_in(segIndex)%goodBas) ! reminder: goodBas is reach with >0 total contributory area
  isHW = .true.
- q_upstream = 0.0_dp
+ Qupstream = 0.0_dp
 
  Qabs = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX ! initial water abstraction (positive) or injection (negative)
  RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_WM_FLUX_actual = RCHFLX_out(iens,segIndex)%REACH_WM_FLUX ! initialize actual water abstraction
@@ -103,25 +103,25 @@ CONTAINS
      if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%Qobs/=realMissing) then
        RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%Qobs
      end if
-     q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
+     Qupstream = Qupstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
    end do
-   q_upstream_mod  = q_upstream
+   Qupstream_mod  = Qupstream
    Qlat = RCHFLX_out(iens,segIndex)%BASIN_QR(1)
  else ! headwater
    if (verbose) then
      write(iulog,'(A)')            ' This is headwater '
    endif
    if (hw_drain_point==top_reach) then ! lateral flow is poured in a reach at the top
-     q_upstream = q_upstream + RCHFLX_out(iens,segIndex)%BASIN_QR(1)
-     q_upstream_mod = q_upstream
+     Qupstream = Qupstream + RCHFLX_out(iens,segIndex)%BASIN_QR(1)
+     Qupstream_mod = Qupstream
      Qlat = 0._dp
    else if (hw_drain_point==bottom_reach) then ! lateral flow is poured in a reach at the top
-     q_upstream_mod = q_upstream
+     Qupstream_mod = Qupstream
      Qlat = RCHFLX_out(iens,segIndex)%BASIN_QR(1)
    end if
  end if
 
- RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_INFLOW = q_upstream ! total inflow from the upstream reaches
+ RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_INFLOW = Qupstream ! total inflow from the upstream reaches
 
  ! Water management - water injection or abstraction (irrigation or industrial/domestic water usage)
  ! For water abstraction, water is extracted from the following priorities:
@@ -133,11 +133,11 @@ CONTAINS
      else ! if inital abstraction is greater than volume
        Qabs = Qabs - RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_VOL(1)/dt ! get residual Qabs after extracting from strorage
        RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_VOL(1) = 0._dp ! voluem gets 0
-       if (q_upstream > Qabs) then ! then take out all residual abstraction from upstream inflow
-         q_upstream_mod = q_upstream - Qabs
+       if (Qupstream > Qabs) then ! then take out all residual abstraction from upstream inflow
+         Qupstream_mod = Qupstream - Qabs
        else ! if residual abstraction is still greater than lateral flow
-         Qabs = Qabs - q_upstream ! get residual abstraction after extracting upstream inflow and storage.
-         q_upstream_mod = 0._dp ! upstream inflow gets 0 (all is gone to abstracted flow).
+         Qabs = Qabs - Qupstream ! get residual abstraction after extracting upstream inflow and storage.
+         Qupstream_mod = 0._dp ! upstream inflow gets 0 (all is gone to abstracted flow).
          if (Qlat > Qabs) then ! then take residual abstraction out from lateral flow
            Qlat = Qlat - Qabs
          else ! if residual abstraction is greater than upstream inflow
@@ -167,7 +167,7 @@ CONTAINS
  ! solve diffusive wave equation
  call diffusive_wave(RPARAM_in(segIndex),                     &  ! input: parameter at segIndex reach
                      T0,T1,                                   &  ! input: start and end of the time step
-                     q_upstream_mod,                          &  ! input: total discharge at top of the reach being processed
+                     Qupstream_mod,                           &  ! input: total discharge at top of the reach being processed
                      Qlat,                                    &  ! input: lateral flow [m3/s]
                      isHW,                                    &  ! input: is this headwater basin?
                      RCHSTA_out(iens,segIndex)%DW_ROUTE,      &  ! inout:
@@ -188,7 +188,7 @@ CONTAINS
          'at ', NETOPO_in(segIndex)%REACHID
  end if
 
- call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxDW, q_upstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
+ call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxDW, Qupstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
 
  END SUBROUTINE dfw_rch
 
@@ -198,7 +198,7 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE diffusive_wave(rch_param,     & ! input: river parameter data structure
                            T0,T1,         & ! input: start and end of the time step
-                           q_upstream,    & ! input: discharge from upstream
+                           Qupstream,    & ! input: discharge from upstream
                            Qlat,          & ! input: lateral discharge into chaneel [m3/s]
                            isHW,          & ! input: is this headwater basin?
                            rstate,        & ! inout: reach state at a reach
@@ -211,31 +211,14 @@ CONTAINS
  !
  !  ck (celerity) and dk (diffusivity) are computed with previous inflow and outflow and current inflow
  !
- !  1) dQ/dt   = (Q(t,x) - Q(t-1,x))/dt
- !  2) dQ/dx   = [(1-wck)(Q(t-1,x+1)-Q(t-1,x-1)) + wck*(Q(t,x+1)-Q(t,x-1))]/2dx
- !  3) d2Q/dx2 = [(1-wdk)(Q(t-1,x+1)-2Q(t-1,x)+Q(t-1,x-1)) + wdk*(Q(t,x+1)-2Q(t,x)+Q(t,x-1))]/2dx
- !
- !  upstream B.C:   Dirchlet BC with inflow at current time-step,t, from upstream basin
- !  downstream B.C: Neumann BC with prescribed Q gradient (Sbc)
- !                  dQ/dx|x=N = Sbc ->  4) Q(t,N)-Q(t,N-1)) = Sbc*dx
- !  Another downstream B.C option is absorbing boundary condition
- !                  dQ/dt|x=N + ck*dQ/dx|x=N = 0
- !
- !  Inserting 1), 2), 3) and 4) into a) and moving Q(t,*) terms to left-hand side and Q(t-1,*) terms to the righ-hand side
- !  results in tridiagonal matrix equation A*Q = b
- !  where A is [N x N] matrix, Q is [N x 1] vector to be solved (next time step Q) and b is [N x 1] vector
- !  N (nMolecule is used in the code) is the number of internal nodes including upstream and downstream boundaries
- !
- !  Since A is a tridiagonal matrix, the code stores only three diagnoal elements - upper, diagonal, and lower
- !  solving the matrix equation use thomas algorithm
- !
  ! ----------------------------------------------------------------------------------------
  USE globalData, ONLY : nMolecule   ! number of internal nodes for finite difference (including upstream and downstream boundaries)
+ USE advection_diffusion, ONLY: solve_ade
  implicit none
  ! Argument variables
  type(RCHPRP), intent(in)        :: rch_param      ! River reach parameter
  real(dp),     intent(in)        :: T0,T1          ! start and end of the time step (seconds)
- real(dp),     intent(in)        :: q_upstream     ! total discharge at top of the reach being processed
+ real(dp),     intent(in)        :: Qupstream      ! total discharge at top of the reach being processed
  real(dp),     intent(in)        :: Qlat           ! lateral discharge into chaneel [m3/s]
  logical(lgt), intent(in)        :: isHW           ! is this headwater basin?
  type(dwRch),  intent(inout)     :: rstate         ! curent reach states
@@ -244,43 +227,22 @@ CONTAINS
  integer(i4b), intent(out)       :: ierr           ! error code
  character(*), intent(out)       :: message        ! error message
  ! Local variables
- real(dp)                        :: Cd             ! Fourier number
- real(dp)                        :: Ca             ! Courant number
- real(dp)                        :: dx             ! length of segment [m]
  real(dp)                        :: Qbar           ! 3-point average discharge [m3/s]
  real(dp)                        :: depth          ! flow depth [m]
  real(dp)                        :: ck             ! kinematic wave celerity [m/s]
  real(dp)                        :: dk             ! diffusivity [m2/s]
- real(dp)                        :: Sbc            ! neumann BC slope
- real(dp), allocatable           :: diagonal(:,:)  ! diagonal part of matrix
- real(dp), allocatable           :: b(:)           ! right-hand side of the matrix equation
  real(dp), allocatable           :: Qlocal(:,:)    ! sub-reach & sub-time step discharge at previous and current time step [m3/s]
- real(dp), allocatable           :: Qsolved(:)     ! solved Q at sub-reach at current time step [m3/s]
  real(dp), allocatable           :: Qprev(:)       ! sub-reach discharge at previous time step [m3/s]
  real(dp)                        :: dTsub          ! time inteval for sub time-step [sec]
- real(dp)                        :: wck            ! weight for advection
- real(dp)                        :: wdk            ! weight for diffusion
  real(dp)                        :: pcntReduc      ! flow profile adjustment based on storage [-]
  integer(i4b)                    :: ix,it          ! loop index
  integer(i4b)                    :: ntSub          ! number of sub time-step
- integer(i4b)                    :: Nx             ! number of internal reach segments
- integer(i4b)                    :: downstreamBC   ! method of B.C condition - absorbing or Neumann
  character(len=strLen)           :: fmt1           ! format string
  character(len=strLen)           :: cmessage       ! error message from subroutine
- ! Local parameters
- integer(i4b), parameter         :: absorbingBC=1
- integer(i4b), parameter         :: neumannBC=2    ! flux derivative w.r.t. distance at downstream boundary
 
  ierr=0; message='diffusive_wave/'
 
- ! hard-coded parameters
- downstreamBC = neumannBC
-
  ntSub = 1  ! number of sub-time step
- wck = 1.0  ! weight in advection term
- wdk = 1.0  ! weight in diffusion term 0.0-> fully explicit, 0.5-> Crank-Nicolson, 1.0 -> fully implicit
-
- Nx = nMolecule%DW_ROUTE - 1  ! Nx: number of internal reach segments
 
  associate(S         => rch_param%R_SLOPE,    & ! channel slope
            n         => rch_param%R_MAN_N,    & ! manning n
@@ -293,27 +255,18 @@ CONTAINS
 
  if (.not. isHW .or. hw_drain_point==top_reach) then
 
-   if (rch_param%RLENGTH > min_length_route) then
+   if (L > min_length_route) then
 
    allocate(Qprev(nMolecule%DW_ROUTE), stat=ierr, errmsg=cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-   allocate(b(nMolecule%DW_ROUTE), stat=ierr, errmsg=cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-   allocate(diagonal(nMolecule%DW_ROUTE,3), stat=ierr, errmsg=cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    ! initialize previous time step flow
    Qprev(1:nMolecule%DW_ROUTE) = rstate%molecule%Q     ! flow state at previous time step
 
-   ! Get the reach parameters
-   dx = L/(Nx-1) ! one extra sub-segment beyond outlet
-
    if (verbose) then
      write(iulog,'(A,1X,G12.5)') ' length [m]        =',L
      write(iulog,'(A,1X,G12.5)') ' slope [-]         =',S
-     write(iulog,'(A,1X,G12.5)') ' channel width [m] =',b
+     write(iulog,'(A,1X,G12.5)') ' channel width [m] =',bt
      write(iulog,'(A,1X,G12.5)') ' manning coef [-]  =',n
    end if
 
@@ -327,73 +280,24 @@ CONTAINS
    allocate(Qlocal(1:nMolecule%DW_ROUTE, 0:1), stat=ierr, errmsg=cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-   allocate(Qsolved(1:nMolecule%DW_ROUTE), stat=ierr, errmsg=cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-   Qlocal(:,0:1) = realMissing
-   Qlocal(1:nMolecule%DW_ROUTE, 0) = Qprev ! previous time step
-   Qlocal(1,1)  = q_upstream     ! infllow at sub-time step in current time step
-
    do it = 1, nTsub
-
-     Qbar = (Qlocal(1,1)+Qlocal(1,0)+Qlocal(nMolecule%DW_ROUTE-1,0))/3.0 ! 3 point average discharge [m3/s]
+     Qbar = (Qupstream+Qprev(1)+Qprev(nMolecule%DW_ROUTE-1))/3.0 ! 3 point average discharge [m3/s]
      depth = flow_depth(abs(Qbar), bt, zc, S, n, zf=zf, bankDepth=bankDepth) ! compute flow depth as normal depth (a function of flow)
-
      ck    = celerity(abs(Qbar), depth, bt, zc, S, n, zf=zf, bankDepth=bankDepth)
      dk    = diffusivity(abs(Qbar), depth, bt, zc, S, n, zf=zf, bankDepth=bankDepth)
 
-     Cd = dk*dTsub/dx**2
-     Ca = ck*dTsub/dx
-
-     ! create a matrix - current time step
-     ! populate tridiagonal elements
-     ! diagonal
-     diagonal(1,2)             = 1._dp
-     diagonal(2:nMolecule%DW_ROUTE-1,2) = 2._dp + 4*wdk*Cd
-     if (downstreamBC == absorbingBC) then
-       diagonal(nMolecule%DW_ROUTE,2)     = 1._dp + wck*Ca
-     else if (downstreamBC == neumannBC) then
-       diagonal(nMolecule%DW_ROUTE,2)     = 1._dp
-     end if
-
-     ! upper
-     diagonal(:,1)           = 0._dp
-     diagonal(3:nMolecule%DW_ROUTE,1) = wck*Ca - 2._dp*wdk*Cd
-
-     ! lower
-     diagonal(:,3)             = 0._dp
-     diagonal(1:nMolecule%DW_ROUTE-2,3) = -wck*Ca - 2._dp*wdk*Cd
-     if (downstreamBC == absorbingBC) then
-       diagonal(nMolecule%DW_ROUTE-1,3)   = -wck*Ca
-     else if (downstreamBC == neumannBC) then
-       diagonal(nMolecule%DW_ROUTE-1,3)     = -1._dp
-     end if
-
-     ! populate right-hand side
-     ! upstream boundary condition
-     b(1)             = Qlocal(1,1)
-     ! downstream boundary condition
-     if (downstreamBC == absorbingBC) then
-       b(nMolecule%DW_ROUTE) = (1._dp-(1._dp-wck)*Ca)*Qlocal(nMolecule%DW_ROUTE,0) + (1-wck)*Ca*Qlocal(nMolecule%DW_ROUTE-1,0)
-     else if (downstreamBC == neumannBC) then
-       Sbc = (Qlocal(nMolecule%DW_ROUTE,0)-Qlocal(nMolecule%DW_ROUTE-1,0))
-       b(nMolecule%DW_ROUTE)     = Sbc
-     end if
-     ! internal node points
-     b(2:nMolecule%DW_ROUTE-1) = ((1._dp-wck)*Ca+2._dp*(1._dp-wdk)*Cd)*Qlocal(1:nMolecule%DW_ROUTE-2,0)  &
-                      + (2._dp-4._dp*(1._dp-wdk)*Cd)*Qlocal(2:nMolecule%DW_ROUTE-1,0)           &
-                      - ((1._dp-wck)*Ca - 2._dp*(1._dp-wdk)*Cd)*Qlocal(3:nMolecule%DW_ROUTE,0)
-
-     ! solve matrix equation - get updated Qlocal
-     call TDMA(nMolecule%DW_ROUTE, diagonal, b, Qsolved)
-
-     if (verbose) then
-       write(fmt1,'(A,I5,A)') '(A,1X',nMolecule%DW_ROUTE,'(1X,G15.4))'
-       write(iulog,fmt1) ' Q sub_reqch=', (Qsolved(ix), ix=1,nMolecule%DW_ROUTE)
-     end if
-
-     Qlocal(:,1) = Qsolved
-     Qlocal(:,0) = Qlocal(:,1)
+     call solve_ade(L,                  & ! input: river parameter data structure
+                    nMolecule%DW_ROUTE, & ! input: number of sub-segments
+                    dTsub,              & ! input: time_step [sec]
+                    Qupstream,          & ! input: quantity from upstream [unit of quantity]
+                    ck,                 & ! input: velocity [m/s]
+                    dk,                 & ! input: diffusivity [m2/s]
+                    Qlat,               & ! input: lateral quantity into chaneel [unit of quantity]
+                    Qprev,              & ! input: quantity at previous time step [unit of quantity]
+                    Qlocal,             & ! inout: quantity soloved at current time step [unit of quantity]
+                    verbose,            & ! input: reach index to be examined
+                    ierr,message)
+     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
    end do
 
    ! For very low flow condition, outflow - inflow may exceed current storage, so limit outflow and adjust flow profile
@@ -402,7 +306,7 @@ CONTAINS
      Qlocal(2:nMolecule%DW_ROUTE,1) = Qlocal(2:nMolecule%DW_ROUTE,1)*pcntReduc
    end if
 
-   rflux%ROUTE(idxDW)%REACH_VOL(1) = rflux%ROUTE(idxDW)%REACH_VOL(1) + (q_upstream - Qlocal(nMolecule%DW_ROUTE-1,1))*dt
+   rflux%ROUTE(idxDW)%REACH_VOL(1) = rflux%ROUTE(idxDW)%REACH_VOL(1) + (Qupstream - Qlocal(nMolecule%DW_ROUTE-1,1))*dt
 
    ! if reach volume exceeds flood threshold volume, excess water is flooded volume.
    if (rflux%ROUTE(idxDW)%REACH_VOL(1) > bankVol) then
@@ -419,20 +323,8 @@ CONTAINS
    ! update state
    rstate%molecule%Q = Qlocal(:,1)
 
-   if (verbose) then
-     write(fmt1,'(A,I5,A)') '(A,1X',nMolecule%DW_ROUTE,'(1X,G15.4))'
-     write(iulog,'(A,1X,G12.5)') ' rflux%REACH_Q= ', rflux%ROUTE(idxDW)%REACH_Q
-     write(iulog,fmt1) ' Qprev(1:nMolecule)= ', Qprev(1:nMolecule%DW_ROUTE)
-     write(iulog,'(A,3(1X,G12.5))') ' Qbar, ck, dk= ',Qbar, ck, dk
-     write(iulog,'(A,2(1X,G12.5))') ' Cd, Ca= ', Cd, Ca
-     write(iulog,fmt1) ' diagonal(:,1)= ', diagonal(:,1)
-     write(iulog,fmt1) ' diagonal(:,2)= ', diagonal(:,2)
-     write(iulog,fmt1) ' diagonal(:,3)= ', diagonal(:,3)
-     write(iulog,fmt1) ' b= ', b(1:nMolecule%DW_ROUTE)
-   end if
-
    else ! length < min_length_route: length is short enough to just pass upstream to downstream
-     rflux%ROUTE(idxDW)%REACH_Q = q_upstream + Qlat
+     rflux%ROUTE(idxDW)%REACH_Q = Qupstream + Qlat
      rstate%molecule%Q(1:nMolecule%DW_ROUTE) = 0._dp
      rstate%molecule%Q(nMolecule%DW_ROUTE)   = rflux%ROUTE(idxDW)%REACH_Q
 
@@ -462,58 +354,5 @@ CONTAINS
  end associate
 
  END SUBROUTINE diffusive_wave
-
- SUBROUTINE TDMA(NX,MAT,b,T)
- ! Solve tridiagonal matrix system of linear equation
- ! NX is the number of unknowns (gridblocks minus boundaries)
- ! Solve system of linear equations, A*T = b where A is tridiagonal matrix
- ! MAT = NX x 3 array holding tri-diagonal portion of A
- ! MAT(NX,1) - uppder diagonals for matrix A
- ! MAT(NX,2) - diagonals for matrix A
- ! MAT(NX,3) - lower diagonals for matrix A
- ! b(NX) - vector of the right hand coefficients b
- ! T(NX) - The solution matrix
- !
- ! example, A
- ! d u 0 0 0
- ! l d u 0 0
- ! 0 l d u 0
- ! 0 0 l d u
- ! 0 0 0 l d
- !
- ! MAT(:,1) = [0, u, u, u, u]
- ! MAT(:,2) = [d, d, d, d, d]
- ! MAT(:,3) = [l, l, l, l, 0]
-
-   implicit none
-   ! Argument variables
-   integer(i4b),  intent(in)     :: NX     ! number of unknown (= number of matrix size, grid point minus two end points)
-   real(dp),      intent(in)     :: MAT(NX,3)
-   real(dp),      intent(in)     :: b(NX)
-   real(dp),      intent(inout)  :: T(NX)
-   ! Local variables
-   integer(i4b)                  :: ix
-   real(dp)                      :: U(NX)
-   real(dp)                      :: D(NX)
-   real(dp)                      :: L(NX)
-   real(dp)                      :: b1(NX)
-   real(dp)                      :: coef
-
-   U(1:NX) = MAT(1:NX,1)
-   D(1:NX) = MAT(1:NX,2)
-   L(1:NX) = MAT(1:NX,3)
-   b1(1:NX) = b(1:NX)
-   do ix = 2, NX
-     coef  = L(ix-1)/D(ix-1)
-     D(ix) = D(ix)-coef*U(ix)
-     b1(ix) = b1(ix)-coef*b1(ix-1)
-   end do
-
-   T(NX) = b1(NX)/D(NX) ! Starts the countdown of answers
-   do ix = NX-1, 1, -1
-       T(ix) = (b1(ix) - U(ix+1)*T(ix+1))/D(ix)
-   end do
-
- END SUBROUTINE TDMA
 
 END MODULE dfw_route_module


### PR DESCRIPTION
Separate a advection-diffusion equation solver out of `dfw_route.f90` and put it in `advection_diffusion.f90` so this can be used for a tracer. The below is the interface. This can be used for advection equation solver by setting dk=0 

```
  SUBROUTINE solve_ade(reach_length,  & ! input: Reach length [m]
                       nMolecule,     & ! input: number of sub-segments
                       dt_local,      & ! input: time_step [sec]
                       FluxUpstream,  & ! input: Flux from upstream [unit of flux]
                       ck,            & ! input: velocity [m/s]
                       dk,            & ! input: diffusivity [m2/s]
                       FluxLat,       & ! input: lateral flux into channel [unit of flux]
                       FluxPrev,      & ! input: Flux at previous time step [unit of flux]
                       FluxLocal,     & ! inout: Flux solved at current time step [unit of flux]
                       verbose,       & ! input: reach index to be examined
                       ierr,message)
```