### PR TITLE
complete direct-insertion implementation

### DIFF
--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -42,14 +42,6 @@ implicit none
   logical(lgt)           :: varFile  = .true.          ! .true. if the variable should be read from a file
  endtype var_info
 
- ! ---------- gauge metadata structures --------------------------------------------------------------------------
-
- type, public :: gage
-   integer(i4b)                   :: nGage
-   character(len=30), allocatable :: gageID(:)
-   integer(i4b),      allocatable :: reachID(:)
- end type gage
-
  ! ---------- basin data structures ----------------------------------------------------------------------
 
  ! segIndex points to the segment in the entire river network data
@@ -359,6 +351,7 @@ implicit none
    real(dp)        :: REACH_VOL(0:1)         ! water volume at previous and current time steps [m3]
    real(dp)        :: REACH_WM_FLUX_actual   ! water management fluxes to and from each reach [m3/s]
    real(dp)        :: WB                     ! reach water balance error [m3]
+   real(dp)        :: Qerror
  end type hydraulic
 
  ! fluxes and states in each reach
@@ -373,6 +366,7 @@ implicit none
   real(dp)                             :: REACH_WM_FLUX          ! water management fluxes to and from each reach [m3/s]
   real(dp)                             :: REACH_WM_VOL           ! target volume from the second water management file [m3]
   real(dp)                             :: Qobs                   ! observed discharge [m3/s]
+  integer(i4b)                         :: Qelapsed               ! number of time step after observed flow is read [-]
   real(dp)                             :: basinEvapo             ! remapped river network catchment Evaporation [unit] (size: number of nHRU)
   real(dp)                             :: basinPrecip            ! remapped river network catchment Precipitation [unit] (size: number of nHRU)
  end type strflx

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -199,7 +199,9 @@ CONTAINS
    endif
  end if
 
- call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxDW, Qupstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
+ if (qmodOption==0) then ! check reach water balance only if data assimilation is off
+   call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxDW, Qupstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
+ end if
 
  END SUBROUTINE dfw_rch
 

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -23,6 +23,7 @@ USE hydraulic,     ONLY: flow_depth
 USE hydraulic,     ONLY: water_height
 USE hydraulic,     ONLY: celerity
 USE hydraulic,     ONLY: diffusivity
+USE data_assimilation, ONLY: direct_insertion ! qmod option (use 1==direct insertion)
 
 implicit none
 
@@ -100,9 +101,6 @@ CONTAINS
    do iUps = 1,nUps
      if (.not. NETOPO_in(segIndex)%goodBas(iUps)) cycle ! skip upstream reach which does not any flow due to zero total contributory areas
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-     if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%Qobs/=realMissing) then
-       RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q = RCHFLX_out(iens,iRch_ups)%Qobs
-     end if
      Qupstream = Qupstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxDW)%REACH_Q
    end do
    Qupstream_mod  = Qupstream
@@ -186,6 +184,19 @@ CONTAINS
  if (RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_VOL(1) < 0) then
    write(iulog,'(A,1X,G12.5,1X,A,1X,I9)') ' ---- NEGATIVE VOLUME = ', RCHFLX_out(iens,segIndex)%ROUTE(idxDW)%REACH_VOL(1), &
          'at ', NETOPO_in(segIndex)%REACHID
