### PR TITLE
update default control variables for cesm-coupled mode

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -8,8 +8,7 @@ MODULE RtmMod
                           shr_pio_getrearranger, shr_pio_getioroot, shr_pio_getiosys
   USE shr_kind_mod, ONLY: r8 => shr_kind_r8, CL => SHR_KIND_CL
   USE shr_sys_mod,  ONLY: shr_sys_flush, shr_sys_abort
-  USE RtmVar,       ONLY: ice_runoff, &
-                          river_depth_minimum, &
+  USE RtmVar,       ONLY: river_depth_minimum, &
                           nsrContinue, nsrBranch, nsrStartup, nsrest, &
                           cfile_name, coupling_period, nsub, &
                           caseid, brnch_retain_casename, inst_name, &

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -593,9 +593,9 @@ CONTAINS
       call t_stopf('mizuRoute_htapes')
 
       !-----------------------------------
-      ! Write out mizuRoute restart file
+      ! Write out mizuRoute restart file - write when coupler said so (rstwr==T) and at end of subcycling
       !-----------------------------------
-      if (rstwr) then
+      if (rstwr .and. ns==nsub) then
         call t_startf('mizuRoute_rest')
 
         call restart_output(ierr, cmessage)

--- a/route/build/cpl/RtmVar.F90
+++ b/route/build/cpl/RtmVar.F90
@@ -42,7 +42,6 @@ MODULE RtmVar
   integer,           public            :: rtmhist_ndens  = 1                        ! namelist: output density of netcdf history files
   integer,           public            :: rtmhist_mfilt  = 30                       ! namelist: number of time samples per tape
   integer,           public            :: rtmhist_nhtfrq = 0                        ! namelist: history write freq(0=monthly)
-  logical,           public            :: ice_runoff     = .false.                  ! true => runoff is split into liquid and ice,
   character(len=256),public            :: cfile_name     = 'mizuRoute.control'
   character(len=256),public            :: para_xxxx      = 'mizuRoute_in'
   ! Miscellaneous variables

