### PR TITLE
Flood volume correction

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -437,7 +437,8 @@ CONTAINS
     !  2. direct_to_outlet: send negative flow to an outlet of the reach and subtract the flow from the outlet reach
     call t_startf('mizuRoute_bypass_route')
 
-    allocate(qSend(ctl%lnumr), source=0._r8)
+    allocate(qSend(ctl%lnumr))
+    qSend = 0._r8
 
     select case(trim(bypass_routing_option))
       case('direct_in_place')

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -463,19 +463,29 @@ CONTAINS
               ctl%qgwl(nr,nt_liq) = 0._r8
             end if
           end if
-          ! --- Transfer qsub to ocean [mm/s]
+          ! --- Transfer negative qsub to ocean [mm/s]
           if(ctl%qsub(nr,nt_liq) < 0._r8) then
             ctl%direct(nr,nt_liq) = ctl%direct(nr,nt_liq)+ ctl%qsub(nr,nt_liq)
             ctl%qsub(nr,nt_liq) = 0._r8
           endif
+          ! --- Transfer negative qsur to ocean [mm/s]
+          if(ctl%qsur(nr,nt_liq) < 0._r8) then
+            ctl%direct(nr,nt_liq) = ctl%direct(nr,nt_liq)+ ctl%qsur(nr,nt_liq)
+            ctl%qsur(nr,nt_liq) = 0._r8
+          endif
         end do
       case('direct_to_outlet')
-        allocate(qSend(ctl%lnumr))
-        qSend(:) = 0._r8     ! total negative q [mm/s] to be sent to the outlet (converted to +)
+        ! total negative q [mm/s] to be sent to the outlet (converted to +)
+        allocate(qSend(ctl%lnumr), source=0._r8)
         do nr = ctl%begr,ctl%endr
-          if(ctl%qgwl(nr,nt_liq) < 0._r8) then
+          if (trim(qgwl_runoff_option) == 'all') then ! send all qgwl flow to ocean
             qSend(nr) = ctl%qgwl(nr,nt_liq)
             ctl%qgwl(nr,nt_liq) = 0._r8
+          else if (trim(qgwl_runoff_option) == 'negative') then
+            if(ctl%qgwl(nr,nt_liq) < 0._r8) then
+              qSend(nr) = ctl%qgwl(nr,nt_liq)
+              ctl%qgwl(nr,nt_liq) = 0._r8
+            end if
           end if
           if(ctl%qsub(nr,nt_liq) < 0._r8) then
             qSend(nr) = qSend(nr) + ctl%qsub(nr,nt_liq)

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -389,7 +389,9 @@ CONTAINS
     flush(iulog)
 
     associate(nt_liq => ctl%nt_liq, &
-              nt_ice => ctl%nt_ice)
+              nt_ice => ctl%nt_ice, &
+              begr => ctl%begr, &
+              endr => ctl%endr)
 
     !-------------------------------------------------------
     ! Initialize mizuRoute history handler and fields
@@ -435,20 +437,22 @@ CONTAINS
     !  2. direct_to_outlet: send negative flow to an outlet of the reach and subtract the flow from the outlet reach
     call t_startf('mizuRoute_bypass_route')
 
+    allocate(qSend(ctl%lnumr), source=0._r8)
+
     select case(trim(bypass_routing_option))
       case('direct_in_place')
         ctl%direct = 0._r8