+ end if
+
+ if (qmodOption==1) then
+   call direct_insertion(iens, segIndex, & ! input: reach index
+                         idxDW,          & ! input: routing method id for diffusive wave routing
+                         ixDesire,       & ! input: verbose seg index
+                         NETOPO_in,      & ! input: reach topology data structure
+                         RCHSTA_out,     & ! inout: reach state data structure
+                         RCHFLX_out,     & ! inout: reach fluxes datq structure
+                         ierr, cmessage)   ! output: error control
+   if(ierr/=0)then
+     write(message,'(A,X,I12,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage); return
+   endif
  end if
 
  call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxDW, Qupstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -18,7 +18,10 @@ MODULE globalData
   USE objTypes,  ONLY: var_info_new  ! metadata type - variable
 
   USE dataTypes, ONLY: inFileInfo    ! data strture - information of input files
-  USE dataTypes, ONLY: gage          ! data structure - gauge metadata
+
+  ! gage data strucuture
+  USE gageMeta_data, ONLY: gageMeta
+  USE obs_data,      ONLY: gageObs
 
   USE dataTypes, ONLY: RCHPRP        ! data structure - Reach parameters (properties)
   USE dataTypes, ONLY: RCHTOPO       ! data structure - Network topology
@@ -113,6 +116,10 @@ MODULE globalData
   type(datetime),                  public :: roBegDatetime        ! forcing data start date/time (yyyy:mm:dd:hh:mm:ss)
   type(datetime),                  public :: wmBegDatetime        ! water management data start date/time (yyyy:mm:dd:hh:mm:ss)
 
+  ! obs data - gage data, watertake etc.
+  type(gageMeta),                  public :: gage_meta_data             ! gauge metadata
+  type(gageObs),                   public :: gage_obs_data_trib         ! gauge observed data for tributary
+  type(gageObs),                   public :: gage_obs_data_main         ! gauge observed data for mainstem
   ! ---------- input file information -------------------------------------------------------------------
 
   type(infileinfo), allocatable,   public :: inFileInfo_ro(:)    ! input runoff/evapo/precipi file information
@@ -207,7 +214,6 @@ MODULE globalData
   type(var_info_new),              public :: meta_dw     (nVarsDW     ) ! DW routing restart fluxes/states
 
   ! ---------- shared data structures ----------------------------------------------------------------------
-  type(gage),                      public :: gage_data              ! gauge metadata
 
   ! river topology and parameter structures
   type(RCHPRP),       allocatable, public :: RPARAM(:)              ! Reach Parameters for whole domain

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -27,6 +27,7 @@ public :: get_mpi_omp
 public :: init_model
 public :: init_ntopo_data
 public :: init_state_data
+public :: init_qmod
 public :: update_time
 public :: init_pio
 
@@ -139,6 +140,7 @@ CONTAINS
   USE public_var,          ONLY: param_nml
   USE public_var,          ONLY: gageMetaFile
   USE public_var,          ONLY: outputAtGage
+  USE public_var,          ONLY: qmodOption        ! option for streamflow modification (DA)
   USE popMetadat_module,   ONLY: popMetadat        ! populate metadata
   USE read_control_module, ONLY: read_control      ! read the control file
   USE read_param_module,   ONLY: read_param        ! read the routing parameters
@@ -165,7 +167,7 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   ! read gauge metadata if specified in control file
-  if (outputAtGage .and. trim(gageMetaFile)/=charMissing) then
+  if ((outputAtGage .or. qmodOption==1).and. trim(gageMetaFile)/=charMissing) then
     call read_gage_meta(trim(ancil_dir)//trim(gageMetaFile),ierr,cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   end if
@@ -409,6 +411,9 @@ CONTAINS
       RCHFLX_trib(:,:)%BASIN_QI     = 0._dp
       RCHFLX_trib(:,:)%BASIN_QR(0)  = 0._dp
       RCHFLX_trib(:,:)%BASIN_QR(1)  = 0._dp
+      RCHFLX(:,:)%Qelapsed = 0
+      RCHFLX(:,:)%Qobs = 0._dp
+
       nRch_root=nRch_mainstem+nTribOutlet+rch_per_proc(0)
       if (onRoute(accumRunoff)) then
         do ix = 1,nRch_root
@@ -420,6 +425,7 @@ CONTAINS
         do ix = 1,nRch_root
           RCHFLX_trib(iens,ix)%ROUTE(idxIRF)%REACH_VOL(0:1) = 0._dp
           RCHFLX_trib(iens,ix)%ROUTE(idxIRF)%REACH_Q        = 0._dp
+          RCHFLX_trib(iens,ix)%ROUTE(idxIRF)%Qerror         = 0._dp
         end do
       end if
       if (onRoute(kinematicWaveTracking)) then
@@ -448,12 +454,14 @@ CONTAINS
         do ix = 1, nRch_root
           RCHFLX_trib(iens,ix)%ROUTE(idxKWT)%REACH_VOL(0:1) = 0._dp
           RCHFLX_trib(iens,ix)%ROUTE(idxKWT)%REACH_Q        = 0._dp
+          RCHFLX_trib(iens,ix)%ROUTE(idxKWT)%Qerror         = 0._dp
         end do
       end if
       if (onRoute(kinematicWave)) then
         do ix = 1, nRch_root
           RCHFLX_trib(iens,ix)%ROUTE(idxKW)%REACH_VOL(0:1) = 0._dp
           RCHFLX_trib(iens,ix)%ROUTE(idxKW)%REACH_Q        = 0._dp
+          RCHFLX_trib(iens,ix)%ROUTE(idxKW)%Qerror = 0._dp
           allocate(RCHSTA_trib(iens,ix)%KW_ROUTE%molecule%Q(nMolecule%KW_ROUTE), stat=ierr, errmsg=cmessage)
           if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA_trib%KW_ROUTE%molecule%Q]'; return; endif
           RCHSTA_trib(iens,ix)%KW_ROUTE%molecule%Q(:) = 0._dp
@@ -463,6 +471,7 @@ CONTAINS
         do ix = 1, nRch_root
           RCHFLX_trib(iens,ix)%ROUTE(idxMC)%REACH_VOL(0:1) = 0._dp
           RCHFLX_trib(iens,ix)%ROUTE(idxMC)%REACH_Q        = 0._dp
+          RCHFLX_trib(iens,ix)%ROUTE(idxMC)%Qerror = 0._dp
           allocate(RCHSTA_trib(iens,ix)%MC_ROUTE%molecule%Q(nMolecule%MC_ROUTE), stat=ierr, errmsg=cmessage)
           if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA_trib%MC_ROUTE%molecule%Q]'; return; endif
           RCHSTA_trib(iens,ix)%MC_ROUTE%molecule%Q(:) = 0._dp
