### PR TITLE
initialize global water balance array

### DIFF
--- a/route/build/src/water_balance.f90
+++ b/route/build/src/water_balance.f90
@@ -178,6 +178,7 @@ CONTAINS
     end if
 
     ! sum water balance components across all the processors
+    wb_global = 0._dp
     call shr_mpi_reduce(wb_local, 'sum', wb_global, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 


### PR DESCRIPTION
**Issue**: 
MPR reduce does not change values in `wb_global` in distributed tasks, just fills computed values in the array in main task. This means that if `wb_global` is not initialized with some value, it gets garbage value and unchanged after `shr_mpi_reduce `call (Line 182), then print out garbage message in line 204 from the distributed tasks.

initializing `wb_global` array with zero, ensure this garbage printing does not happen.

This does not affect any scientific computation. 