### PR TITLE
Corrections related to CESM/CTSM coupling

### DIFF
--- a/route/build/cpl/RtmVar.F90
+++ b/route/build/cpl/RtmVar.F90
@@ -51,9 +51,8 @@ MODULE RtmVar
   logical,           public            :: do_flood       = .false.                  !
   character(len=CL), public            :: nrevsn_rtm     = ' '                      ! restart data file name for branch run
   real(r8),          public            :: river_depth_minimum = 1.e-1               ! minimum river depth for water take [mm]
-  real(r8),          public            :: delt_coupling                             ! coupling period [sec]
   integer,           public            :: nsub                                      ! number of subcyling for rof simulation per coupling
-  integer,           public            :: coupling_period                           ! coupling period [day]
+  real(r8),          public            :: coupling_period                           ! coupling period [sec]
   integer,           public            :: rtmhist_ndens  = 1                        ! namelist: output density of netcdf history files
   integer,           public            :: rtmhist_mfilt  = 30                       ! namelist: number of time samples per tape
   integer,           public            :: rtmhist_nhtfrq = 0                        ! namelist: history write freq(0=monthly)

--- a/route/build/cpl/nuopc/rof_comp_nuopc.F90
+++ b/route/build/cpl/nuopc/rof_comp_nuopc.F90
@@ -35,7 +35,7 @@ module rof_comp_nuopc
   USE RtmVar                , ONLY : cfile_name
   use RtmVar                , only : inst_index, inst_suffix, inst_name, rofVarSet
   use RtmVar                , only : nsrStartup, nsrContinue, nsrBranch
-  use RtmVar                , only : coupling_period !day
+  use RtmVar                , only : coupling_period !sec
 
   use perf_mod              , only : t_startf, t_stopf, t_barrierf
   use rof_import_export     , only : advertise_fields, realize_fields
@@ -451,7 +451,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Get coupling interval in day
-    call ESMF_TimeIntervalGet( timeStep, d=coupling_period, rc=rc)
+    call ESMF_TimeIntervalGet( timeStep, s_r8=coupling_period, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! get ymd integer and string for start time, end time and reference time


### PR DESCRIPTION
A few fixes related to cesm coupling:

1. Previously the coupling frequency was allowed to be more than 1 day because ``coupling_period`` was integer and unit of the coupling frequency was set to day in nuopc. Here, the type of ``coupling_period`` was changed to real and unit of frequency is set to sec. This allows us to use sub-daily coupling frequency and also make the code slightly cleaner (removed some lines)

2. Also there was bug (wrong loop index variable) when checking the outlet reach, which is fixed here. This fix seems to enable mizuRoute to run in fully CESM coupled mode without crash. 

Fix #594 