@@ -472,6 +481,7 @@ CONTAINS
         do ix = 1, nRch_root
           RCHFLX_trib(iens,ix)%ROUTE(idxDW)%REACH_VOL(0:1) = 0._dp
           RCHFLX_trib(iens,ix)%ROUTE(idxDW)%REACH_Q        = 0._dp
+          RCHFLX_trib(iens,ix)%ROUTE(idxDW)%Qerror = 0._dp
           allocate(RCHSTA_trib(iens,ix)%DW_ROUTE%molecule%Q(nMolecule%DW_ROUTE), stat=ierr, errmsg=cmessage)
           if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA_trib%DW_ROUTE%molecule%Q]'; return; endif
           RCHSTA_trib(iens,ix)%DW_ROUTE%molecule%Q(:) = 0._dp
@@ -482,6 +492,8 @@ CONTAINS
         RCHFLX_trib(:,:)%BASIN_QI     = 0._dp
         RCHFLX_trib(:,:)%BASIN_QR(0)  = 0._dp
         RCHFLX_trib(:,:)%BASIN_QR(1)  = 0._dp
+        RCHFLX_trib(:,:)%Qelapsed = 0
+        RCHFLX_trib(:,:)%Qobs = 0._dp
         if (onRoute(accumRunoff)) then
           do ix = 1, size(RCHFLX_trib(1,:))
             RCHFLX_trib(iens,ix)%ROUTE(idxSUM)%REACH_VOL(0:1) = 0._dp
@@ -492,6 +504,7 @@ CONTAINS
           do ix = 1, size(RCHFLX_trib(1,:))
             RCHFLX_trib(iens,ix)%ROUTE(idxIRF)%REACH_VOL(0:1) = 0._dp
             RCHFLX_trib(iens,ix)%ROUTE(idxIRF)%REACH_Q        = 0._dp
+            RCHFLX_trib(iens,ix)%ROUTE(idxIRF)%Qerror         = 0._dp
           end do
         end if
         if (onRoute(kinematicWaveTracking)) then
@@ -509,6 +522,7 @@ CONTAINS
           do ix = 1, size(RCHFLX_trib(1,:))
             RCHFLX_trib(iens,ix)%ROUTE(idxKWT)%REACH_VOL(0:1) = 0._dp
             RCHFLX_trib(iens,ix)%ROUTE(idxKWT)%REACH_Q        = 0._dp
+            RCHFLX_trib(iens,ix)%ROUTE(idxKWT)%Qerror         = 0._dp
           end do
         end if
         if (onRoute(kinematicWave)) then
@@ -516,6 +530,7 @@ CONTAINS
             RCHFLX_trib(iens,ix)%ROUTE(idxKW)%FLOOD_VOL(0:1) = 0._dp
             RCHFLX_trib(iens,ix)%ROUTE(idxKW)%REACH_VOL(0:1) = 0._dp
             RCHFLX_trib(iens,ix)%ROUTE(idxKW)%REACH_Q        = 0._dp
+            RCHFLX_trib(iens,ix)%ROUTE(idxKW)%Qerror         = 0._dp
             allocate(RCHSTA_trib(iens,ix)%KW_ROUTE%molecule%Q(nMolecule%KW_ROUTE), stat=ierr, errmsg=cmessage)
             if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA_trib%KW_ROUTE%molecule%Q]'; return; endif
             RCHSTA_trib(iens,ix)%KW_ROUTE%molecule%Q(:) = 0._dp
@@ -526,6 +541,7 @@ CONTAINS
             RCHFLX_trib(iens,ix)%ROUTE(idxMC)%FLOOD_VOL(0:1) = 0._dp
             RCHFLX_trib(iens,ix)%ROUTE(idxMC)%REACH_VOL(0:1) = 0._dp
             RCHFLX_trib(iens,ix)%ROUTE(idxMC)%REACH_Q        = 0._dp
+            RCHFLX_trib(iens,ix)%ROUTE(idxMC)%Qerror         = 0._dp
             allocate(RCHSTA_trib(iens,ix)%MC_ROUTE%molecule%Q(nMolecule%MC_ROUTE), stat=ierr, errmsg=cmessage)
             if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA_trib%MC_ROUTE%molecule%Q]'; return; endif
             RCHSTA_trib(iens,ix)%MC_ROUTE%molecule%Q(:) = 0._dp
@@ -536,6 +552,7 @@ CONTAINS
             RCHFLX_trib(iens,ix)%ROUTE(idxDW)%FLOOD_VOL(0:1) = 0._dp
             RCHFLX_trib(iens,ix)%ROUTE(idxDW)%REACH_VOL(0:1) = 0._dp
             RCHFLX_trib(iens,ix)%ROUTE(idxDW)%REACH_Q        = 0._dp
