### PR TITLE
bugfix related restarting

### DIFF
--- a/route/build/src/histVars_data.f90
+++ b/route/build/src/histVars_data.f90
@@ -570,30 +570,31 @@ MODULE histVars_data
             end if
           end if
 
-          if (meta_rflx(ixSoluteMass)%varFile) then
-            call read_dist_array(pioFileDesc, meta_rflx(ixSoluteMass)%varName, array_tmp, ioDesc_rch_double, ierr, cmessage)
-            if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-            ! need to shift tributary part in main core to after halo reaches (nTribOutlet)
-            if (masterproc) then
-              this%solute_mass(1:nRch_mainstem, ixRoute) = array_tmp(1:nRch_mainstem)
-              this%solute_mass(nRch_mainstem+nTribOutlet+1:this%nRch, ixRoute) = array_tmp(nRch_mainstem+1:nRch_mainstem+nRch_trib)
-            else
-              this%solute_mass(:,ixRoute) = array_tmp
+          if (routeMethods(ixRoute)==diffusiveWave) then
+            if (meta_rflx(ixSoluteMass)%varFile) then
+              call read_dist_array(pioFileDesc, meta_rflx(ixSoluteMass)%varName, array_tmp, ioDesc_rch_double, ierr, cmessage)
+              if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+              ! need to shift tributary part in main core to after halo reaches (nTribOutlet)
+              if (masterproc) then
+                this%solute_mass(1:nRch_mainstem, ixRoute) = array_tmp(1:nRch_mainstem)
+                this%solute_mass(nRch_mainstem+nTribOutlet+1:this%nRch, ixRoute) = array_tmp(nRch_mainstem+1:nRch_mainstem+nRch_trib)
+              else
+                this%solute_mass(:,ixRoute) = array_tmp
+              end if
             end if
-          end if
 
-          if (meta_rflx(ixSoluteFlux)%varFile) then
-            call read_dist_array(pioFileDesc, meta_rflx(ixSoluteFlux)%varName, array_tmp, ioDesc_rch_double, ierr, cmessage)
-            if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-            ! need to shift tributary part in main core to after halo reaches (nTribOutlet)
-            if (masterproc) then
-              this%solute_flux(1:nRch_mainstem, ixRoute) = array_tmp(1:nRch_mainstem)
-              this%solute_flux(nRch_mainstem+nTribOutlet+1:this%nRch, ixRoute) = array_tmp(nRch_mainstem+1:nRch_mainstem+nRch_trib)
-            else
-              this%solute_flux(:,ixRoute) = array_tmp
+            if (meta_rflx(ixSoluteFlux)%varFile) then
+              call read_dist_array(pioFileDesc, meta_rflx(ixSoluteFlux)%varName, array_tmp, ioDesc_rch_double, ierr, cmessage)
+              if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+              ! need to shift tributary part in main core to after halo reaches (nTribOutlet)
+              if (masterproc) then
+                this%solute_flux(1:nRch_mainstem, ixRoute) = array_tmp(1:nRch_mainstem)
+                this%solute_flux(nRch_mainstem+nTribOutlet+1:this%nRch, ixRoute) = array_tmp(nRch_mainstem+1:nRch_mainstem+nRch_trib)
+              else
+                this%solute_flux(:,ixRoute) = array_tmp
+              end if
             end if
-          end if
-
+          end if ! end of routeMethods==diffusiveWave if-statement
         end do ! end of ixRoute loop
       end if ! end of nRoute>0 if-statement
 

--- a/route/build/src/popMetadat.f90
+++ b/route/build/src/popMetadat.f90
@@ -296,7 +296,7 @@ contains
 
  ! Impulse Response Function
  call meta_irf(ixIRF%qfuture)%init('irf_qfuture', 'future flow series',   'm3/s' ,ncd_double, [ixStateDims%seg,ixStateDims%tdh_irf] , .true.)
- call meta_irf(ixIRF%vol    )%init('volume_irf' , 'volume in reach/lake', 'm3'   ,ncd_double, [ixStateDims%seg,ixStateDims%tbound] , .true.)
+ call meta_irf(ixIRF%vol    )%init('volume_irf' , 'volume in reach/lake', 'm3'   ,ncd_double, [ixStateDims%seg], .true.)
  call meta_irf(ixIRF%qerror)%init('qerror_irf',   'discharge error',      'm3/s', ncd_double, [ixStateDims%seg], .false.)
 
  ! Basin Impulse Response Function

--- a/route/build/src/read_restart.f90
+++ b/route/build/src/read_restart.f90
@@ -334,7 +334,8 @@ CONTAINS
     do iVar=1,nVarsIRF
       select case(iVar)
         case(ixIRF%qfuture); allocate(state%var(iVar)%array_2d_dp(nSeg, ntdh_irf), stat=ierr)
-        case(ixIRF%vol : ixIRF%qerror); allocate(state%var(iVar)%array_2d_dp(nSeg, nTbound), stat=ierr)
+        case(ixIRF%vol); allocate(state%var(iVar)%array_1d_dp(nSeg), stat=ierr)
+        case(ixIRF%qerror); allocate(state%var(iVar)%array_1d_dp(nSeg), stat=ierr)
         case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
       end select
       if(ierr/=0)then; message1=trim(message1)//'problem allocating space for IRF routing state:'//trim(meta_irf(iVar)%varName); return; endif
