### PR TITLE
change how restart file is specified

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -236,7 +236,7 @@ def _create_control_files(case, caseroot, srcroot, confdir, inst_string, infile,
                 filename = "%s.mizuroute.r.%s-%s.nc" %(run_refcase, run_refdate, run_tod)
 
             fname_state_in = filename
-         else:
+        else:
             fname_state_in = "empty"
 
     ctl.set( "fname_state_in", fname_state_in )

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -225,20 +225,18 @@ def _create_control_files(case, caseroot, srcroot, confdir, inst_string, infile,
     #----------------------------------------------------
 
     fname_state_in = ctl.get("fname_state_in")
-    if run_type == 'branch' or run_type == 'hybrid':
-        run_refcase = case.get_value("RUN_REFCASE")
-        run_refdate = case.get_value("RUN_REFDATE")
-        run_tod = case.get_value("RUN_REFTOD")
-        filename = "%s.mizuroute%s.r.%s-%s.nc" %(run_refcase, inst_string, run_refdate, run_tod)
-        if not os.path.exists(os.path.join(rundir, filename)):
-            filename = "%s.mizuroute.r.%s-%s.nc" %(run_refcase, run_refdate, run_tod)
 
-        fname_state_in = filename
+    if fname_state_in.strip() == '' or fname_state_in.strip() == 'STATE_IN_NC':
+        if run_type == 'branch' or run_type == 'hybrid':
+            run_refcase = case.get_value("RUN_REFCASE")
+            run_refdate = case.get_value("RUN_REFDATE")
+            run_tod = case.get_value("RUN_REFTOD")
+            filename = "%s.mizuroute%s.r.%s-%s.nc" %(run_refcase, inst_string, run_refdate, run_tod)
+            if not os.path.exists(os.path.join(rundir, filename)):
+                filename = "%s.mizuroute.r.%s-%s.nc" %(run_refcase, run_refdate, run_tod)
 
-    elif fname_state_in.strip() == '':
-        fname_state_in = "empty"
-    else:
-        if ctl.get('fname_state_in') == 'STATE_IN_NC':
+            fname_state_in = filename
+         else:
             fname_state_in = "empty"
 
     ctl.set( "fname_state_in", fname_state_in )

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -223,7 +223,7 @@ def _create_control_files(case, caseroot, srcroot, confdir, inst_string, infile,
     #----------------------------------------------------
     # Set the restart file depending on start type
     #----------------------------------------------------
-
+    # The default value is set in $CESMROOT/components/mizuRoute/route/settings/SAMPLE-coupled.control 
     fname_state_in = ctl.get("fname_state_in")
 
     if fname_state_in.strip() == '' or fname_state_in.strip() == 'STATE_IN_NC':
@@ -236,14 +236,14 @@ def _create_control_files(case, caseroot, srcroot, confdir, inst_string, infile,
                 filename = "%s.mizuroute.r.%s-%s.nc" %(run_refcase, run_refdate, run_tod)
 
             fname_state_in = filename
-        else:
+        else: # for startup run type
             fname_state_in = "empty"
 
     ctl.set( "fname_state_in", fname_state_in )
     # Check that the restart file exists and if not see if it can be found in the run directory
     if fname_state_in is not "empty":
-        if not os.path.exists(fname_state_in):
-            nmlgen.set_value( "fname_state_in", value=os.path.join( rundir, fname_state_in ) )
+        if not os.path.exists(os.path.join( rundir, fname_state_in )):
+            nmlgen.set_value( "fname_state_in", value=os.path.join(rundir, fname_state_in) )
             expect(os.path.exists(fname_state_in), "mizuRoute restart file does NOT exist: "+fname_state_in)
 
     # Read in the user control file for the case and change settings to it

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -240,8 +240,11 @@ def _create_control_files(case, caseroot, srcroot, confdir, inst_string, infile,
             fname_state_in = "empty"
 
     ctl.set( "fname_state_in", fname_state_in )
+    # Check that the restart file exists and if not see if it can be found in the run directory
     if fname_state_in is not "empty":
-        nmlgen.set_value( "fname_state_in", value=os.path.join( ancil_dir, fname_ntopOld ) )
+        if not os.path.exists(fname_state_in):
+            nmlgen.set_value( "fname_state_in", value=os.path.join( rundir, fname_state_in ) )
+            expect(os.path.exists(fname_state_in), "mizuRoute restart file does NOT exist: "+fname_state_in)
 
     # Read in the user control file for the case and change settings to it
     file_src = "user_nl_mizuroute_control"

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -32,7 +32,6 @@
 <ancil_dir>             ANCIL_DIR                  ! directory containing ancillary data (river network data)
 <input_dir>             INPUT_DIR                  ! directory containing input data
 <output_dir>            OUTPUT_DIR                 ! directory containing output data
-<restart_dir>           RESTART_DIR                ! directory containing restart netCDF
 ! ****************************************************************************************************************************
 ! DEFINE FINE NAME AND DIMENSIONS
 ! ---------------------------------------

--- a/route/settings/SAMPLE-coupled.control
+++ b/route/settings/SAMPLE-coupled.control
@@ -32,6 +32,7 @@
 <ancil_dir>             ANCIL_DIR                  ! directory containing ancillary data (river network data)
 <input_dir>             INPUT_DIR                  ! directory containing input data
 <output_dir>            OUTPUT_DIR                 ! directory containing output data
+<restart_dir>           RESTART_DIR                ! directory containing restart netCDF
 ! ****************************************************************************************************************************
 ! DEFINE FINE NAME AND DIMENSIONS
 ! ---------------------------------------


### PR DESCRIPTION
Here is how restart file setup works after this PR.

1. get `fname_state_in`
2. if `fname_state_in` in control file is 'STATE_IN_NC' **AND** cesm/ctsm run type is `branch` or `hybrid`, construct restart file based on `RUN_REFCASE` and `RUN_REFDATE`, `RUN_REFTOD` and set the constructed name to `fname_state_in`.
3. if `fname_state_in` in control file is 'STATE_IN_NC' only, set "empty" to `fname_state_in`. (so cold start)
4. neither 2 nor 3 == something other than "empty",  trust user put a valid restart file name in control file. if not, mizuRoute will complains. 

resolve #621
resolve #641 