+            RCHFLX_trib(iens,ix)%ROUTE(idxDW)%Qerror         = 0._dp
             allocate(RCHSTA_trib(iens,ix)%DW_ROUTE%molecule%Q(nMolecule%DW_ROUTE), stat=ierr, errmsg=cmessage)
             if(ierr/=0)then; message=trim(message)//trim(cmessage)//' [RCHSTA_trib%DW_ROUTE%molecule%Q]'; return; endif
             RCHSTA_trib(iens,ix)%DW_ROUTE%molecule%Q(:) = 0._dp
@@ -769,5 +786,73 @@ CONTAINS
     end do
 
   END SUBROUTINE init_route_method
+
+ ! *****
+ ! public subroutine: initialize data gauge observed data
+ ! *********************************************************************
+ SUBROUTINE init_qmod(ierr, message)
+
+   USE public_var,    ONLY: qmodOption          ! option for streamflow modification (DA)
+   USE public_var,    ONLY: ancil_dir           ! name of the ancillary directory
+   USE public_var,    ONLY: fname_gageObs       ! name of gage obseved flow netCDF
+   USE public_var,    ONLY: vname_gageFlow      ! name of observed flow variable in flow netCDF
+   USE public_var,    ONLY: vname_gageTime      ! name of time variable in flow netCDF
+   USE public_var,    ONLY: dname_gageTime      ! name of time dimension in flow netCDF
+   USE public_var,    ONLY: vname_gageSite      ! name of gage site ID (chacter) variable in flow netCDF
+   USE public_var,    ONLY: dname_gageSite      ! name of site dimension in flow netCDF
+   USE globalData,    ONLY: masterproc
+   USE globalData,    ONLY: nRch_mainstem       ! number of mainstem reaches
+   USE globalData,    ONLY: gage_obs_data_trib  ! instantiated gage obs data for tributary reaches
+   USE globalData,    ONLY: gage_obs_data_main  ! instantiated gage obs data for mainstem reaches
+   USE globalData,    ONLY: gage_meta_data      ! instantiated gage meta data
+   USE globalData,    ONLY: NETOPO_main         ! mainstem NETOPO data strucutre to get reach ID in mainstem (only masterproc)
+   USE globalData,    ONLY: NETOPO_trib         ! tributary NETOPO data strucutre to get reach ID in tributary (all procs)
+   USE obs_data,      ONLY: gageObs             ! gage obs and water take classes
+
+   implicit none
+   ! argument variables
+   integer(i4b), intent(out)  :: ierr        ! error code
+   character(*), intent(out)  :: message     ! error message
+   ! local variables
+   character(len=strLen)      :: cmessage    ! error message from subroutine
+   logical(lgt)               :: fileExist   ! file exists or not
+   integer(i4b), parameter    :: no_mod=0
+   integer(i4b), parameter    :: direct_insert=1
+
+   ierr=0; message='init_qmod/'
+
+   select case(qmodOption)
+     case(no_mod)
+     case(direct_insert)
+       ! initialize gage obs data
+       inquire(file=trim(ancil_dir)//trim(fname_gageObs), exist=fileExist)
+       if (fileExist) then
+         gage_obs_data_trib = gageObs(trim(ancil_dir)//trim(fname_gageObs), &
+                                      vname_gageFlow,                       &
+                                      vname_gageTime, vname_gageSite,       &
+                                      dname_gageTime, dname_gageSite,       &
+                                      ierr, cmessage)
+         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+         ! compute link between gage ID and reach ID (river network domain) - index of reachID for each gage ID
+         call gage_obs_data_trib%comp_link(NETOPO_trib(:)%REACHID, gage_meta_data)
+
+         if (masterproc .and. nRch_mainstem>0) then
+           gage_obs_data_main = gageObs(trim(ancil_dir)//trim(fname_gageObs), &
+                                        vname_gageFlow,                       &
+                                        vname_gageTime, vname_gageSite,       &
+                                        dname_gageTime, dname_gageSite,       &
+                                        ierr, cmessage)
+           if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+           call gage_obs_data_main%comp_link(NETOPO_main(:)%REACHID, gage_meta_data)
+         end if
+       else
+         qmodOption=no_mod
+       end if
+     case default
+       ierr=1; message=trim(message)//"Error: qmodOption invalid"; return
+   end select
+
+ END SUBROUTINE init_qmod
 
 END MODULE init_model_data

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -217,7 +217,9 @@ CONTAINS
     endif
   end if
 
-  call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxIRF, q_upstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
+  if (qmodOption==0) then ! check reach water balance only if data assimilation is off
+    call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxIRF, q_upstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
+  end if
 
  END SUBROUTINE irf_rch
 

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -10,11 +10,13 @@ USE public_var,        ONLY: iulog             ! i/o logical unit number
 USE public_var,        ONLY: realMissing       ! missing value for real number
 USE public_var,        ONLY: integerMissing    ! missing value for integer number
 USE public_var,        ONLY: dt                ! simulation time step [sec]
-USE globalData,        ONLY: idxIRF            ! routing method index for IRF method
+USE public_var,        ONLY: qmodOption      ! qmod option (use 1==direct insertion)
 USE public_var,        ONLY: hw_drain_point    ! headwater catchment pour point (top_reach==1 or bottom_reach==2)
 USE public_var,        ONLY: min_length_route  ! minimum reach length for routing to be performed.
+USE globalData,        ONLY: idxIRF            ! routing method index for IRF method
 USE water_balance,     ONLY: comp_reach_wb     ! compute water balance error
 USE base_route,        ONLY: base_route_rch    ! base (abstract) reach routing method class
+USE data_assimilation, ONLY: direct_insertion  ! qmod option (use 1==direct insertion)
 
 implicit none
 
@@ -200,6 +202,19 @@ CONTAINS
     write(iulog,'(A,1X,G12.5,1X,A,1X,I9)') ' ---- NEGATIVE FLOW [m3/s] = ', RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q, &
            'at ', NETOPO_in(segIndex)%REACHID
 !    RCHFLX_out(iens,segIndex)%ROUTE(idxIRF)%REACH_Q = 0._dp
+  end if
+
+  if (qmodOption==1) then
+    call direct_insertion(iens, segIndex, & ! input: reach index
+                          idxIRF,         & ! input: routing method id for Euler kinematic wave
+                          ixDesire,       & ! input: verbose seg index
+                          NETOPO_in,      & ! input: reach topology data structure
+                          RCHSTA_out,     & ! inout: reach state data structure
+                          RCHFLX_out,     & ! inout: reach fluxes datq structure
+                          ierr, cmessage)   ! output: error control
+    if(ierr/=0)then
+      write(message,'(A,X,I12,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage); return
+    endif
   end if
 
   call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxIRF, q_upstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)

--- a/route/build/src/kwe_route.f90
+++ b/route/build/src/kwe_route.f90
@@ -197,7 +197,9 @@ CONTAINS
    endif
  end if
 
- call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxKW, q_upstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
+ if (qmodOption==0) then ! check reach water balance only if data assimilation is off
+   call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxKW, q_upstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
+ end if
 
  END SUBROUTINE kw_rch
 

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -198,7 +198,9 @@ CONTAINS
    endif
  end if
 
- call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxMC, q_upstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
+ if (qmodOption==0) then ! check reach water balance only if data assimilation is off
+   call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxMC, q_upstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)
+ end if
 
  END SUBROUTINE mc_rch
 

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -23,6 +23,7 @@ USE hydraulic,     ONLY: flow_depth      ! function to compute Normal flow depth
 USE hydraulic,     ONLY: water_height    ! function to compute water height bsed on flow area [m]
 USE hydraulic,     ONLY: celerity        ! function to compute celerity [m/s2]
 USE hydraulic,     ONLY: Btop            ! function to compute flow top width [m]