@@ -346,7 +347,7 @@ CONTAINS
     do iVar=1,nVarsIRF
       select case(iVar)
         case(ixIRF%qfuture); call get_nc(fname, meta_irf(iVar)%varName, state%var(iVar)%array_2d_dp, [1,1], [nSeg,ntdh_irf], ierr, cmessage1)
-        case(ixIRF%vol);     call get_nc(fname, meta_irf(iVar)%varName, state%var(iVar)%array_2d_dp, [1,1], [nSeg,nTbound], ierr, cmessage1)
+        case(ixIRF%vol);     call get_nc(fname, meta_irf(iVar)%varName, state%var(iVar)%array_1d_dp, 1, nSeg, ierr, cmessage1)
         case(ixIRF%qerror)
           call open_nc(fname, 'r', ncidRestart, ierr, cmessage1)
           if(ierr/=0)then; message1=trim(message1)//trim(cmessage1); return; endif
@@ -369,7 +370,7 @@ CONTAINS
         do iVar=1,nVarsIRF
           select case(iVar)
             case(ixIRF%qfuture); RCHFLX(jSeg)%QFUTURE_IRF    = state%var(iVar)%array_2d_dp(iSeg,1:numQF(iSeg))
-            case(ixIRF%vol);     RCHFLX(jSeg)%ROUTE(idxIRF)%REACH_VOL(0:1) = state%var(iVar)%array_2d_dp(iSeg,1:2)
+            case(ixIRF%vol);     RCHFLX(jSeg)%ROUTE(idxIRF)%REACH_VOL(1) = state%var(iVar)%array_1d_dp(iSeg)
             case(ixIRF%qerror);  RCHFLX(iSeg)%ROUTE(idxIRF)%Qerror = state%var(iVar)%array_1d_dp(iSeg)
             case default; ierr=20; message1=trim(message1)//'unable to identify variable index'; return
           end select

--- a/route/build/src/write_restart_pio.f90
+++ b/route/build/src/write_restart_pio.f90
@@ -65,7 +65,6 @@ USE globalData,        ONLY: ioDesc_mesh_kw_double
 USE globalData,        ONLY: ioDesc_mesh_mc_double
 USE globalData,        ONLY: ioDesc_mesh_dw_double
 USE globalData,        ONLY: ioDesc_irf_double
-USE globalData,        ONLY: ioDesc_vol_double
 USE globalData,        ONLY: ioDesc_irf_bas_double
 
 implicit none
@@ -1015,13 +1014,13 @@ CONTAINS
           call write_pnetcdf(pioFileDesc, meta_irf(iVar)%varName, array_2d_dp, ioDesc_irf_double, ierr, cmessage)
           deallocate(array_2d_dp)
         case(ixIRF%vol)
-          allocate(array_2d_dp(nSeg,nTbound), stat=ierr, errmsg=cmessage)
+          allocate(array_1d_dp(nSeg), stat=ierr, errmsg=cmessage)
           if(ierr/=0)then; message1=trim(message1)//trim(cmessage)//':IRF routing state:'//trim(meta_irf(iVar)%varName); return; endif
           do iSeg=1,nSeg
-            array_2d_dp(iSeg,1:nTbound) = RCHFLX_local(iSeg)%ROUTE(idxIRF)%REACH_VOL(0:1)
+            array_1d_dp(iSeg) = RCHFLX_local(iSeg)%ROUTE(idxIRF)%REACH_VOL(1)
           end do
-          call write_pnetcdf(pioFileDesc, meta_irf(iVar)%varName, array_2d_dp, ioDesc_vol_double, ierr, cmessage)
-          deallocate(array_2d_dp)
+          call write_pnetcdf(pioFileDesc, meta_irf(iVar)%varName, array_1d_dp, ioDesc_rch_double, ierr, cmessage)
+          deallocate(array_1d_dp)
         case(ixIRF%qerror) ! if data assimilation is off, no need to be written
           if (meta_irf(iVar)%varFile) then
             allocate(array_1d_dp(nSeg), stat=ierr, errmsg=cmessage)
@@ -1029,7 +1028,7 @@ CONTAINS
             do iSeg=1,nSeg
               array_1d_dp(iSeg) = RCHFLX_local(iSeg)%ROUTE(idxIRF)%Qerror
             end do
-            call write_pnetcdf(pioFileDesc, meta_irf(iVar)%varName, array_1d_dp, ioDesc_vol_double, ierr, cmessage)
+            call write_pnetcdf(pioFileDesc, meta_irf(iVar)%varName, array_1d_dp, ioDesc_rch_double, ierr, cmessage)
             deallocate(array_1d_dp)
           end if
         case default; ierr=20; message1=trim(message1)//'unable to identify IRF variable index for nc writing'; return


### PR DESCRIPTION
This was found when running in debugging mode

This fix should not change any answer.

Also, this is not really bug, but it is clean up. irf volume in restart I/O does not has to use 2D array, i.e., REACH_VOL(0:1) does not has to be saved, but just REACH_VOL(1) is needed like the other routing method.