-        do nr = ctl%begr,ctl%endr
-          ! --- Transfer qgwl [mm/s] to ocean
-          if (trim(qgwl_runoff_option) == 'all') then ! send all qgwl flow to ocean
-            ctl%direct(nr,nt_liq) = ctl%qgwl(nr,nt_liq)
-            ctl%qgwl(nr,nt_liq) = 0._r8
-          else if (trim(qgwl_runoff_option) == 'negative') then ! send only negative qgwl flow to ocean
-            if(ctl%qgwl(nr,nt_liq) < 0._r8) then
-              ctl%direct(nr,nt_liq) = ctl%qgwl(nr,nt_liq)
-              ctl%qgwl(nr,nt_liq) = 0._r8
-            endif
-          else if (trim(qgwl_runoff_option) == 'threshold') then
+        ! --- Transfer qgwl [mm/s] to ocean
+        if (trim(qgwl_runoff_option) == 'all') then ! send all qgwl flow to ocean
+          ctl%direct(begr:endr, nt_liq) = ctl%direct(begr:endr, nt_liq) + ctl%qgwl(begr:endr, nt_liq)
+          ctl%qgwl(begr:endr, nt_liq) = 0._r8
+        else if (trim(qgwl_runoff_option) == 'negative') then ! send only negative qgwl flow to ocean
+          where (ctl%qgwl(begr:endr, nt_liq) < 0._r8)
+            ctl%direct(begr:endr, nt_liq) = ctl%direct(begr:endr, nt_liq) + ctl%qgwl(begr:endr, nt_liq)
+            ctl%qgwl(begr:endr, nt_liq) = 0._r8
+          end where
+        else if (trim(qgwl_runoff_option) == 'threshold') then
+          do nr = begr,endr
             ! if qgwl is negative, and adding it to the main channel
             ! would bring main channel storage below a threshold,
             ! send qgwl directly to ocean
@@ -462,36 +466,38 @@ CONTAINS
               ctl%direct(nr,nt_liq) = ctl%qgwl(nr,nt_liq)
               ctl%qgwl(nr,nt_liq) = 0._r8
             end if
-          end if
-          ! --- Transfer negative qsub to ocean [mm/s]
-          if(ctl%qsub(nr,nt_liq) < 0._r8) then
-            ctl%direct(nr,nt_liq) = ctl%direct(nr,nt_liq)+ ctl%qsub(nr,nt_liq)
-            ctl%qsub(nr,nt_liq) = 0._r8
-          endif
-          ! --- Transfer negative qsur to ocean [mm/s]
-          if(ctl%qsur(nr,nt_liq) < 0._r8) then
-            ctl%direct(nr,nt_liq) = ctl%direct(nr,nt_liq)+ ctl%qsur(nr,nt_liq)
-            ctl%qsur(nr,nt_liq) = 0._r8
-          endif
-        end do
+          end do
+        end if
+        ! --- Transfer negative qsub to ocean [mm/s]
+        where (ctl%qsub(begr:endr, nt_liq) < 0._r8)
+          ctl%direct(begr:endr, nt_liq) = ctl%direct(begr:endr, nt_liq) + ctl%qsub(begr:endr, nt_liq)
+          ctl%qsub(begr:endr, nt_liq) = 0._r8
+        end where
+
+        ! --- Transfer negative qsur to ocean [mm/s]
+        where (ctl%qsur(begr:endr, nt_liq) < 0._r8)
+          ctl%direct(begr:endr, nt_liq) = ctl%direct(begr:endr, nt_liq) + ctl%qsur(begr:endr, nt_liq)
+          ctl%qsur(begr:endr, nt_liq) = 0._r8
+        end where
+
       case('direct_to_outlet')
-        ! total negative q [mm/s] to be sent to the outlet (converted to +)
-        allocate(qSend(ctl%lnumr), source=0._r8)
-        do nr = ctl%begr,ctl%endr
-          if (trim(qgwl_runoff_option) == 'all') then ! send all qgwl flow to ocean
-            qSend(nr) = ctl%qgwl(nr,nt_liq)
-            ctl%qgwl(nr,nt_liq) = 0._r8
-          else if (trim(qgwl_runoff_option) == 'negative') then
-            if(ctl%qgwl(nr,nt_liq) < 0._r8) then
-              qSend(nr) = ctl%qgwl(nr,nt_liq)
-              ctl%qgwl(nr,nt_liq) = 0._r8
-            end if
-          end if
-          if(ctl%qsub(nr,nt_liq) < 0._r8) then
-            qSend(nr) = qSend(nr) + ctl%qsub(nr,nt_liq)
-            ctl%qsub(nr,nt_liq) = 0._r8
-          end if
-        end do
+        ! ----  qgwl [mm/s]
+        select case(trim(qgwl_runoff_option))
+          case('all') ! send all qgwl flow to the outlet
+            qSend(begr:endr) = qSend(begr:endr) + ctl%qgwl(begr:endr, nt_liq)
+            ctl%qgwl(begr:endr, nt_liq) = 0._r8
+          case('negative') ! send negative qgwl flow to the outlet
+            where (ctl%qgwl(begr:endr, nt_liq) < 0._r8)
+              qSend(begr:endr) = qSend(begr:endr) + ctl%qgwl(begr:endr, nt_liq)
+              ctl%qgwl(begr:endr, nt_liq) = 0._r8
+            end where
+          case default; call shr_sys_abort(trim(subname)//'unexpected qgwl_runoff_option for direct_to_outlet')
+        end select
+        ! ---- qsub [mm/s]
+        where (ctl%qsub(begr:endr, nt_liq) < 0._r8)
+          qSend(begr:endr) = qSend(begr:endr) + ctl%qsub(begr:endr, nt_liq)
+          ctl%qsub(begr:endr, nt_liq) = 0._r8
+        end where
 
         ! Distribute "direct runoff to ocean" to targe reach (i.e., outlet of river network)
         call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct(:,nt_liq), fillvalue=0._r8)
