### PR TITLE
refactoring tracer name handling in ctsm/cesm coupling

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -101,7 +101,7 @@ CONTAINS
     call ctl%init_tracer_names(rof_tracers)
 
     if (masterproc) then
-      write(iulog,'(A,*(1X,A,:))') "mizuRoute tracers=", (trim(ctl%tracer_names(nt)), nt=1,ctl%ntracers)
+      write(iulog,'(A,*(1X,A,":"))') "mizuRoute tracers=", (trim(ctl%tracer_names(nt)), nt=1,ctl%ntracers)
     end if
 
     !-------------------------------------------------------
@@ -515,6 +515,9 @@ CONTAINS
 
     ! Distribute "direct runoff to ocean" to targe reach (i.e., outlet of river network)
     call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct(:,nt_ice), fillvalue=0._r8)
+
+    call shr_mpi_barrier(mpicom_rof, cmessage)
+    if(ierr/=0)then; call shr_sys_flush(iulog); call shr_sys_abort(trim(subname)//"mpi_barrier error"); endif
 
     ! Set ctl%qsur, ctl%qsub and ctl%qgwl to zero for nt_ice
     ctl%qsur(:,nt_ice) = 0._r8

--- a/route/build/cpl/RtmVar.F90
+++ b/route/build/cpl/RtmVar.F90
@@ -1,7 +1,7 @@
 MODULE RtmVar
 
   ! Public variables used for only coupled version mizuRoute
-
+  USE RunoffMod,     ONLY: rof_control
   USE shr_kind_mod , ONLY: r8 => shr_kind_r8, CL => SHR_KIND_CL
   USE shr_sys_mod  , ONLY: shr_sys_abort, shr_sys_flush
   USE globalData   , ONLY: masterproc
@@ -14,12 +14,8 @@ MODULE RtmVar
   save
 
   ! public variables (saved)
-  !TODO - nt_rof and rof_tracers need to be removed and set by access to the index array
-  integer,           public, parameter :: nt_rof = 2                      ! number of tracers
-  character(len=3),  public, parameter :: rof_tracers(nt_rof) = (/'LIQ','ICE'/)
-
-  logical,           public            :: barrier_timers = .false.       ! barrier timers
-
+  ! rof control data that interact with import/export in coupler
+  type(rof_control), public            :: ctl
   ! Metadata variables used in history and restart files's global attributes
   character(len=CL), public            :: caseid      = ' '              ! case id
   character(len=CL), public            :: ctitle      = ' '              ! case title
@@ -28,19 +24,16 @@ MODULE RtmVar
   character(len=CL), public            :: conventions = 'CF-1.0'         ! dataset conventions
   character(len=CL), public            :: model_doi_url                  ! Web address of the Digital Object Identifier (DOI) for this model version
   character(len=CL), public            :: source   = 'mizuRoute'         ! description of this source
-
   ! Run startup
   integer,           public, parameter :: nsrStartup  = 0                ! Startup from initial conditions
   integer,           public, parameter :: nsrContinue = 1                ! Continue from restart files
   integer,           public, parameter :: nsrBranch   = 2                ! Branch from restart files
   integer,           public            :: nsrest = integerMissing        ! Type of run
   logical,           public            :: brnch_retain_casename = .false.! true => allow case name to remain the same for branch run
-
   ! Instance control
   integer,           public            :: inst_index
   character(len=16), public            :: inst_name
   character(len=16), public            :: inst_suffix
-
   ! rof control variables
   character(len=CL), public            :: nrevsn_rtm     = ' '                      ! restart data file name for branch run
   real(r8),          public            :: river_depth_minimum = 1.e-1               ! minimum river depth for water take [mm]
@@ -52,5 +45,7 @@ MODULE RtmVar
   logical,           public            :: ice_runoff     = .false.                  ! true => runoff is split into liquid and ice,
   character(len=256),public            :: cfile_name     = 'mizuRoute.control'
   character(len=256),public            :: para_xxxx      = 'mizuRoute_in'
+  ! Miscellaneous variables
+  logical,           public            :: barrier_timers = .false.       ! barrier timers
 
 END MODULE RtmVar

--- a/route/build/cpl/RunoffMod.F90
+++ b/route/build/cpl/RunoffMod.F90
@@ -3,62 +3,67 @@ MODULE RunoffMod
 ! DESCRIPTION:
 ! Module containing data structures for coupler runoff data
 
-  USE nrtype,     ONLY : r8 => dp
+  USE nrtype,     ONLY : r8 => dp, cs => strLen
   USE public_var, ONLY : iulog
   USE public_var, ONLY : integerMissing
-  USE rtmVar,     ONLY : nt_rof
   USE shr_sys_mod,ONLY : shr_sys_abort, shr_sys_flush
 
   implicit none
 
   private
 
-  type, public :: runoff_flow
+  type, public :: rof_control
+    ! tracers
+    integer           :: ntracers = integerMissing   ! number of tracers
+    character(len=cs), allocatable :: tracer_names(:) ! tracer names
+    integer           :: nt_liq                      ! index of liquid tracer in tracer_names
+    integer           :: nt_ice                      ! index of ice tracer in tracer_names
+    logical           :: rof_from_glc                ! if true, will receive liq and ice runoff from glc
+    ! domain and decomposition info
     integer           :: begr,endr        ! local start/stop indices
     integer           :: lnumr            ! local number of catchments
     integer           :: numr             ! gdc global number of catchments
-
     integer , pointer :: gindex(:)        ! global index consistent with map file
-
     real(r8), pointer :: area(:)          ! area of hru (AKA catchment) [m2]
     integer , pointer :: mask(:)          ! reach category. 1=non outle, 2=interior basin outlet, 3=ocean outlet
-
+    ! import variables
     real(r8), pointer :: qsur(:,:)        ! coupler importing surface forcing [mm/s]
     real(r8), pointer :: qsub(:,:)        ! coupler importing subsurface forcing [mm/s]
     real(r8), pointer :: qgwl(:,:)        ! coupler importing glacier/wetland/lake forcing [mm/s]
     real(r8), pointer :: qirrig(:)        ! coupler importing irrigation [mm/s] - negative
     real(r8), pointer :: qirrig_actual(:) ! actual water take from river reach [mm/s]
-
+    ! export variables
     real(r8), pointer :: direct(:,:)      ! coupler return direct flow to ocean [mm/s]
-
     real(r8), pointer :: discharge(:,:)   ! coupler exporting river discharge [m3/s]
     real(r8), pointer :: volr(:)          ! coupler exporting river storage per unit HRU area (m)
     real(r8), pointer :: flood(:)         ! coupler exporting flood water sent back to clm [m3/s]
-  end type runoff_flow
-
-  type(runoff_flow), public :: ctl
-
-  public :: RunoffInit
+  CONTAINS
+    procedure, public  :: init
+    procedure, public  :: init_tracer_names
+  end type rof_control
 
 CONTAINS
 
-  SUBROUTINE RunoffInit(begr, endr, numr)
-
+  SUBROUTINE init(this, begr, endr, numr)
+    implicit none
+    class(rof_control)  :: this
     integer, intent(in) :: begr, endr, numr
+    integer :: nt
     integer :: ierr
 
-    allocate(ctl%gindex(begr:endr),            &
-             ctl%area(begr:endr),              &
-             ctl%mask(begr:endr),              &
-             ctl%qsur(begr:endr,nt_rof),       &
-             ctl%qsub(begr:endr,nt_rof),       &
-             ctl%qgwl(begr:endr,nt_rof),       &
-             ctl%qirrig(begr:endr),            &
-             ctl%qirrig_actual(begr:endr),     &
-             ctl%discharge(begr:endr,nt_rof),  &
-             ctl%direct(begr:endr,nt_rof),     &
-             ctl%volr(begr:endr),              &
-             ctl%flood(begr:endr),             &
+    nt = this%ntracers
+    allocate(this%gindex(begr:endr),          &
+             this%area(begr:endr),            &
+             this%mask(begr:endr),            &
+             this%qsur(begr:endr,nt),         &
+             this%qsub(begr:endr,nt),         &
+             this%qgwl(begr:endr,nt),         &
+             this%qirrig(begr:endr),          &
+             this%qirrig_actual(begr:endr),   &
+             this%discharge(begr:endr,nt),    &
+             this%direct(begr:endr,nt),       &
+             this%volr(begr:endr),            &
+             this%flood(begr:endr),           &
              stat=ierr)
     if (ierr/=0) then
       write(iulog,*)'Rtmini ERROR allocation of runoff local arrays'
@@ -66,19 +71,47 @@ CONTAINS
       call shr_sys_abort
     end if
 
-    ctl%gindex(:)       = integerMissing
-    ctl%mask(:)         = integerMissing
-    ctl%area(:)         = 0._r8
-    ctl%qirrig(:)       = 0._r8
-    ctl%qirrig_actual(:)= 0._r8
-    ctl%qsur(:,:)       = 0._r8
-    ctl%qsub(:,:)       = 0._r8
-    ctl%qgwl(:,:)       = 0._r8
-    ctl%discharge(:,:)  = 0._r8
-    ctl%direct(:,:)     = 0._r8
-    ctl%volr(:)         = 0._r8
-    ctl%flood(:)        = 0._r8
+    this%gindex(:)       = integerMissing
+    this%mask(:)         = integerMissing
+    this%area(:)         = 0._r8
+    this%qirrig(:)       = 0._r8
+    this%qirrig_actual(:)= 0._r8
+    this%qsur(:,:)       = 0._r8
+    this%qsub(:,:)       = 0._r8
+    this%qgwl(:,:)       = 0._r8
+    this%discharge(:,:)  = 0._r8
+    this%direct(:,:)     = 0._r8
+    this%volr(:)         = 0._r8
+    this%flood(:)        = 0._r8
 
-  END SUBROUTINE RunoffInit
+  END SUBROUTINE init
+
+  SUBROUTINE init_tracer_names(this, tracer_names)
+    implicit none
+    ! Argument variables
+    class(rof_control)            :: this
+    character(len=cs), intent(in) :: tracer_names(:)    ! string array of tracer names
+    ! Local variables
+    integer :: nt
+    character(len=*),parameter :: subname = '(RunoffMod: init_tracer_names)'
+
+    ! Determine number of tracers and array of tracer names
+    this%ntracers = len(tracer_names)
+    allocate(this%tracer_names(this%ntracers))
+    do nt = 1,this%ntracers
+      this%tracer_names(nt) = tracer_names(nt)
+    end do
+    ! Set tracers
+    this%nt_liq = 0
+    this%nt_ice = 0
+    do nt = 1,this%ntracers
+       if (trim(this%tracer_names(nt)) == 'LIQ') this%nt_liq = nt
+       if (trim(this%tracer_names(nt)) == 'ICE') this%nt_ice = nt
+    enddo
+    if (this%nt_liq == 0 .or. this%nt_ice == 0) then
+       write(iulog,*) trim(subname),': ERROR in tracers LIQ ICE ',this%nt_liq,this%nt_ice,this%tracer_names(:)
+       call shr_sys_abort()
+    endif
+  END SUBROUTINE init_tracer_names
 
 END MODULE RunoffMod

--- a/route/build/cpl/RunoffMod.F90
+++ b/route/build/cpl/RunoffMod.F90
@@ -45,6 +45,10 @@ MODULE RunoffMod
 CONTAINS
 
   SUBROUTINE init(this, begr, endr, numr)
+
+    ! DESCRIPTION:
+    ! Initialize rof_control derived data variables
+
     implicit none
     class(rof_control)  :: this
     integer, intent(in) :: begr, endr, numr
@@ -87,6 +91,12 @@ CONTAINS
   END SUBROUTINE init
 
   SUBROUTINE init_tracer_names(this, tracer_names)
+
+    ! DESCRIPTION:
+    ! Initialize tracer names in rof_coontrol derived data
+    ! LIQ (i.e., water) and ICE are always initialized
+    ! Any additional tracers to be tracked can be added.
+
     implicit none
     ! Argument variables
     class(rof_control)            :: this

--- a/route/build/cpl/RunoffMod.F90
+++ b/route/build/cpl/RunoffMod.F90
@@ -96,7 +96,7 @@ CONTAINS
     character(len=*),parameter :: subname = '(RunoffMod: init_tracer_names)'
 
     ! Determine number of tracers and array of tracer names
-    this%ntracers = len(tracer_names)
+    this%ntracers = size(tracer_names)
     allocate(this%tracer_names(this%ntracers))
     do nt = 1,this%ntracers
       this%tracer_names(nt) = tracer_names(nt)

--- a/route/build/cpl/nuopc/rof_comp_nuopc.F90
+++ b/route/build/cpl/nuopc/rof_comp_nuopc.F90
@@ -31,7 +31,7 @@ module rof_comp_nuopc
   use globalData            , only : nRoutes                     ! number of active routing methods - for cesm-coupling, limit to one
   use globalData            , only : version
   use init_model_data       , only : get_mpi_omp, init_model
-  use RunoffMod             , only : ctl
+  use RtmVar                , only : ctl
   use RtmMod                , only : route_ini, route_run
   use RtmTimeManager        , only : shr_timeStr
   use RtmVar                , only : cfile_name

--- a/route/build/cpl/nuopc/rof_import_export.F90
+++ b/route/build/cpl/nuopc/rof_import_export.F90
@@ -15,8 +15,7 @@ module rof_import_export
   use globalData      , only : masterproc          !create this  logical variable  in mizuRoute (masterproc=true => master task, false => other tasks
   use globalData      , only : mpicom_route
   use globalData      , only : iTime               ! get step number in mizuRoute
-  use RunoffMod       , only : ctl
-  use RtmVar          , only : nt_rof, rof_tracers
+  use RtmVar          , only : ctl
 
   implicit none
   private ! except
@@ -236,7 +235,6 @@ contains
     integer, intent(out) :: rc
     ! Local variables
     type(ESMF_State) :: importState
-    integer          :: n,nt
     integer          :: nliq, nice
     character(len=*), parameter :: subname='(rof_import_export:import_fields)'
     !---------------------------------------------------------------------------
@@ -249,17 +247,8 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Set tracers
-    nliq = 0
-    nice = 0
-    do nt = 1,nt_rof
-       if (trim(rof_tracers(nt)) == 'LIQ') nliq = nt
-       if (trim(rof_tracers(nt)) == 'ICE') nice = nt
-    enddo
-    if (nliq == 0 .or. nice == 0) then
-       write(iulog,*) trim(subname),': ERROR in rof_tracers LIQ ICE ',nliq,nice,rof_tracers
-       call shr_sys_flush(iulog)
-       call shr_sys_abort()
-    endif
+    nliq = ctl%nt_liq
+    nice = ctl%nt_ice
 
     ! NOTE: Unit of runoff from  state_getimport is kg/m2s (mm/s)
     call state_getimport(importState, 'Flrl_rofsur', begr, endr, output=ctl%qsur(:,nliq), &
@@ -305,7 +294,7 @@ contains
 
     ! Local variables
     type(ESMF_State)  :: exportState
-    integer           :: n,nt
+    integer           :: n
     integer           :: nliq, nice
     real(r8)          :: rofl(begr:endr)
     real(r8)          :: rofi(begr:endr)
@@ -324,17 +313,8 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Set tracers
-    nliq = 0
-    nice = 0
-    do nt = 1,nt_rof
-       if (trim(rof_tracers(nt)) == 'LIQ') nliq = nt
-       if (trim(rof_tracers(nt)) == 'ICE') nice = nt
-    enddo
-    if (nliq == 0 .or. nice == 0) then
-       write(iulog,*) trim(subname),': ERROR in rof_tracers LIQ ICE ',nliq,nice,rof_tracers
-       call shr_sys_flush(iulog)
-       call shr_sys_abort()
-    endif
+    nliq = ctl%nt_liq
+    nice = ctl%nt_ice
 
     if (first_time) then
        if (masterproc) then

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -278,6 +278,12 @@ CONTAINS
   call shr_mpi_bcast(basinID,ierr, cmessage)
   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
+  ! define the number of reaches/hrus on the mainstem
+  nRch_mainstem = rch_per_proc(-1)
+  nHRU_mainstem = hru_per_proc(-1)
+  nRch_trib     = rch_per_proc(pid)
+  nHRU_trib     = hru_per_proc(pid)
+
   ! element-to-element transfer data
   if (trim(runMode)=='cesm-coupling' .and. &
       trim(bypass_routing_option)=='direct_to_outlet') then
@@ -286,12 +292,6 @@ CONTAINS
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
   end if
-
-  ! define the number of reaches/hrus on the mainstem
-  nRch_mainstem = rch_per_proc(-1)
-  nHRU_mainstem = hru_per_proc(-1)
-  nRch_trib     = rch_per_proc(pid)
-  nHRU_trib     = hru_per_proc(pid)
 
   ! ********************************************************************************************************************
   ! process for processor 0 through nNodes (tributary domains)
@@ -2951,10 +2951,10 @@ CONTAINS
    allocate(destIndex_local(nRch_trib))
    allocate(destTask_local(nRch_trib))
 
-   call shr_mpi_scatterV(destIndex, rch_per_proc(root:nNodes-1), destIndex_local, ierr, cmessage)
+   call shr_mpi_scatterV(destIndex(nRch_mainstem+1:nRch_in), rch_per_proc(root:nNodes-1), destIndex_local, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
-   call shr_mpi_scatterV(destTask, rch_per_proc(root:nNodes-1), destTask_local, ierr, cmessage)
+   call shr_mpi_scatterV(destTask(nRch_mainstem+1:nRch_in), rch_per_proc(root:nNodes-1), destTask_local, ierr, cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
    if (masterproc) then ! main task includes mainstems and tributarires
@@ -2964,8 +2964,8 @@ CONTAINS
        commRch(1:nRch_mainstem)%destIndex= destIndex(1:nRch_mainstem)
      end if
      if (nRch_trib > 0) then ! tributary
-       commRch(nRch_mainstem+1:nRch_trib)%destTask  = destTask_local(1:nRch_trib)
-       commRch(nRch_mainstem+1:nRch_trib)%destIndex = destIndex_local(1:nRch_trib)
+       commRch(nRch_mainstem+1:nRch_mainstem+nRch_trib)%destTask  = destTask_local(1:nRch_trib)
+       commRch(nRch_mainstem+1:nRch_mainstem+nRch_trib)%destIndex = destIndex_local(1:nRch_trib)
      end if
    else ! other tasks include only tributary
      allocate(commRch(nRch_trib))


### PR DESCRIPTION
Now, tracer name including liquid and ice are hard coded and not allow to incorporate other constituents (isotopes, DOC etc). This PR code mode to accommodate additional tracer names in the future.

Also, Now ice flux (from CLM snowcap) is passed to the coupler via direct_to_ocean. 

Fix #608 
Fixes #153