+USE data_assimilation, ONLY: direct_insertion ! qmod option (use 1==direct insertion)
 
 implicit none
 
@@ -100,9 +101,6 @@ CONTAINS
    do iUps = 1,nUps
      if (.not. NETOPO_in(segIndex)%goodBas(iUps)) cycle ! skip upstream reach which does not any flow due to zero total contributory areas
      iRch_ups = NETOPO_in(segIndex)%UREACHI(iUps)      !  index of upstream of segIndex-th reach
-     if (qmodOption==1 .and. RCHFLX_out(iens,iRch_ups)%Qobs/=realMissing) then
-       RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q = RCHFLX_out(iens,iRch_ups)%Qobs
-     end if
      q_upstream = q_upstream + RCHFLX_out(iens, iRch_ups)%ROUTE(idxMC)%REACH_Q
    end do
    q_upstream_mod  = q_upstream
@@ -185,6 +183,19 @@ CONTAINS
  if (RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_VOL(1) < 0._dp) then
    write(iulog,'(A,1X,G12.5,1X,A,1X,I9)') ' ---- NEGATIVE VOLUME = ', RCHFLX_out(iens,segIndex)%ROUTE(idxMC)%REACH_VOL(1), &
          'at ', NETOPO_in(segIndex)%REACHID
