### PR TITLE
Including the global flag `LakeInputOption` to control whether water balance fluxes (precipitation, evaporation, and/or runoff) are considered for lakes and reservoirs.

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -215,6 +215,7 @@ IO = \
 # CORE
 CORE = \
     advection_diffusion.f90 \
+    data_assimilation.f90 \
     accum_runoff.f90 \
     basinUH.f90 \
     water_balance.f90 \

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -412,8 +412,8 @@ CONTAINS
       RCHFLX_trib(:,:)%BASIN_QI     = 0._dp
       RCHFLX_trib(:,:)%BASIN_QR(0)  = 0._dp
       RCHFLX_trib(:,:)%BASIN_QR(1)  = 0._dp
-      RCHFLX(:,:)%Qelapsed = 0
-      RCHFLX(:,:)%Qobs = 0._dp
+      RCHFLX_trib(:,:)%Qelapsed     = 0
+      RCHFLX_trib(:,:)%Qobs         = 0._dp
 
       nRch_root=nRch_mainstem+nTribOutlet+rch_per_proc(0)
       if (onRoute(accumRunoff)) then

--- a/route/build/src/lake_route.f90
+++ b/route/build/src/lake_route.f90
@@ -167,10 +167,10 @@ CONTAINS
     ! add upstream, precipitation and subtract evaporation from the lake volume
     RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(0) = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) ! updating storage at previous time step
     RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) + q_upstream * dt  ! input upstream discharge from m3/s to m3
-    if ((LakeInputOption == 2) .or. (LakeInputOption == 3)) then ! considers runoff for lake fluxes
+    if ((LakeInputOption == 1) .or. (LakeInputOption == 2)) then ! considers runoff for lake fluxes
       RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) + RCHFLX_out(iens,segIndex)%BASIN_QR(1) * dt ! add lateral flow
     end if
-    if ((LakeInputOption == 0) .or. (LakeInputOption == 3)) then ! considers precipitation and evaporation for lake fluxes
+    if ((LakeInputOption == 0) .or. (LakeInputOption == 2)) then ! considers precipitation and evaporation for lake fluxes
       RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) + RCHFLX_out(iens,segIndex)%basinprecip * dt ! input lake precipitation
       if (RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) > RCHFLX_out(iens,segIndex)%basinevapo*dt) then ! enough water to evaporate
         RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) - RCHFLX_out(iens,segIndex)%basinevapo * dt ! output lake evaporation

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -104,6 +104,7 @@ MODULE public_var
   integer(i4b)         ,public    :: hw_drain_point       = 2               ! how to add inst. runoff in reach for headwater HRUs. 1->top of reach, 2->bottom of reach (default)
   logical(lgt)         ,public    :: is_lake_sim          = .false.         ! logical if lakes are activated in simulation
   logical(lgt)         ,public    :: lakeRegulate         = .true.          ! logical: F -> turn all the lakes into natural (lakeType=1) regardless of lakeModelType defined individually
+  integer(i4b)         ,public    :: LakeInputOption      = 0               ! fluxes for lake simulation; 0->evaporation+precipitation, 1->runoff, 3->evaporation+precipitation+runoff
   logical(lgt)         ,public    :: is_flux_wm           = .false.         ! logical if flow is added or removed from a reach
   logical(lgt)         ,public    :: is_vol_wm            = .false.         ! logical if target volume is considered for a lake
   logical(lgt)         ,public    :: is_vol_wm_jumpstart  = .false.         ! logical if true the volume is reset to target volume for the first time step of modeling

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -105,7 +105,7 @@ MODULE public_var
   logical(lgt)         ,public    :: tracer               = .false.         ! logical if tracer is activated to compute a solute or constituent transport.
   logical(lgt)         ,public    :: is_lake_sim          = .false.         ! logical if lakes are activated in simulation
   logical(lgt)         ,public    :: lakeRegulate         = .true.          ! logical: F -> turn all the lakes into natural (lakeType=1) regardless of lakeModelType defined individually
-  integer(i4b)         ,public    :: LakeInputOption      = 0               ! fluxes for lake simulation; 0->evaporation+precipitation, 1->runoff, 3->evaporation+precipitation+runoff
+  integer(i4b)         ,public    :: LakeInputOption      = 0               ! input flux(es) for lake: 0->evaporation+precipitation (default), 1->runoff, 2->evaporation+precipitation+runoff
   logical(lgt)         ,public    :: is_flux_wm           = .false.         ! logical if flow is added or removed from a reach
   logical(lgt)         ,public    :: is_vol_wm            = .false.         ! logical if target volume is considered for a lake
   logical(lgt)         ,public    :: is_vol_wm_jumpstart  = .false.         ! logical if true the volume is reset to target volume for the first time step of modeling

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -135,7 +135,7 @@ CONTAINS
    case('<tracer>');               read(cData,*,iostat=io_error) tracer                ! logical: tracer is activated to compute a solute or constituent transport.
    case('<is_lake_sim>');          read(cData,*,iostat=io_error) is_lake_sim           ! logical; lakes are simulated
    case('<lakeRegulate>');         read(cData,*,iostat=io_error) lakeRegulate          ! logical: F -> turn all the lakes into natural (lakeType=1) regardless of lakeModelType defined individually. T (default)