@@ -505,10 +511,8 @@ CONTAINS
 
     call t_startf('mizuRoute_direct_to_outlet_land_ice')
 
-    qSend(:) = 0._r8     ! total negative q [mm/s] to be sent to the outlet (converted to +)
-    do nr = ctl%begr,ctl%endr
-      qSend(nr) = ctl%qsur(nr,nt_ice) + ctl%qsub(nr,nt_ice) + ctl%qgwl(nr,nt_ice)
-    end do
+    qSend(:) = 0._r8
+    qSend(begr:endr) = qSend(begr:endr) + ctl%qsur(begr:endr, nt_ice) + ctl%qsub(begr:endr, nt_ice) + ctl%qgwl(begr:endr, nt_ice)
 
     ! Distribute "direct runoff to ocean" to targe reach (i.e., outlet of river network)
     call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct(:,nt_ice), fillvalue=0._r8)

--- a/route/build/cpl/nuopc/rof_import_export.F90
+++ b/route/build/cpl/nuopc/rof_import_export.F90
@@ -346,7 +346,7 @@ contains
     ! Flooding back to land, sign convention is positive in land->rof direction
     ! so if water is sent from rof to land, the flux must be negative.
     do n = begr, endr
-       flood(n)   =  ctl%flood(n) ! floodplain volume per HRU area [mm/s]
+       flood(n)   =  -1._r8*ctl%flood(n) ! floodplain volume per HRU area [mm/s]
        volr(n)    =  ctl%volr(n)  ! volume (channel+floodplain) per HRU area [m]
        volrmch(n) =  ctl%volr(n)  ! volume per HRU area [m]
     end do

--- a/route/build/src/mpi_process.f90
+++ b/route/build/src/mpi_process.f90
@@ -725,6 +725,8 @@ CONTAINS
   USE globalData, ONLY: nTribOutlet      !
   USE globalData, ONLY: ixRch_order      ! global reach index in the order of proc assignment (size = total number of reaches in the entire network)
   USE globalData, ONLY: global_ix_comm   ! global reach index at tributary reach outlets to mainstem (size = sum of tributary outlets within entire network)
+  USE globalData, ONLY: NETOPO_trib      ! tributary reach parameter structure
+  USE globalData, ONLY: NETOPO_main      ! mainstem reach parameter structure
   USE globalData, ONLY: RPARAM_trib      ! tributary reach parameter structure
   USE globalData, ONLY: RPARAM_main      ! mainstem reach parameter structure
   USE globalData, ONLY: RCHFLX_trib      ! tributary reach flux structure
@@ -977,6 +979,7 @@ CONTAINS
       if (nRch_mainstem>0) then ! populate flood volume (NOTE channel volume is already populated) for mainstem
         do iSeg = 1, nRch_mainstem
           RCHFLX_trib(iSeg)%ROUTE(idxDW)%FLOOD_VOL(1) = 0._dp
