### PR TITLE
fix custom css

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,0 +1,17 @@
+/* Make equation numbers float to the right */
+.eqno {
+    margin-left: 5px;
+    float: right;
+}
+/* Hide the link... */
+.math .headerlink {
+    display: none;
+    visibility: hidden;
+}
+/* ...unless the equation is hovered */
+.math:hover .headerlink {
+    display: inline-block;
+    visibility: visible;
+    /* Place link in margin and keep equation number aligned with boundary */
+    margin-right: -0.7em;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,9 @@ extensions = [
 math_numfig = True
 numfig = True
 
+def setup(app):
+    app.add_css_file('css/custom.css')
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
With this change, equation numbers appear to the right.

custum.css is from [CTSM doc](https://github.com/ESMCI/doc-builder/blob/3ab6d06971e508f2886f0079db37156ab93c2b07/_static/css/custom.css)