### PR TITLE
MPI call cleanup

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -74,7 +74,6 @@ CONTAINS
     USE init_model_data,     ONLY: init_ntopo_data             !
     USE init_model_data,     ONLY: init_state_data
     USE RtmTimeManager,      ONLY: init_time
-    USE mpi_process,         ONLY: pass_global_data
     USE write_simoutput_pio, ONLY: init_histFile
 
     implicit none
@@ -200,9 +199,6 @@ CONTAINS
     !-------------------------------------------------------
 
     call init_ntopo_data(iam, npes, mpicom_rof, ierr, cmessage)
-    if(ierr/=0)then; call shr_sys_flush(iulog); call shr_sys_abort(trim(subname)//trim(cmessage)); endif
-
-    call pass_global_data(mpicom_rof, ierr, cmessage)
     if(ierr/=0)then; call shr_sys_flush(iulog); call shr_sys_abort(trim(subname)//trim(cmessage)); endif
 
     !-------------------------------------------------------

--- a/route/build/src/init_model_data.f90
+++ b/route/build/src/init_model_data.f90
@@ -200,7 +200,6 @@ CONTAINS
   USE read_streamSeg,       ONLY: mod_meta_varFile         ! modify variable I/O options
   USE model_utils,          ONLY: model_finalize
   USE mpi_process,          ONLY: comm_ntopo_data          ! mpi routine: initialize river network data in slave procs (incl. river data transfer from root proc)
-  USE mpi_utils,            ONLY: shr_mpi_initialized      ! If MPI is being used
   USE domain_decomposition, ONLY: mpi_domain_decomposition ! domain decomposition for mpi
   USE network_topo,         ONLY: lakeInlet                ! identify lake inlet reach
   USE network_topo,         ONLY: outletSegment            ! subroutine: find oultlet reach id, index  as a destination reach
@@ -277,7 +276,6 @@ CONTAINS
    end if
 
    call comm_ntopo_data(pid, nNodes, comm,                                    & ! input: proc id, # of procs and commnicator
-                        nRch, nHRU,                                           & ! input: number of reach and HRUs that contribut to any reaches
                         structHRU, structSEG, structHRU2SEG, structNTOPO,     & ! input: river network data structures for the entire network
                         ierr, cmessage)                                         ! output: error controls
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -282,7 +282,7 @@ CONTAINS
   if (trim(runMode)=='cesm-coupling' .and. &
       trim(bypass_routing_option)=='direct_to_outlet') then
 
-    call sparse_dist_data(pid, nNodes, nRch_in, reachID, structNTOPO, ixNode, ierr, message)
+    call sparse_dist_data(pid, nNodes, nRch, reachID, structNTOPO, ixNode, ierr, message)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   end if

--- a/route/build/src/standalone/model_setup.f90
+++ b/route/build/src/standalone/model_setup.f90
@@ -54,7 +54,6 @@ CONTAINS
    USE globalData,          ONLY: version             ! mizuRoute version
    USE globalData,          ONLY: gitBranch           ! git branch
    USE globalData,          ONLY: gitHash             ! git commit hash
-   USE mpi_process,         ONLY: pass_global_data    ! mpi globaldata copy to slave proc
    USE init_model_data,     ONLY: init_ntopo_data
    USE init_model_data,     ONLY: init_state_data
    USE init_model_data,     ONLY: init_qmod
@@ -100,10 +99,6 @@ CONTAINS
      call init_forc_data(ierr, cmessage)
      if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
    end if
-
-   ! broadcast public and some global variables
-   call pass_global_data(comm, ierr, cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    ! restart initialization
    call init_state_data(pid, nNodes, comm, ierr, cmessage)


### PR DESCRIPTION
1. Several variables are broadcasted in `pass_global_data` routine. This routine was removed and variables that need to be broadcasted in `comm_ntopo_data` routine (where some other variables are broadcasted).

2. use routines in mpi_utils.f90 as much as possible instead of calling directly MPI native routine.  e.g., shr_mpi_bcast instead of MPI_BCAST.