+ end if
+
+ if (qmodOption==1) then
+   call direct_insertion(iens, segIndex, & ! input: reach index
+                         idxMC,          & ! input: routing method id for diffusive wave routing
+                         ixDesire,       & ! input: verbose seg index
+                         NETOPO_in,      & ! input: reach topology data structure
+                         RCHSTA_out,     & ! inout: reach state data structure
+                         RCHFLX_out,     & ! inout: reach fluxes datq structure
+                         ierr, cmessage)   ! output: error control
+   if(ierr/=0)then
+     write(message,'(A,X,I12,X,A)') trim(message)//'/segment=', NETOPO_in(segIndex)%REACHID, '/'//trim(cmessage); return
+   endif
  end if
 
  call comp_reach_wb(NETOPO_in(segIndex)%REACHID, idxMC, q_upstream, Qlat, RCHFLX_out(iens,segIndex), verbose, lakeFlag=.false.)

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -1146,6 +1146,8 @@ CONTAINS
   USE globalData, ONLY: RPARAM_main         ! mainstem reach parameter structure
   USE globalData, ONLY: RCHFLX_trib         ! tributary reach flux structure
   USE globalData, ONLY: RCHSTA_trib         ! tributary reach state data structure
+  USE globalData, ONLY: gage_obs_data_trib  ! instantiated gage obs data for tributary reaches
+  USE globalData, ONLY: gage_obs_data_main  ! instantiated gage obs data for mainstem reaches
   USE globalData, ONLY: basinRunoff_main    ! mainstem only HRU runoff
   USE globalData, ONLY: basinRunoff_trib    ! tributary only HRU runoff
   USE globalData, ONLY: basinEvapo_main     ! mainstem only HRU Evaporation
@@ -1266,6 +1268,7 @@ CONTAINS
                   ixPrint(2),        &  ! input: reach index to be checked by on-screen pringing
                   RCHFLX_trib(:,ix1:ix2),   &  ! inout: reach flux data structure
                   RCHSTA_trib(:,ix1:ix2),   &  ! inout: reach state data structure
+                  gage_obs_data_trib, &  ! inout: gage obs data for tributary reaches
                   ierr, cmessage)        ! output: error control
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
   call t_stopf ('route/tributary-route')
@@ -1346,6 +1349,7 @@ CONTAINS
                       ixPrint(1),              &  ! input: reach index to be checked by on-screen pringing
                       RCHFLX_trib(:,1:nRch_mainstem+nTribOutlet),  &  ! inout: reach flux data structure
                       RCHSTA_trib(:,1:nRch_mainstem+nTribOutlet),  &  ! inout: reach state data structure
+                      gage_obs_data_main,      &  ! inout: gage obs data for mainstem reaches
                       ierr, cmessage)              ! output: error control
       if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 

--- a/route/build/src/pio_decomp_data.f90
+++ b/route/build/src/pio_decomp_data.f90
@@ -44,7 +44,7 @@ CONTAINS
     USE globalData, ONLY: nHRU                   !
     USE globalData, ONLY: nEns                   !
     USE globalData, ONLY: onRoute                !
-    USE globalData, ONLY: gage_data
+    USE globalData, ONLY: gage_meta_data
     USE globalData, ONLY: pioSystem              !
     USE pio_utils,  ONLY: pio_decomp
     USE pio_utils,  ONLY: ncd_int
@@ -62,6 +62,7 @@ CONTAINS
     integer(i4b),   intent(out)     :: ierr                ! error code
     character(*),   intent(out)     :: message             ! error message
     ! local variables
+    integer(i4b)                    :: nGage               ! total number of gauges
     integer(i4b), allocatable       :: compdof_rch(:)      !
     integer(i4b), allocatable       :: compdof_rch_gage(:) !
     integer(i4b), allocatable       :: compdof_hru(:)      !
@@ -105,9 +106,10 @@ CONTAINS
     if (outputAtGage) then
       call get_compdof_gage(compdof_rch_gage, ierr, cmessage)
 
+      nGage=gage_meta_data%gage_num()
       call pio_decomp(pioSystem,         & ! inout: pio system descriptor
                       ncd_float,         & ! input: data type (pio_int, pio_real, pio_double, pio_char)
-                      [gage_data%nGage], & ! input: dimension length == global array size
+                      [nGage],           & ! input: dimension length == global array size
                       compdof_rch_gage,  & ! input: local->global mapping
                       ioDesc_gauge_float)
     end if
@@ -282,7 +284,7 @@ CONTAINS
     USE globalData, ONLY: nTribOutlet         ! number of tributary outlets flowing to the mainstem
     USE globalData, ONLY: NETOPO_main         ! mainstem Reach neteork
     USE globalData, ONLY: NETOPO_trib         ! tributary Reach network
-    USE globalData, ONLY: gage_data
+    USE globalData, ONLY: gage_meta_data
     USE process_gage_meta, ONLY: reach_subset
 
     implicit none
@@ -313,7 +315,7 @@ CONTAINS
       reachID_local = NETOPO_trib(:)%REACHID
     endif
 
