### PR TITLE
Clean ixDesire

### DIFF
--- a/route/build/src/accum_runoff.f90
+++ b/route/build/src/accum_runoff.f90
@@ -10,6 +10,7 @@ USE dataTypes,   ONLY: STRSTA          ! state in each reach
 USE dataTypes,   ONLY: RCHTOPO         ! Network topology
 USE dataTypes,   ONLY: RCHPRP          ! Reach parameter
 USE public_var,  ONLY: iulog           ! i/o logical unit number
+USE public_var,  ONLY: desireId        ! ID or reach where detailed reach state is print in log
 USE globalData,  ONLY: idxSUM          ! routing method index for runoff accumulation method
 USE base_route,  ONLY: base_route_rch  ! base (abstract) reach routing method class
 
@@ -31,7 +32,6 @@ CONTAINS
  SUBROUTINE accum_inst_runoff(this,         &  ! "accum_runoff_rchr" object to bound this procedure
                               iEns,         &  ! input: index of runoff ensemble to be processed
                               segIndex,     &  ! input: index of reach to be processed
-                              ixDesire,     &  ! input: reachID to be checked by on-screen pringing
                               T0,T1,        &  ! input: start and end of the time step
                               NETOPO_in,    &  ! input: reach topology data structure
                               RPARAM_in,    &  ! input: reach parameter data structure
@@ -43,7 +43,6 @@ CONTAINS
  class(accum_runoff_rch)                  :: this            ! "accum_runoff_rchr" object to bound this procedure
  integer(i4b),  intent(in)                :: iEns            ! runoff ensemble to be routed
  integer(i4b),  intent(in)                :: segIndex        ! segment where routing is performed
- integer(i4b),  intent(in)                :: ixDesire        ! index of the reach for verbose output
  real(dp),      intent(in)                :: T0,T1           ! start and end of the time step (seconds)
  type(RCHTOPO), intent(in),   allocatable :: NETOPO_in(:)    ! River Network topology
  type(RCHPRP),  intent(inout),allocatable :: RPARAM_in(:)    ! River reach parameter
@@ -78,7 +77,7 @@ CONTAINS
  endif
 
  ! check
- if(segIndex == ixDesire)then
+ if(NETOPO_in(segIndex)%REACHID==desireId)then
    write(iulog,'(2a)') new_line('a'),'** Check upstream discharge accumulation **'
    write(iulog,'(a,1x,I10,1x,I10)') ' Reach index & ID =', segIndex, NETOPO_in(segIndex)%REACHID
    if (nUps>0) then

--- a/route/build/src/base_route.f90
+++ b/route/build/src/base_route.f90
@@ -29,7 +29,6 @@ MODULE base_route
     SUBROUTINE sub_route_rch(this,          & ! object to bound the procedure
                              iEns,          & ! input: ensemble index
                              segIndex,      & ! input: reach indice
-                             ixDesire,      & ! input: index of verbose reach
                              T0, T1,        & ! input: start and end of simulation time step since start [sec]
                              NETOPO_in,     & ! input: reach topology data structure
                              RPARAM_in,     & ! input: reach parameter data structure
@@ -41,7 +40,6 @@ MODULE base_route
       !   to perform a routing (after instantiated) at a given reasch (segIndex) and time step
       !   reach parameters (RPARAM), river network topology (NETOPO) to get upstream location,
       !   state (RCHSTA) and flux (RCHFLX) are required for a set of input
-      !   ixDesire is index of reach where more information is writting in log along the computation
 
       USE nrtype
       USE dataTypes, ONLY: STRFLX       ! fluxes in each reach
@@ -54,7 +52,6 @@ MODULE base_route
       class(base_route_rch)                     :: this             ! object to bound the procedure
       integer(i4b),  intent(in)                 :: iEns             ! ensemble member
       integer(i4b),  intent(in)                 :: segIndex         ! ensemble member
-      integer(i4b),  intent(in)                 :: ixDesire         ! index of the reach for verbose output
       real(dp),      intent(in)                 :: T0, T1           ! start and end of the time step (seconds)
       type(RCHTOPO), intent(in),    allocatable :: NETOPO_in(:)     ! River Network topology
       type(RCHPRP),  intent(inout), allocatable :: RPARAM_in(:)     ! River reach parameter

--- a/route/build/src/data_assimilation.f90
+++ b/route/build/src/data_assimilation.f90
@@ -56,9 +56,7 @@ contains
    ierr=0; message='direct_insertion/'
 
    verbose = .false.
-   if(NETOPO_in(segIndex)%REACHID == desireId)then
-     verbose = .true.
-   end if
+   if(NETOPO_in(segIndex)%REACHID == desireId) verbose = .true.
 
    if (RCHFLX_out(iens,segIndex)%Qobs>0._dp) then ! there is observation
      RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%Qerror = RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_Q - RCHFLX_out(iens,segIndex)%Qobs ! compute error

--- a/route/build/src/data_assimilation.f90
+++ b/route/build/src/data_assimilation.f90
@@ -11,6 +11,7 @@ USE dataTypes, ONLY: STRSTA            ! state in each reach
 USE dataTypes, ONLY: RCHTOPO           ! Network topology
 ! global data
 USE public_var, ONLY: iulog             ! i/o logical unit number
+USE public_var, ONLY: desireId          ! ID or reach where detailed reach state is print in log
 USE public_var, ONLY: qBlendPeriod      ! number of time steps for which direct insertion is performed
 USE public_var, ONLY: QerrTrend         ! temporal discharge error trend: 1->constant,2->linear, 3->logistic
 
@@ -26,7 +27,6 @@ contains
  ! *********************************************************************
  subroutine direct_insertion(iEns, segIndex,   & ! input: index of runoff ensemble to be processed
                              idxRoute,         & ! input: reachID to be checked by on-screen pringing
-                             ixDesire,         & ! input: reachID to be checked by on-screen pringing
                              NETOPO_in,        & ! input: reach topology data structure
                              RCHSTA_out,       & ! inout: reach state data structure
                              RCHFLX_out,       & ! inout: reach flux data structure
@@ -36,7 +36,6 @@ contains
    integer(i4b),  intent(in)                 :: iEns              ! runoff ensemble to be routed
    integer(i4b),  intent(in)                 :: segIndex          ! segment where routing is performed
    integer(i4b),  intent(in)                 :: idxRoute          ! index of routing method
-   integer(i4b),  intent(in)                 :: ixDesire          ! index of the reach for verbose output
    type(RCHTOPO), intent(in),    allocatable :: NETOPO_in(:)      ! River Network topology
    type(STRSTA),  intent(inout)              :: RCHSTA_out(:,:)   ! reach state data
    type(STRFLX),  intent(inout)              :: RCHFLX_out(:,:)   ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
@@ -57,7 +56,7 @@ contains
    ierr=0; message='direct_insertion/'
 
    verbose = .false.
-   if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+   if(NETOPO_in(segIndex)%REACHID == desireId)then
      verbose = .true.
    end if
 

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -11,6 +11,7 @@ USE dataTypes,     ONLY: dwRCH           ! dw specific state data structure
 USE public_var,    ONLY: iulog           ! i/o logical unit number
 USE public_var,    ONLY: realMissing     ! missing value for real number
 USE public_var,    ONLY: integerMissing  ! missing value for integer number
+USE public_var,    ONLY: desireId        ! ID or reach where detailed reach state is print in log
 USE public_var,    ONLY: dt              ! simulation time step [sec]
 USE public_var,    ONLY: is_flux_wm      ! logical water management components fluxes should be read
 USE public_var,    ONLY: qmodOption      ! qmod option (use 1==direct insertion)
@@ -45,7 +46,6 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE dfw_rch(this,           & ! dfw_route_rch object to bound this procedure
                     iens, segIndex, & ! input: index of runoff ensemble to be processed
-                    ixDesire,       & ! input: reachID to be checked by on-screen pringing
                     T0,T1,          & ! input: start and end of the time step
                     NETOPO_in,      & ! input: reach topology data structure
                     RPARAM_in,      & ! input: reach parameter data structure
@@ -58,7 +58,6 @@ CONTAINS
  class(dfw_route_rch)                      :: this              ! dfw_route_rch object to bound this procedure
  integer(i4b),  intent(in)                 :: iens              ! runoff ensemble to be routed
  integer(i4b),  intent(in)                 :: segIndex          ! segment where routing is performed
- integer(i4b),  intent(in)                 :: ixDesire          ! index of the reach for verbose output
  real(dp),      intent(in)                 :: T0,T1             ! start and end of the time step (seconds)
  type(RCHTOPO), intent(in),    allocatable :: NETOPO_in(:)      ! River Network topology
  type(RCHPRP),  intent(inout), allocatable :: RPARAM_in(:)      ! River reach parameter
@@ -81,7 +80,7 @@ CONTAINS
  ierr=0; message='dfw_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+ if(NETOPO_in(segIndex)%REACHID == desireId)then
    verbose = .true.
  end if
 
@@ -189,7 +188,6 @@ CONTAINS
  if (qmodOption==1) then
    call direct_insertion(iens, segIndex, & ! input: reach index
                          idxDW,          & ! input: routing method id for diffusive wave routing
-                         ixDesire,       & ! input: verbose seg index
                          NETOPO_in,      & ! input: reach topology data structure
                          RCHSTA_out,     & ! inout: reach state data structure
                          RCHFLX_out,     & ! inout: reach fluxes datq structure

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -80,9 +80,7 @@ CONTAINS
  ierr=0; message='dfw_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHID == desireId)then
-   verbose = .true.
- end if
+ if(NETOPO_in(segIndex)%REACHID == desireId) verbose = .true.
 
  ! get discharge coming from upstream
  nUps = count(NETOPO_in(segIndex)%goodBas) ! reminder: goodBas is reach with >0 total contributory area

--- a/route/build/src/globalData.f90
+++ b/route/build/src/globalData.f90
@@ -130,7 +130,6 @@ MODULE globalData
   ! ---------- Misc. data -------------------------------------------------------------------------
   character(len=strLen),           public :: runMode='standalone'        ! run options: standalone or cesm-coupling
   character(len=12),               public :: hfile_dayStamp='period-start' ! day stamp in history file for daily file. period-start or period-end
-  integer(i4b),                    public :: ixPrint(1:2)=integerMissing ! index of desired reach to be on-screen print
   integer(i4b),                    public :: nEns=1                      ! number of ensemble
   integer(i4b),                    public :: maxtdh                      ! maximum unit-hydrograph future time steps
   type(cMolecule),                 public :: nMolecule                   ! number of computational molecule (used for KW, MC, DW)

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -78,9 +78,7 @@ CONTAINS
  ierr=0; message='irf_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHID == desireId)then
-   verbose = .true.
- end if
+ if(NETOPO_in(segIndex)%REACHID == desireId) verbose = .true.
 
   ! get discharge coming from upstream
   nUps = count(NETOPO_in(segIndex)%goodBas) ! reminder: goodBas is reach with >0 total contributory area

--- a/route/build/src/irf_route.f90
+++ b/route/build/src/irf_route.f90
@@ -9,8 +9,9 @@ USE dataTypes,         ONLY: irfRCH            ! irf specific state data structu
 USE public_var,        ONLY: iulog             ! i/o logical unit number
 USE public_var,        ONLY: realMissing       ! missing value for real number
 USE public_var,        ONLY: integerMissing    ! missing value for integer number
+USE public_var,        ONLY: desireId          ! ID or reach where detailed reach state is print in log
 USE public_var,        ONLY: dt                ! simulation time step [sec]
-USE public_var,        ONLY: qmodOption      ! qmod option (use 1==direct insertion)
+USE public_var,        ONLY: qmodOption        ! qmod option (use 1==direct insertion)
 USE public_var,        ONLY: hw_drain_point    ! headwater catchment pour point (top_reach==1 or bottom_reach==2)
 USE public_var,        ONLY: min_length_route  ! minimum reach length for routing to be performed.
 USE globalData,        ONLY: idxIRF            ! routing method index for IRF method
@@ -39,7 +40,6 @@ CONTAINS
  SUBROUTINE irf_rch(this,         & ! irf_route_rch object to bound this procedure
                     iEns,         & ! input: index of runoff ensemble
                     segIndex,     & ! input: reach index
-                    ixDesire,     & ! input: reachID to be checked by on-screen pringing
                     T0,T1,        & ! input: start and end of the time step
                     NETOPO_in,    & ! input: reach topology data structure
                     RPARAM_in,    & ! input: reach parameter data structure
@@ -54,7 +54,6 @@ CONTAINS
  class(irf_route_rch)                     :: this            ! irf_route_rch object to bound this procedure
  integer(i4b),  intent(in)                :: iEns            ! runoff ensemble to be routed
  integer(i4b),  intent(in)                :: segIndex        ! segment where routing is performed
- integer(i4b),  intent(in)                :: ixDesire        ! index of the reach for verbose output
  real(dp),      intent(in)                :: T0,T1           ! start and end of the time step (seconds)
  type(RCHTOPO), intent(in),   allocatable :: NETOPO_in(:)    ! River Network topology
  type(RCHPRP),  intent(inout),allocatable :: RPARAM_in(:)    ! River reach parameter
@@ -79,7 +78,7 @@ CONTAINS
  ierr=0; message='irf_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+ if(NETOPO_in(segIndex)%REACHID == desireId)then
    verbose = .true.
  end if
 
@@ -199,7 +198,6 @@ CONTAINS
   if (qmodOption==1) then
     call direct_insertion(iens, segIndex, & ! input: reach index
                           idxIRF,         & ! input: routing method id for Euler kinematic wave
-                          ixDesire,       & ! input: verbose seg index
                           NETOPO_in,      & ! input: reach topology data structure
                           RCHSTA_out,     & ! inout: reach state data structure
                           RCHFLX_out,     & ! inout: reach fluxes datq structure

--- a/route/build/src/kwe_route.f90
+++ b/route/build/src/kwe_route.f90
@@ -11,6 +11,7 @@ USE dataTypes,     ONLY: kwRCH           ! kw specific state data structure
 USE public_var,    ONLY: iulog           ! i/o logical unit number
 USE public_var,    ONLY: realMissing     ! missing value for real number
 USE public_var,    ONLY: integerMissing  ! missing value for integer number
+USE public_var,    ONLY: desireId        ! ID or reach where detailed reach state is print in log
 USE public_var,    ONLY: dt              ! simulation time step [sec]
 USE public_var,    ONLY: is_flux_wm      ! logical water management components fluxes should be read
 USE public_var,    ONLY: qmodOption      ! qmod option (use 1==direct insertion)
@@ -45,7 +46,6 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE kw_rch(this,           & ! kwe_route_rch object to bound this procedure
                    iEns, segIndex, & ! input: index of runoff ensemble to be processed
-                   ixDesire,       & ! input: reachID to be checked by on-screen pringing
                    T0,T1,          & ! input: start and end of the time step
                    NETOPO_in,      & ! input: reach topology data structure
                    RPARAM_in,      & ! input: reach parameter data structure
@@ -57,7 +57,6 @@ CONTAINS
  class(kwe_route_rch)                      :: this              ! kwe_route_rch object to bound this procedure
  integer(i4b),  intent(in)                 :: iEns              ! runoff ensemble to be routed
  integer(i4b),  intent(in)                 :: segIndex          ! segment where routing is performed
- integer(i4b),  intent(in)                 :: ixDesire          ! index of the reach for verbose output
  real(dp),      intent(in)                 :: T0,T1             ! start and end of the time step (seconds)
  type(RCHTOPO), intent(in),    allocatable :: NETOPO_in(:)      ! River Network topology
  type(RCHPRP),  intent(inout), allocatable :: RPARAM_in(:)      ! River reach parameter
@@ -80,7 +79,7 @@ CONTAINS
  ierr=0; message='kw_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+ if(NETOPO_in(segIndex)%REACHID == desireId)then
    verbose = .true.
  end if
 
@@ -187,7 +186,6 @@ CONTAINS
  if (qmodOption==1) then
    call direct_insertion(iens, segIndex, & ! input: reach index
                          idxKW,          & ! input: routing method id for diffusive wave routing
-                         ixDesire,       & ! input: verbose seg index
                          NETOPO_in,      & ! input: reach topology data structure
                          RCHSTA_out,     & ! inout: reach state data structure
                          RCHFLX_out,     & ! inout: reach fluxes datq structure

--- a/route/build/src/kwe_route.f90
+++ b/route/build/src/kwe_route.f90
@@ -79,9 +79,7 @@ CONTAINS
  ierr=0; message='kw_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHID == desireId)then
-   verbose = .true.
- end if
+ if(NETOPO_in(segIndex)%REACHID == desireId) verbose = .true.
 
  ! get discharge coming from upstream
  nUps = count(NETOPO_in(segIndex)%goodBas) ! reminder: goodBas is reach with >0 total contributory area

--- a/route/build/src/kwt_route.f90
+++ b/route/build/src/kwt_route.f90
@@ -140,9 +140,7 @@ CONTAINS
    ierr=0; message='kwt_rch/'
 
    verbose = .false.
-   if(NETOPO_in(segIndex)%REACHID == desireId)then
-     verbose = .true.
-   end if
+   if(NETOPO_in(segIndex)%REACHID == desireId) verbose = .true.
 
    if(verbose) then
      write(iulog,'(2a)') new_line('a'),'** Check kinematic wave tracking routing **'

--- a/route/build/src/lake_route.f90
+++ b/route/build/src/lake_route.f90
@@ -6,6 +6,7 @@ USE dataTypes,     ONLY: RCHTOPO         ! data struct: Network topology
 USE dataTypes,     ONLY: RCHPRP          ! data struct: Network parameter
 USE public_var,    ONLY: iulog           ! parameter: i/o logical unit number
 USE public_var,    ONLY: realMissing     ! parameter: missing value for real number
+USE public_var,    ONLY: desireId        ! ID or reach where detailed reach state is print in log
 USE public_var,    ONLY: pi              ! parameter: pi value of 3.14159265359_dp
 USE globalData,    ONLY: isColdStart     ! parameter: restart flag
 USE water_balance, ONLY: comp_reach_wb   ! routine: compute water balance error
@@ -28,7 +29,6 @@ CONTAINS
   SUBROUTINE lake_route(iEns,       &    ! input: index of runoff ensemble to be processed
                         segIndex,   &    ! input: index of runoff ensemble to be processed
                         idxRoute,   &    ! input: routing method index
-                        ixDesire,   &    ! input: reachID to be checked by on-screen pringing (here reachID can be lake)
                         NETOPO_in,  &    ! input: reach topology data structure
                         RPARAM_in,  &    ! input: reach parameter data strcuture
                         RCHFLX_out, &    ! inout: reach flux data structure
@@ -50,7 +50,6 @@ CONTAINS
   integer(i4b), intent(in)                 :: iEns           ! runoff ensemble to be routed
   integer(i4b), intent(in)                 :: segIndex       ! segment where routing is performed
   integer(i4b), intent(in)                 :: idxRoute       ! index of the reach for verbose output
-  integer(i4b), intent(in)                 :: ixDesire       ! index of the reach for verbose output
   type(RCHTOPO), intent(in),   allocatable :: NETOPO_in(:)   ! River Network topology
   type(RCHPRP), intent(inout), allocatable :: RPARAM_in(:)   ! River Network topology
   TYPE(STRFLX), intent(inout)              :: RCHFLX_out(:,:)! Reach fluxes (ensembles, space [reaches]) for decomposed domains
@@ -87,7 +86,7 @@ CONTAINS
   ierr=0; message='lake_route/'
 
   verbose = .false.
-  if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+  if(NETOPO_in(segIndex)%REACHID == desireId)then
     verbose = .true.
   end if
 
@@ -450,7 +449,7 @@ CONTAINS
 !    - RCHFLX_out(iens,segIndex)%basinevapo * dt - RCHFLX_out(iens,segIndex)%REACH_WM_FLUX_actual * dt &
 !    - (RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(1) - RCHFLX_out(iens,segIndex)%ROUTE(idxRoute)%REACH_VOL(0))
 !
-!    if ((1._dp<WB).or.(segIndex==ixDesire)) then; ! larger than 1 cubic meter or desired lake
+!    if ((1._dp<WB).or.verbose) then; ! larger than 1 cubic meter or desired lake
 !      ! NOTE: The lake discharge and storage need to be solved iterative way to reduce water balance error
 !      write(iulog,*) 'Water balance for lake ID = ', NETOPO_in(segIndex)%REACHID, ' excees the Tolerance'
 !      write(iulog,'(A,1PG15.7)') 'WBerr [m3]       = ', WB

--- a/route/build/src/main_route.f90
+++ b/route/build/src/main_route.f90
@@ -38,7 +38,6 @@ CONTAINS
                        river_basin,    &  ! input: OMP basin decomposition
                        NETOPO_in,      &  ! input: reach topology data structure
                        RPARAM_in,      &  ! input: reach parameter data structure
-                       ixDesire,       &  ! input: index of verbose reach
                        RCHFLX_out,     &  ! inout: reach flux data structure
                        RCHSTA_out,     &  ! inout: reach state data structure
                        gage_obs_data,  &  ! inout: gauge data
@@ -72,7 +71,6 @@ CONTAINS
    type(subbasin_omp), allocatable, intent(in)    :: river_basin(:)       ! OMP basin decomposition
    type(RCHTOPO),      allocatable, intent(in)    :: NETOPO_in(:)         ! River Network topology
    type(RCHPRP),       allocatable, intent(inout) :: RPARAM_in(:)         ! River reach parameter
-   integer(i4b),                    intent(in)    :: ixDesire             ! index of the reach for verbose output
    type(STRFLX),                    intent(inout) :: RCHFLX_out(:,:)      ! Reach fluxes (ensembles, space [reaches]) for decomposed domains
    type(STRSTA),                    intent(inout) :: RCHSTA_out(:,:)      ! reach state data structure
    type(gageObs),                   intent(inout) :: gage_obs_data        ! gauge observation data
@@ -246,7 +244,6 @@ CONTAINS
                         iens,                     &  ! input: ensemble index
                         river_basin,              &  ! input: river basin data type
                         TSEC(1), TSEC(2),         &  ! input: start and end of the time step since simulation start [sec]
-                        ixDesire,                 &  ! input: index of verbose reach
                         NETOPO_in,                &  ! input: reach topology data structure
                         RPARAM_in,                &  ! input: reach parameter
                         RCHSTA_out,               &  ! inout: reach state data structure
@@ -266,7 +263,6 @@ CONTAINS
                            iens,                 & ! input: ensemble index
                            river_basin,          & ! input: river basin information (mainstem, tributary outlet etc.)
                            T0,T1,                & ! input: start and end of the time step since simulation start [sec]
-                           ixDesire,             & ! input: reachID to be checked by on-screen pringing
                            NETOPO_in,            & ! input: reach topology data structure
                            RPARAM_in,            & ! input: reach parameter data structure
                            RCHSTA_out,           & ! inout: reach state data structure
@@ -294,7 +290,6 @@ CONTAINS
     integer(i4b),          intent(in)                 :: iEns                 ! ensemble member
     type(subbasin_omp),    intent(in),    allocatable :: river_basin(:)       ! river basin information (mainstem, tributary outlet etc.)
     real(dp),              intent(in)                 :: T0,T1                ! start and end of the time step (seconds)
-    integer(i4b),          intent(in)                 :: ixDesire             ! index of the reach for verbose output
     type(RCHTOPO),         intent(in),    allocatable :: NETOPO_in(:)         ! River Network topology
     type(RCHPRP),          intent(inout), allocatable :: RPARAM_in(:)         ! River reach parameter
     type(STRSTA),          intent(inout)              :: RCHSTA_out(:,:)      ! reach state data
@@ -360,7 +355,7 @@ CONTAINS
 !$OMP          shared(RPARAM_in)                        & ! data structure shared
 !$OMP          shared(RCHSTA_out)                       & ! data structure shared
 !$OMP          shared(RCHFLX_out)                       & ! data structure shared
-!$OMP          shared(ix, iEns, ixDesire, idxRoute)     & ! indices shared
+!$OMP          shared(ix, iEns, idxRoute)               & ! indices shared
 !$OMP          firstprivate(nTrib)
       do iTrib = 1,nTrib
         do iSeg = 1,river_basin(ix)%branch(iTrib)%nRch
@@ -369,14 +364,12 @@ CONTAINS
           if ((NETOPO_in(jseg)%islake).and.(is_lake_sim).and.idxRoute/=idxSUM) then
             call lake_route(iEns, jSeg,    & ! input: ensemble and reach indices
                             idxRoute,      & ! input: routing method index
-                            ixDesire,      & ! input: index of verbose reach
                             NETOPO_in,     & ! input: reach topology data structure
                             RPARAM_in,     & ! input: reach parameter data structure
                             RCHFLX_out,    & ! inout: reach flux data structure
                             ierr,cmessage)   ! output: error control
           else
             call rch_route%route(iEns,jSeg,      & ! input: array indices
-                                 ixDesire,       & ! input: index of verbose reach
                                  T0,T1,          & ! input: start and end of the time step
                                  NETOPO_in,      & ! input: reach topology data structure
                                  RPARAM_in,      & ! input: reach parameter data structure
@@ -388,7 +381,6 @@ CONTAINS
           if (tracer .and. idxRoute/=idxSUM) then
             call constituent_rch(iEns,jSeg ,    & ! input: index of runoff ensemble to be processed
                                  idxRoute,      & ! input: routing method index
-                                 ixDesire,      & ! input: reachID to be checked by on-screen pringing
                                  NETOPO_in,     & ! input: reach topology data structure
                                  RPARAM_in,     & ! input: reach parameter data structure
                                  RCHSTA_out,    & ! inout: reach state data structure

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -80,9 +80,7 @@ CONTAINS
  ierr=0; message='mc_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHID == desireId)then
-   verbose = .true.
- end if
+ if(NETOPO_in(segIndex)%REACHID == desireId) verbose = .true.
 
  ! get discharge coming from upstream
  nUps = count(NETOPO_in(segIndex)%goodBas) ! reminder: goodBas is reach with >0 total contributory area

--- a/route/build/src/mc_route.f90
+++ b/route/build/src/mc_route.f90
@@ -11,6 +11,7 @@ USE dataTypes,     ONLY: mcRCH           ! MC specific state data structure
 USE public_var,    ONLY: iulog           ! i/o logical unit number
 USE public_var,    ONLY: realMissing     ! missing value for real number
 USE public_var,    ONLY: integerMissing  ! missing value for integer number
+USE public_var,    ONLY: desireId        ! ID or reach where detailed reach state is print in log
 USE public_var,    ONLY: dt              ! simulation time step [sec]
 USE public_var,    ONLY: qmodOption      ! qmod option (use 1==direct insertion)
 USE public_var,    ONLY: hw_drain_point  ! headwater catchment pour point (top_reach==1 or bottom_reach==2)
@@ -45,7 +46,6 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE mc_rch(this,           & ! mc_route_rch object to bound this procedure
                    iEns, segIndex, & ! input: index of runoff ensemble to be processed
-                   ixDesire,       & ! input: reachID to be checked by on-screen pringing
                    T0,T1,          & ! input: start and end of the time step
                    NETOPO_in,      & ! input: reach topology data structure
                    RPARAM_in,      & ! input: reach parameter data structure
@@ -58,7 +58,6 @@ CONTAINS
  class(mc_route_rch)                       :: this              ! mc_route_rch object to bound this procedure
  integer(i4b),  intent(in)                 :: iEns              ! runoff ensemble to be routed
  integer(i4b),  intent(in)                 :: segIndex          ! segment where routing is performed
- integer(i4b),  intent(in)                 :: ixDesire          ! index of the reach for verbose output
  real(dp),      intent(in)                 :: T0,T1             ! start and end of the time step (seconds)
  type(RCHTOPO), intent(in),    allocatable :: NETOPO_in(:)      ! River Network topology
  type(RCHPRP),  intent(inout), allocatable :: RPARAM_in(:)      ! River reach parameter
@@ -81,7 +80,7 @@ CONTAINS
  ierr=0; message='mc_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+ if(NETOPO_in(segIndex)%REACHID == desireId)then
    verbose = .true.
  end if
 
@@ -188,7 +187,6 @@ CONTAINS
  if (qmodOption==1) then
    call direct_insertion(iens, segIndex, & ! input: reach index
                          idxMC,          & ! input: routing method id for diffusive wave routing
-                         ixDesire,       & ! input: verbose seg index
                          NETOPO_in,      & ! input: reach topology data structure
                          RCHSTA_out,     & ! inout: reach state data structure
                          RCHFLX_out,     & ! inout: reach fluxes datq structure

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -81,7 +81,6 @@ CONTAINS
                             structNTOPO,        & ! input: data structure for network toopology
                             ierr, message)        ! output: error control
 
-  USE globalData,          ONLY: ixPrint                  ! reach index to be checked by on-screen pringing
   USE globalData,          ONLY: domains_mpi              ! MPI domain data structure - for each domain listing segment and hru indices
   USE globalData,          ONLY: nDomain_mpi              ! count of MPI decomposed domains (tributaries + mainstems)
   USE globalData,          ONLY: river_basin_main         ! OMP domain data structure for mainstem
@@ -463,18 +462,6 @@ CONTAINS
       end do
     end do
 
-    ! find index of desired reach
-    if (desireId/=integerMissing) then
-      if (allocated(array_int_temp_local)) deallocate(array_int_temp_local)
-      allocate(array_int_temp_local(rch_per_proc(pid)), stat=ierr, errmsg=cmessage)
-      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-      do iSeg = 1,rch_per_proc(pid)
-        array_int_temp_local(iSeg) = structNTOPO_local(iSeg)%var(ixNTOPO%segId)%dat(1)
-      end do
-      ixPrint(2) = findIndex(array_int_temp_local, desireId, integerMissing)
-    end if
-
     ! compute additional ancillary infomration
     call augment_ntopo(hru_per_proc(pid),            & ! input: number of HRUs
                        rch_per_proc(pid),            & ! input: number of stream segments
@@ -779,18 +766,6 @@ CONTAINS
         structNTOPO_main(global_ix_main(iSeg))%var(ixNTOPO%upSegIds    )%dat(:) = structNTOPO(jSeg)%var(ixNTOPO%upSegIds)%dat(:)
         structNTOPO_main(global_ix_main(iSeg))%var(ixNTOPO%upSegIndices)%dat(:) = integerMissing
       enddo
-
-      ! find index of desired reach
-      if (desireId/=integerMissing) then
-        if (allocated(array_int_temp)) deallocate(array_int_temp)
-        allocate(array_int_temp(nRch_mainstem), stat=ierr, errmsg=cmessage)
-        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-        do iSeg = 1, nRch_mainstem
-          array_int_temp(iSeg) = structNTOPO_main(iSeg)%var(ixNTOPO%segId)%dat(1)
-        end do
-        ixPrint(1) = findIndex(array_int_temp, desireId, integerMissing)
-      end if
 
       ! copy data to routing structres RPARAM_trib and NETOPO_trib
       call put_data_struct(nRch_mainstem+nTribOutlet, structSEG_main, structNTOPO_main, & ! input
@@ -1184,7 +1159,6 @@ CONTAINS
                       ierr, message, & ! output: error control
                       scatter_ro)      ! optional input: logical. .true. => scatter global hru runoff to mainstem and tributary
   ! shared data
-  USE globalData, ONLY: ixPrint             ! desired reach index
   USE globalData, ONLY: NETOPO_trib         ! tributary river netowrk topology structure
   USE globalData, ONLY: NETOPO_main         ! mainstem river netowrk topology structure
   USE globalData, ONLY: RPARAM_trib         ! tributary reach parameter structure
@@ -1313,7 +1287,6 @@ CONTAINS
                   river_basin_trib,  &  ! input: OMP basin decomposition
                   NETOPO_trib,       &  ! input: reach topology data structure
                   RPARAM_trib,       &  ! input: reach parameter data structure
-                  ixPrint(2),        &  ! input: reach index to be checked by on-screen pringing
                   RCHFLX_trib(:,ix1:ix2),   &  ! inout: reach flux data structure
                   RCHSTA_trib(:,ix1:ix2),   &  ! inout: reach state data structure
                   gage_obs_data_trib, &  ! inout: gage obs data for tributary reaches
@@ -1394,7 +1367,6 @@ CONTAINS
                       river_basin_main,        &  ! input: OMP basin decomposition
                       NETOPO_main,             &  ! input: reach topology data structure
                       RPARAM_main,             &  ! input: reach parameter data structure
-                      ixPrint(1),              &  ! input: reach index to be checked by on-screen pringing
                       RCHFLX_trib(:,1:nRch_mainstem+nTribOutlet),  &  ! inout: reach flux data structure
                       RCHSTA_trib(:,1:nRch_mainstem+nTribOutlet),  &  ! inout: reach state data structure
                       gage_obs_data_main,      &  ! inout: gage obs data for mainstem reaches

--- a/route/build/src/tracer.f90
+++ b/route/build/src/tracer.f90
@@ -16,6 +16,7 @@ USE dataTypes,     ONLY: STRSTA                ! state in each reach
 USE dataTypes,     ONLY: RCHTOPO               ! Network topology
 USE dataTypes,     ONLY: RCHPRP                ! Reach parameter
 USE public_var,    ONLY: iulog                 ! i/o logical unit number
+USE public_var,    ONLY: desireId              ! ID or reach where detailed reach state is print in log
 USE public_var,    ONLY: dt                    ! simulation time step [sec]
 USE public_var,    ONLY: hw_drain_point        ! headwater catchment pour point (top_reach==1 or bottom_reach==2)
 USE public_var,    ONLY: min_length_route      ! minimum reach length for routing to be performed.
@@ -41,7 +42,6 @@ CONTAINS
  ! *********************************************************************
  SUBROUTINE constituent_rch(iens, segIndex,   & ! input: index of runoff ensemble to be processed
                             idxRoute,         & ! input: routing method index
-                            ixDesire,         & ! input: reachID to be checked by on-screen pringing
                             NETOPO_in,        & ! input: reach topology data structure
                             RPARAM_in,        & ! input: reach parameter data structure
                             RCHSTA_out,       & ! inout: reach state data structure
@@ -53,7 +53,6 @@ CONTAINS
  integer(i4b),     intent(in)                 :: iens              ! runoff ensemble to be routed
  integer(i4b),     intent(in)                 :: segIndex          ! segment where routing is performed
  integer(i4b),     intent(in)                 :: idxRoute          ! routing method index
- integer(i4b),     intent(in)                 :: ixDesire          ! index of the reach for verbose output
  type(RCHTOPO),    intent(in),    allocatable :: NETOPO_in(:)      ! River Network topology
  type(RCHPRP),     intent(inout), allocatable :: RPARAM_in(:)      ! River reach parameter
  type(STRSTA),     intent(inout)              :: RCHSTA_out(:,:)   ! reach state data
@@ -73,7 +72,7 @@ CONTAINS
  ierr=0; message='constituent_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHIX == ixDesire)then
+ if(NETOPO_in(segIndex)%REACHID == desireId)then
    verbose = .true.
  end if
 

--- a/route/build/src/tracer.f90
+++ b/route/build/src/tracer.f90
@@ -72,9 +72,7 @@ CONTAINS
  ierr=0; message='constituent_rch/'
 
  verbose = .false.
- if(NETOPO_in(segIndex)%REACHID == desireId)then
-   verbose = .true.
- end if
+ if(NETOPO_in(segIndex)%REACHID == desireId) verbose = .true.
 
  ! get mass flux from upstream
  nUps = count(NETOPO_in(segIndex)%goodBas) ! reminder: goodBas is reach with >0 total contributory area


### PR DESCRIPTION
Remove ixDesire (index of reach where detailed information is written in log file). Instead of using index, use desireId (reach ID specified in control file) directly. 