-   case('<LakeInputOption>');      read(cData,*,iostat=io_error) LakeInputOption       ! fluxes for lake simulation; 0->evaporation & precipitation, 1->runoff, 3->evaporation & precipitation & runoff
+   case('<LakeInputOption>');      read(cData,*,iostat=io_error) LakeInputOption       ! fluxes for lake simulation; 0->evaporation+precipitation (default), 1->runoff, 2->evaporation+precipitation+runoff
    case('<is_flux_wm>');           read(cData,*,iostat=io_error) is_flux_wm            ! logical; provided fluxes to or from seg/lakes should be considered
    case('<is_vol_wm>');            read(cData,*,iostat=io_error) is_vol_wm             ! logical; provided target volume for managed lakes are considered
    case('<is_vol_wm_jumpstart>');  read(cData,*,iostat=io_error) is_vol_wm_jumpstart   ! logical; jump to the first time step target volume is set to true

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -131,6 +131,7 @@ CONTAINS
    case('<hw_drain_point>');       read(cData,*,iostat=io_error) hw_drain_point        ! integer: how to add inst. runoff in reach for headwater HRUs. 1->top of reach, 2->bottom of reach (default)
    case('<is_lake_sim>');          read(cData,*,iostat=io_error) is_lake_sim           ! logical; lakes are simulated
    case('<lakeRegulate>');         read(cData,*,iostat=io_error) lakeRegulate          ! logical: F -> turn all the lakes into natural (lakeType=1) regardless of lakeModelType defined individually. T (default)
+   case('<LakeInputOption>');      read(cData,*,iostat=io_error) LakeInputOption       ! fluxes for lake simulation; 0->evaporation & precipitation, 1->runoff, 3->evaporation & precipitation & runoff
    case('<is_flux_wm>');           read(cData,*,iostat=io_error) is_flux_wm            ! logical; provided fluxes to or from seg/lakes should be considered
    case('<is_vol_wm>');            read(cData,*,iostat=io_error) is_vol_wm             ! logical; provided target volume for managed lakes are considered
    case('<is_vol_wm_jumpstart>');  read(cData,*,iostat=io_error) is_vol_wm_jumpstart   ! logical; jump to the first time step target volume is set to true

--- a/route/build/src/standalone/get_basin_runoff.f90
+++ b/route/build/src/standalone/get_basin_runoff.f90
@@ -27,6 +27,7 @@ CONTAINS
   USE public_var,           ONLY: vname_vol_wm        ! varibale precipitation in netCDF file
   USE public_var,           ONLY: is_remap            ! logical runnoff needs to be mapped to river network HRU
   USE public_var,           ONLY: is_lake_sim         ! logical lake should be simulated
+  USE public_var,           ONLY: LakeInputOption     ! lake input fluxes option
   USE public_var,           ONLY: is_flux_wm          ! logical water management components fluxes should be read
   USE public_var,           ONLY: is_vol_wm           ! logical water management components target volume should be read
   USE public_var,           ONLY: scale_factor_runoff ! float; factor to scale the runoff values
@@ -105,7 +106,8 @@ CONTAINS
   end if
 
   ! Optional: lake module on -> read actual evaporation and preciptation
-  if (is_lake_sim) then
+  ! while global parameter for LakeInputOption is either 0 or 2 (and not only runff which is 1)
+  if (is_lake_sim .and. ((LakeInputOption == 0) .or. (LakeInputOption == 2))) then
 
     if ((abs(scale_factor_Ep)<verySmall) .and. ((abs(offset_value_Ep)<verySmall) .or. (abs(offset_value_Ep-realmissing)<verySmall))) then  ! not reading evaporation
       runoff_data%basinEvapo  = 0._dp ! set evaporation to zero


### PR DESCRIPTION
Added a control variable `LakeInputOption` with possible values (0, 1, 2). This controls which variable is input into lake polygon, NOT to catchment where runoff is only input. 

0 → Precipitation and evaporation (default when LakeInputOption is not specified in the control file)
1 → Runoff only
2 → Precipitation, evaporation, and runoff (for special cases if needed)

This PR partially resolve #525. Do not close the issue yet 