-    call reach_subset(reachID_local, gage_data, ierr, cmessage, compdof=compdof_rch, index2=index_write_gage)
+    call reach_subset(reachID_local, gage_meta_data, ierr, cmessage, compdof=compdof_rch, index2=index_write_gage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     ! Need to adjust tributary indices in root processor

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -273,18 +273,22 @@ contains
  ! Kinematic Wave
  call meta_kw(ixKW%qsub)%init('q_sub_kw' , 'flow at computational moelcule', 'm3/s', ncd_double, [ixStateDims%seg,ixStateDims%mol_kw,ixStateDims%ens], .true.)
  call meta_kw(ixKW%vol )%init('volume_kw', 'volume in reach/lake',           'm3',   ncd_double, [ixStateDims%seg,ixStateDims%ens] , .true.)
+ call meta_kw(ixKW%qerror)%init('qerror_kw', 'discharge error',              'm3/s', ncd_double, [ixStateDims%seg,ixStateDims%ens] , .false.)
 
  ! Diffusive Wave
  call meta_dw(ixDW%qsub)%init('q_sub_dw' , 'flow at computational moelcule', 'm3/s', ncd_double, [ixStateDims%seg,ixStateDims%mol_dw,ixStateDims%ens], .true.)
  call meta_dw(ixDW%vol )%init('volume_dw', 'volume in reach/lake',           'm3',   ncd_double, [ixStateDims%seg,ixStateDims%ens] , .true.)
+ call meta_dw(ixDW%qerror)%init('qerror_dw', 'discharge error',              'm3/s', ncd_double, [ixStateDims%seg,ixStateDims%ens] , .false.)
 
  ! Muskingum-cunge
  call meta_mc(ixMC%qsub)%init('q_sub_mc' , 'flow at computational molecule', 'm3/s', ncd_double, [ixStateDims%seg,ixStateDims%mol_mc,ixStateDims%ens], .true.)
  call meta_mc(ixMC%vol )%init('volume_mc', 'volume in reach/lake',           'm3',   ncd_double, [ixStateDims%seg,ixStateDims%ens] , .true.)
+ call meta_mc(ixMC%qerror)%init('qerror_mc', 'discharge error',              'm3/s', ncd_double, [ixStateDims%seg,ixStateDims%ens] , .false.)
 
  ! Impulse Response Function
  call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series',   'm3/s' ,ncd_double, [ixStateDims%seg,ixStateDims%tdh_irf,ixStateDims%ens] , .true.)
  call meta_irf(ixIRF%vol    )%init('volume_irf' , 'volume in reach/lake', 'm3'   ,ncd_double, [ixStateDims%seg,ixStateDims%tbound, ixStateDims%ens] , .true.)
+ call meta_irf(ixIRF%qerror)%init('qerror_irf',   'discharge error',      'm3/s', ncd_double, [ixStateDims%seg,ixStateDims%ens] , .false.)
 
  ! Basin Impulse Response Function
  call meta_irf_bas(ixIRFbas%qfuture)%init('qfuture', 'future flow series', 'm3/s' ,ncd_double, [ixStateDims%seg,ixStateDims%tdh,ixStateDims%ens], .true.)

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -50,12 +50,14 @@ CONTAINS
                       ierr, message)   ! output: error control
 
    USE public_var,          ONLY: continue_run        ! T-> append output in existing history files. F-> write output in new history file
+   USE public_var,          ONLY: qmodOption          ! DA option: 1-> direct insersion, 0-> do nothing
    USE globalData,          ONLY: version             ! mizuRoute version
    USE globalData,          ONLY: gitBranch           ! git branch
    USE globalData,          ONLY: gitHash             ! git commit hash
    USE mpi_process,         ONLY: pass_global_data    ! mpi globaldata copy to slave proc
    USE init_model_data,     ONLY: init_ntopo_data
    USE init_model_data,     ONLY: init_state_data
+   USE init_model_data,     ONLY: init_qmod
    USE write_simoutput_pio, ONLY: init_histFile       ! open existing history file to append (only continue_run is true)
 
    implicit none
