### PR TITLE
write gauge id as character array in gauge only history file

### DIFF
--- a/route/build/src/csv_data.f90
+++ b/route/build/src/csv_data.f90
@@ -548,7 +548,7 @@ CONTAINS
         type is (character(len=*))
           tmp = repeat(' ',len(col_data)) ! size the string
           call this%get_cell_value(i, icol, tmp, istat)
-          col_data(i) = tmp
+          col_data(i:this%nrows) = tmp  ! this works with both intel and gcc.  col_data(i)=tmp works only with intel, not with gcc.
         class default
           call this%get_cell_value(i, icol, col_data(i), istat)
         end select

--- a/route/build/src/gageMeta_data.f90
+++ b/route/build/src/gageMeta_data.f90
@@ -1,6 +1,6 @@
 module gageMeta_data
 
-  use nrtype
+  use nrtype,        only: i4b, lgt, strLen, gageStrLen
   use public_var,    only: integerMissing
   use csv_data,      only: csv
   use nr_utils,      only: match_index
@@ -12,7 +12,7 @@ module gageMeta_data
   type :: gageMeta
     private
     integer(i4b)                   :: nGage
-    character(len=30), allocatable :: gageID(:)
+    character(len=gageStrLen), allocatable :: gageID(:)
     integer(i4b),      allocatable :: reachID(:)
 
     contains
@@ -86,7 +86,7 @@ module gageMeta_data
     function fn_get_gageID(this) result(gageID)
       implicit none
       class(gageMeta), intent(in) :: this
-      character(30), allocatable  :: gageID(:)
+      character(len=gageStrLen), allocatable :: gageID(:)
       allocate(gageID(this%nGage))
       gageID = this%gageID
     end function fn_get_gageID
@@ -95,7 +95,7 @@ module gageMeta_data
       implicit none
       class(gageMeta), intent(in) :: this
       integer(i4b)                :: ix(:)
-      character(30), allocatable  :: gageID(:)
+      character(len=gageStrLen), allocatable :: gageID(:)
       allocate(gageID(size(ix)))
       gageID = this%gageID(ix)
     end function fn_get_gageID_vec
@@ -104,7 +104,7 @@ module gageMeta_data
       implicit none
       class(gageMeta), intent(in) :: this
       integer(i4b)                :: ix
-      character(30)               :: gageID
+      character(len=gageStrLen)   :: gageID
       gageID = this%gageID(ix)
     end function fn_get_gageID_scalar
 

--- a/route/build/src/nrtype.f90
+++ b/route/build/src/nrtype.f90
@@ -10,6 +10,7 @@ MODULE nrtype
     integer, parameter     :: DPC = KIND((1.0D0,1.0D0))
     integer, parameter     :: LGT = KIND(.true.)
     ! common variables
-    integer(i4b),parameter :: strLen=256            ! string length
+    integer(i4b),parameter :: strLen=256            ! general string length
     integer(i4b),parameter :: FileStrLen=300        ! File string length
+    integer(i4b),parameter :: gageStrLen=30         ! gauge id string length
 END MODULE nrtype

--- a/route/build/src/write_simoutput_pio.f90
+++ b/route/build/src/write_simoutput_pio.f90
@@ -53,7 +53,8 @@ CONTAINS
     ! local variables
     logical(lgt)                    :: createNewFile       ! logical to make alarm for restart writing
     integer(i4b)                    :: nGage               ! number of gauge points
-    integer(i4b), allocatable       :: reach_id_local(:)   ! logical to make alarm for restart writing
+    integer(i4b), allocatable       :: reach_id_local(:)   ! reach id
+    character(len=30), allocatable  :: gage_id_local(:)    !
     character(len=strLen)           :: cmessage            ! error message of downwind routine
 
     ierr=0; message='main_new_file/'
@@ -84,8 +85,9 @@ CONTAINS
 
         hist_gage = histFile(hfileout_gage, gageOutput=.true.)
         nGage = gage_meta_data%gage_num()
-        allocate(reach_id_local(nGage))
+
         reach_id_local = gage_meta_data%reach_id()
+        gage_id_local = gage_meta_data%gage_id()
 
         call hist_gage%createNC(ierr, cmessage, nRch_in= nGage)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -94,6 +96,9 @@ CONTAINS
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
         call hist_gage%write_loc(reach_id_local, ierr, message)
+        if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+
+        call hist_gage%write_loc(gage_id_local, ierr, message)
         if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
       end if
 


### PR DESCRIPTION
Now, when you write the results in gauge site only history file, the history file includes only reach ID. 

This PR includes gauge ID in the history file using character type in netcdf (not string which is available in netcdf4).