--- a/route/build/cpl/nuopc/rof_comp_nuopc.F90
+++ b/route/build/cpl/nuopc/rof_comp_nuopc.F90
@@ -463,8 +463,6 @@ contains
 
     call ESMF_TimeGet( stopTime, yy=yy, mm=mm, dd=dd, s=stop_tod, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    ! adjust stopTime for mizuRoute clock
-    stopTime = stopTime - timeStep
     call shr_cal_ymd2date(yy,mm,dd,stop_ymd)
     call shr_timeStr( stopTime, simEnd )
 

--- a/route/build/cpl/nuopc/rof_import_export.F90
+++ b/route/build/cpl/nuopc/rof_import_export.F90
@@ -284,7 +284,7 @@ contains
     !---------------------------------------------------------------------------
 
     ! uses
-    use RtmVar, only : ice_runoff
+    use public_var, only : ice_runoff
 
     ! input/output/variables
     type(ESMF_GridComp)  :: gcomp

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -206,6 +206,7 @@ MODULE public_var
   ! CESM Coupling variables
   character(len=32)    ,public    :: bypass_routing_option = 'direct_in_place' ! bypass routing model method: direct_in_place or direct_to_outlet
   character(len=32)    ,public    :: qgwl_runoff_option    = 'threshold'       ! method for handling qgwl runoff: all, negative, or threshold
-  logical(lgt)         ,public    :: correct_area          = .false.           ! method for handling qgwl runoff: all, negative, or threshold
+  logical(lgt)         ,public    :: correct_area          = .false.           ! .true. => correct area based on differenec between model and coupler areas.
+  logical(lgt)         ,public    :: ice_runoff            = .true.            ! .true. => ice sent to coupler separately from liquid, otherwise combined with liquid
 
 END MODULE public_var

--- a/route/build/src/read_control.f90
+++ b/route/build/src/read_control.f90
@@ -367,7 +367,8 @@ CONTAINS
    ! CESM coupling variables (not used for stand-alone)
    case('<qgwl_runoff_option>'   ); qgwl_runoff_option    = trim(cData)                        ! handling negative qgwl runoff: all, negative, threshold
    case('<bypass_routing_option>'); bypass_routing_option = trim(cData)                        ! routing bypass option: direct_in_place, direct_to_outlet, none
-   case('<correct_area>');          read(cData,*,iostat=io_error) correct_area                 ! logical for area correction between model and coupler areas.
+   case('<correct_area>');          read(cData,*,iostat=io_error) correct_area                 ! logical flag: area correction between model and coupler areas.
+   case('<ice_runoff>');            read(cData,*,iostat=io_error) ice_runoff                   ! logical flag: true => ice sent to coupler separately from liquid, otherwise combined with liquid
 
    ! if not in list then keep going
    case default

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -87,7 +87,8 @@
 !       all: apply all qgwl runoff to bypass_routing, negative: apply only negative runoff, threshold: apply runoff below threshold
 <bypass_routing_option> direct_to_outlet            ! options: direct_in_place, or direct_to_outlet
 <qgwl_runoff_option>    negative                    ! options: all, negative, or threshold
-<correct_area>          F                           ! logical: area correction between model and coupler areas
+<correct_area>          F                           ! T => perform area correction between model and coupler areas
+<ice_runoff>            T                           ! T => ice runoff exported to cpler separately from liquid, otherwise ice is combined with liquid 
 ! ****************************************************************************************************************************
 ! ****************************************************************************************************************************
 ! ****************************************************************************************************************************

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -23,7 +23,7 @@
 <fname_state_in>        STATE_IN_NC                ! input restart netCDF name. remove for run without any particular initial channel states
 <newFileFrequency>      monthly                    ! frequency for new output files (daily, monthly, yearly, single)
 <outputFrequency>       monthly                    ! time frequency used for temporal aggregation of output variables - numeric or daily, monthyly, or yearly
-<dt_qsim>               86400                      ! simulation time interval [sec]
+<dt_qsim>               3600                       ! simulation time interval [sec]
 <continue_run>          F                          ! logical; T-> append output in existing history files. F-> write output in new history file
 <debug>                 F                          ! debug verbosity level; T -> extra log output. F-> normal log output
 ! ****************************************************************************************************************************

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -19,6 +19,7 @@
 <doesBasinRoute>        1                          ! basin routing options   0-> no, 1->gamma-diestribution UH, otherwise error
 <is_flux_wm>            T                          ! switch for water abstraction/injection
 <hw_drain_point>        1                          ! how lateral flow is put into a headwater reach 1-> top of headwater, 2-> bottom of headwater
+<floodplain>            T                          ! logical: floodwater is computed, otherwise, channel is unlimited bank depth
 <fname_state_in>        STATE_IN_NC                ! input restart netCDF name. remove for run without any particular initial channel states
 <newFileFrequency>      monthly                    ! frequency for new output files (daily, monthly, yearly, single)
 <outputFrequency>       monthly                    ! time frequency used for temporal aggregation of output variables - numeric or daily, monthyly, or yearly
@@ -74,15 +75,7 @@
 <instRunoff>            F                          ! intantaneou runoff volume from Local HRUs at reach [L3/T]
 <dlayRunoff>            F                          ! delayed runoff voluem (discharge) from local HRUsi at reach [L3/T] 
 <sumUpstreamRunoff>     F                          ! accumulated total upstream discharge at reach [L3/T]
-<KWTroutedRunoff>       T                          ! kinematic wave tracking routed discharge at reach [L3/T]
-<IRFroutedRunoff>       T                          ! impulse response function routed discharge at reach [L3/T]
-<MCroutedRunoff>        T                          ! kinematic wave routed discharge at reach [L3/T]
-<KWroutedRunoff>        T                          ! muskingum-cunge routed discharge at reach [L3/T]
 <DWroutedRunoff>        T                          ! diffusive wave routed discharge at reach [L3/T]
-<KWTvolume>             T                          ! kinematic wave tracking volume at the end of time step at reach [L3]
-<IRFvolume>             T                          ! impulse response function volume at the end of time step at reach [L3]
-<KWvolume>              T                          ! Euler kinematic wave volume at the end of time step at reach [L3]
-<MCvolume>              T                          ! muskingum-cunge volume at the end of time step at reach [L3]
 <DWvolume>              T                          ! diffusive wave volume at the end of time step at reach [L3]
 ! ****************************************************************************************************************************
 ! cesm-coupler: negative flow (qgwl and excess irrigation demand) handling option
@@ -92,9 +85,9 @@
 !       direct_to_outlet: send negative HRU runoff directly to the basin outlet (ocean or endoheic lake) and putting it into the outlet reach.
 !       <qgwl_runoff_option> is options for handling qgwl runoff from CLM.
 !       all: apply all qgwl runoff to bypass_routing, negative: apply only negative runoff, threshold: apply runoff below threshold
-<bypass_routing_option> direct_in_place            ! options: direct_in_place, or direct_to_outlet
-<qgwl_runoff_option>    threshold                  ! options: all, negative, or threshold
-<correct_area>          F                          ! logical: area correction between model and coupler areas
+<bypass_routing_option> direct_to_outlet            ! options: direct_in_place, or direct_to_outlet
+<qgwl_runoff_option>    negative                    ! options: all, negative, or threshold
+<correct_area>          F                           ! logical: area correction between model and coupler areas
 ! ****************************************************************************************************************************
 ! ****************************************************************************************************************************
 ! ****************************************************************************************************************************


### PR DESCRIPTION
Update default setup for cesm/ctsm coupled mode to the current default MOSART setup.

The following changes:

- `bypass_routing` to "direct_to_outlet"
- `qgwl_runoff_option` to "negative" (this is active if `bypass_routing` is switched to "direct_in_place")
- `ice_runoff` to True
- `dt_qsim` to 3600 

`correct_area` is False now (it is True for MOSART) because this works properly for 0.5 degree grid for mizuRoute.

resolved #616