@@ -106,6 +108,11 @@ CONTAINS
    ! restart initialization
    call init_state_data(pid, nNodes, comm, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+   if (qmodOption==1) then
+     call init_qmod(ierr,cmessage)
+     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   end if
 
    if (continue_run) then
      call init_histFile(ierr, cmessage)

--- a/route/build/src/var_lookup.f90
+++ b/route/build/src/var_lookup.f90
@@ -249,6 +249,7 @@ MODULE var_lookup
  type, public  ::  iLook_IRF
   integer(i4b)     :: qfuture        = integerMissing  ! 1. future routed flow (m3/s)
   integer(i4b)     :: vol            = integerMissing  ! 2. reach volume (m3)
+  integer(i4b)     :: qerror         = integerMissing  ! 3. discharge error (m3/s): optional
  endtype iLook_IRF
  ! KWT state/fluxes
  type, public  ::  iLook_KWT
@@ -263,16 +264,19 @@ MODULE var_lookup
  type, public  ::  iLook_KW
   integer(i4b)     :: qsub           = integerMissing  ! 1. discharge (m3/s)
   integer(i4b)     :: vol            = integerMissing  ! 2. reach volume (m3)
+  integer(i4b)     :: qerror         = integerMissing  ! 3. discharge error (m3/s): optional
  endtype iLook_KW
  ! DW state/fluxes
  type, public  ::  iLook_DW
   integer(i4b)     :: qsub           = integerMissing  ! 1. discharge (m3/s)
   integer(i4b)     :: vol            = integerMissing  ! 2. reach volume (m3)
+  integer(i4b)     :: qerror         = integerMissing  ! 3. discharge error (m3/s): optional
  endtype iLook_DW
  ! MC state/fluxes
  type, public  ::  iLook_MC
   integer(i4b)     :: qsub           = integerMissing  ! 1. discharge (m3/s)
   integer(i4b)     :: vol            = integerMissing  ! 2. reach volume (m3)
+  integer(i4b)     :: qerror         = integerMissing  ! 3. discharge error (m3/s): optional
  endtype iLook_MC
  ! ***********************************************************************************************************
  ! ** define data vectors
@@ -302,11 +306,11 @@ MODULE var_lookup
  type(iLook_HFLX)     ,public,parameter :: ixHFLX      = iLook_HFLX     ( 1)
  type(iLook_basinQ)   ,public,parameter :: ixBasinQ    = iLook_basinQ   ( 1)
  type(iLook_IRFbas)   ,public,parameter :: ixIRFbas    = iLook_IRFbas   ( 1)
- type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      ( 1, 2)
+ type(iLook_IRF)      ,public,parameter :: ixIRF       = iLook_IRF      ( 1, 2, 3)
  type(iLook_KWT)      ,public,parameter :: ixKWT       = iLook_KWT      ( 1, 2, 3, 4, 5, 6)
- type(iLook_KW)       ,public,parameter :: ixKW        = iLook_KW       ( 1, 2)
- type(iLook_DW)       ,public,parameter :: ixDW        = iLook_DW       ( 1, 2)
- type(iLook_MC)       ,public,parameter :: ixMC        = iLook_MC       ( 1, 2)
+ type(iLook_KW)       ,public,parameter :: ixKW        = iLook_KW       ( 1, 2, 3)
+ type(iLook_DW)       ,public,parameter :: ixDW        = iLook_DW       ( 1, 2, 3)
+ type(iLook_MC)       ,public,parameter :: ixMC        = iLook_MC       ( 1, 2, 3)
  ! ***********************************************************************************************************
  ! ** define size of data vectors
  ! ***********************************************************************************************************

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -44,7 +44,7 @@ CONTAINS
     USE globalData, ONLY: basinID           !
     USE globalData, ONLY: nRch              !
     USE globalData, ONLY: nHRU              !
-    USE globalData, ONLY: gage_data         !
+    USE globalData, ONLY: gage_meta_data    !
 
     implicit none
     ! Argument variables
@@ -52,6 +52,8 @@ CONTAINS
     character(*),   intent(out)     :: message          ! error message
     ! local variables
     logical(lgt)                    :: createNewFile       ! logical to make alarm for restart writing
+    integer(i4b)                    :: nGage               ! number of gauge points
+    integer(i4b), allocatable       :: reach_id_local(:)   ! logical to make alarm for restart writing
     character(len=strLen)           :: cmessage            ! error message of downwind routine
 
     ierr=0; message='main_new_file/'
@@ -81,14 +83,17 @@ CONTAINS
       if (outputAtGage) then
 
         hist_gage = histFile(hfileout_gage, gageOutput=.true.)
+        nGage = gage_meta_data%gage_num()
+        allocate(reach_id_local(nGage))
+        reach_id_local = gage_meta_data%reach_id()
 
-        call hist_gage%createNC(ierr, cmessage, nRch_in=gage_data%nGage)
+        call hist_gage%createNC(ierr, cmessage, nRch_in= nGage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
         call hist_gage%openNC(ierr, message)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-        call hist_gage%write_loc(gage_data%reachID, ierr, message)
+        call hist_gage%write_loc(reach_id_local, ierr, message)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       end if
 


### PR DESCRIPTION
This is continuation of PR #506 to complete the implementation of at gauge direct-insertion DA.

Confirmed this implementation re-create the results from v1.2.3 (serial version), although bit-by-bit comparison of `DWroutedRunoff`, `MCroutedRunoff`, `KWroutedRunoff` are not identical due to slight different method to compute celerity and diffusivity between current version and v1.2.3. (see PR #470).

**Important note:**
If restart is performed during the DA periods (which is specified by the users in a control file: `qBlendPeriod`), exact restart won't occur due to the errors computed during the DA period (`Qerror`, and `Qelapsed`) are not saved in restart file. This could be addressed in the future.

**Evaluation:**
The implementation was tested using MERIT-basin network in PNW (/glade/work/mizukami/test_mizuRoute/PNW_MERIT_hydro) and analysis is in a notebook (/glade/work/mizukami/test_mizuRoute/PNW_MERIT_hydro/notebooks/NB1_PNW_DA_test.ipynb)