### PR TITLE
small temporary change in Makefile

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -215,7 +215,6 @@ IO = \
 # CORE
 CORE = \
     advection_diffusion.f90 \
-    data_assimilation.f90 \
     accum_runoff.f90 \
     basinUH.f90 \
     water_balance.f90 \


### PR DESCRIPTION
In PR #506, data_assimilation.f90 was added, but this f90 is not compiled since a few components in `strflx` data type `strflx%ROUTE%Qerror` and `strflx%Qelapsed` used in direct_insertion routine in the f90 are not defined in dataType.f90 yet. So data_assimilation.f90 is removed temporarily.

data_assimilation.f90 will be put back in Makefile in the PR #509 - "complete direct-insertion implementation" 