+          if (is_lake_sim .and. NETOPO_main(iSeg)%isLake) cycle ! if lake keep 0 for flood_vol
           if (RCHFLX_trib(iSeg)%ROUTE(idxDW)%REACH_VOL(1) > RPARAM_main(iSeg)%R_STORAGE) then
             RCHFLX_trib(iSeg)%ROUTE(idxDW)%FLOOD_VOL(1) = RCHFLX_trib(iSeg)%ROUTE(idxDW)%REACH_VOL(1) - RPARAM_main(iSeg)%R_STORAGE
           end if
@@ -986,6 +989,7 @@ CONTAINS
         RCHFLX_trib(nRch_mainstem+nTribOutlet+iSeg)%ROUTE(idxDW)%REACH_VOL(1) = vol_local(iSeg)
         ! populate flood volume
         RCHFLX_trib(nRch_mainstem+nTribOutlet+iSeg)%ROUTE(idxDW)%FLOOD_VOL(1) = 0._dp
+        if (is_lake_sim .and. NETOPO_trib(iSeg)%isLake) cycle ! if lake keep 0 for flood_vol
         if (vol_local(iSeg) > RPARAM_trib(iSeg)%R_STORAGE) then
           RCHFLX_trib(nRch_mainstem+nTribOutlet+iSeg)%ROUTE(idxDW)%FLOOD_VOL(1) = vol_local(iSeg)-RPARAM_trib(iSeg)%R_STORAGE
         end if
@@ -995,6 +999,7 @@ CONTAINS
         RCHFLX_trib(iSeg)%ROUTE(idxDW)%REACH_VOL(1) = vol_local(iSeg)
         ! populate flood volume
         RCHFLX_trib(iSeg)%ROUTE(idxDW)%FLOOD_VOL(1) = 0._dp
+        if (is_lake_sim .and. NETOPO_trib(iSeg)%isLake) cycle ! if lake keep 0 for flood_vol
         if (vol_local(iSeg) > RPARAM_trib(iSeg)%R_STORAGE) then
           RCHFLX_trib(iSeg)%ROUTE(idxDW)%FLOOD_VOL(1) =  vol_local(iSeg)-RPARAM_trib(iSeg)%R_STORAGE
         end if

--- a/route/build/src/public_var.f90
+++ b/route/build/src/public_var.f90
@@ -29,7 +29,7 @@ MODULE public_var
   real(dp),    parameter,public   :: verySmall=tiny(1.0_dp) ! a very small number
   real(dp),    parameter,public   :: min_slope=1.e-6_dp     ! minimum slope
   real(dp),    parameter,public   :: negRunoffTol=-1.e-3_dp ! nagative runoff tolerance
-  real(dp),    parameter,public   :: lakeWBtol=1.e-3_dp     ! lake water balance tolerance
+  real(dp),    parameter,public   :: lakeWBtol=2.e-2_dp     ! lake water balance tolerance
   real(dp),    parameter,public   :: negVolTol=-1.0e-50_dp  ! negative channel volume tolerance
 
   ! routing related constants

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -19,7 +19,7 @@
 <doesBasinRoute>        1                          ! basin routing options   0-> no, 1->gamma-diestribution UH, otherwise error
 <is_flux_wm>            T                          ! switch for water abstraction/injection
 <hw_drain_point>        1                          ! how lateral flow is put into a headwater reach 1-> top of headwater, 2-> bottom of headwater
-<floodplain>            T                          ! logical: floodwater is computed, otherwise, channel is unlimited bank depth
+<floodplain>            F                          ! logical: floodwater is computed, otherwise, channel is unlimited bank depth
 <fname_state_in>        STATE_IN_NC                ! input restart netCDF name. remove for run without any particular initial channel states
 <newFileFrequency>      monthly                    ! frequency for new output files (daily, monthly, yearly, single)
 <outputFrequency>       monthly                    ! time frequency used for temporal aggregation of output variables - numeric or daily, monthyly, or yearly


### PR DESCRIPTION
flood volume was initialized correctly when doing restart when lake is turned on. This happen even when floodplain is off. This does not affect discharge and storage in channel.  

Also, instead of looping through array elements, use where statement to detect negative flow and move them to `direct` array. This seems to be more efficient. 

Turned off floodplain for default as the flood in MOSART is also off.  Made the sign of the flood exported to the coupler negative (as MOSART does), but unclear why