### PR TITLE
Cleanups and mapping correction fixed

### DIFF
--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -129,7 +129,8 @@ ifeq "$(FC)" "nvidia"
     FLAGS = -fast -O3 -Mdclchk $(FLAGS_OMP) -cpp -DVERSION=\"$(VERSION)\" -DBRANCH=\"$(GITBRCH)\" -DHASH=\"$(GITHASH)\"
   endif
   ifeq "$(MODE)" "debug"
-    FLAGS = -g -traceback -Mbounds -Mlist -Minfo -Mdclchk $(FLAGS_OMP) -cpp -DVERSION=\"$(VERSION)\" -DBRANCH=\"$(GITBRCH)\" -DHASH=\"$(GITHASH)\"
+    FLAGS = -g -O0 $(FLAGS_OMP) -traceback -Mbounds -Mdclchk -Mchkptr -Mchkstk -Ktrap=divz,inv,ovf $(FLAGS_OMP) -cpp -DVERSION=\"$(VERSION)\" -DBRANCH=\"$(GITBRCH)\" -DHASH=\"$(GITHASH)\"
+
   endif
 endif
 

--- a/route/build/src/advection_diffusion.f90
+++ b/route/build/src/advection_diffusion.f90
@@ -197,25 +197,21 @@ CONTAINS
     real(dp),      intent(inout)  :: T(NX)
     ! Local variables
     integer(i4b)                  :: ix
-    real(dp)                      :: U(NX)
     real(dp)                      :: D(NX)
-    real(dp)                      :: L(NX)
     real(dp)                      :: b1(NX)
     real(dp)                      :: coef
 
-    U(1:NX) = MAT(1:NX,1)
     D(1:NX) = MAT(1:NX,2)
-    L(1:NX) = MAT(1:NX,3)
     b1(1:NX) = b(1:NX)
     do ix = 2, NX
-      coef  = L(ix-1)/D(ix-1)
-      D(ix) = D(ix)-coef*U(ix)
+      coef  = MAT(ix-1,3)/D(ix-1)
+      D(ix) = D(ix)-coef*MAT(ix,1)
       b1(ix) = b1(ix)-coef*b1(ix-1)
     end do
 
     T(NX) = b1(NX)/D(NX) ! Starts the countdown of answers
     do ix = NX-1, 1, -1
-        T(ix) = (b1(ix) - U(ix+1)*T(ix+1))/D(ix)
+        T(ix) = (b1(ix) - MAT(ix+1,1)*T(ix+1))/D(ix)
     end do
 
   END SUBROUTINE TDMA

--- a/route/build/src/dataTypes.f90
+++ b/route/build/src/dataTypes.f90
@@ -193,11 +193,12 @@ implicit none
   real(dp)                                   :: BASAREA        ! local basin area
   real(dp)                                   :: TOTAREA        ! UPSAREA + BASAREA
   real(dp)                                   :: MINFLOW        ! minimum environmental flow
+  ! lake - natural lake: Doll 2003 parameters
   real(dp)                                   :: D03_MaxStorage ! Doll 2003; maximume storage [m3]
   real(dp)                                   :: D03_Coefficient! Doll 2003; Coefficient [?]
   real(dp)                                   :: D03_Power      ! Doll 2003; Power [-]
   real(dp)                                   :: D03_S0         ! Doll 2003; Additional parameter to represent inactive storage
-
+  ! lake - managed lake: HYP parameters
   real(dp)                                   :: HYP_E_emr      ! HYPE; elevation of emergency spillway [m]
   real(dp)                                   :: HYP_E_lim      ! HYPE; elevation below which primary spillway flow is restrcited [m]
   real(dp)                                   :: HYP_E_min      ! HYPE; elevation below which outflow is zero [m]
@@ -210,7 +211,7 @@ implicit none
   logical(lgt)                               :: HYP_prim_F     ! HYPE; if the reservoir has a primary spillway then set to 1 otherwise 0
   real(dp)                                   :: HYP_A_avg      ! HYPE; average area for the lake; this might not be used if bathymetry is provided [m]
   logical(lgt)                               :: HYP_Qsim_mode  ! HYPE; the outflow is sum of emergency and primary spillways if 1, otherwise the maximum
-
+  ! lake - managed lake: Hanasaki 2006 parameters
   real(dp)                                   :: H06_Smax       ! Hanasaki 2006; maximume reservoir storage [m3]
   real(dp)                                   :: H06_alpha      ! Hanasaki 2006; fraction of active storage compared to total storage [-]
   real(dp)                                   :: H06_envfact    ! Hanasaki 2006; fraction of inflow that can be used to meet demand [-]
@@ -269,11 +270,6 @@ implicit none
   character(len=32),dimension(:),allocatable :: pfafCode     ! pfafstetter code
   integer(i4b)                               :: RHORDER      ! Processing sequence
   real(dp)    ,dimension(:),allocatable      :: UH           ! Unit hydrograph for upstream
-!  integer(i4b)                               :: LAKE_IX      ! Lake index (1,2,...,nlak)
-!  integer(i4b)                               :: LAKE_ID      ! Lake ID (REC code)
-!  real(dp)                                   :: BASULAK      ! Area of basin under lake
-!  real(dp)                                   :: RCHULAK      ! Length of reach under lake
-!  logical(lgt)                               :: USRTAKE      ! .TRUE. if user takes from reach, .FALSE. otherwise
   logical(lgt)                               :: LAKINLT      ! .TRUE. if reach is lake inlet, .FALSE. otherwise
   logical(lgt)                               :: ISLAKE       ! .TRUE. if the object is a lake
   logical(lgt)                               :: LAKETARGVOL  ! .TRUE. if the lake follow a given target volume
@@ -383,7 +379,7 @@ implicit none
  ! ---------- lake data types -----------------------------------------------------------------
 
  ! Lake Parameters
- TYPE, public :: LAKPRP
+ type, public :: LAKPRP
   real(dp)                             :: AREAREF            ! lake area
   real(dp)                             :: LAKREFLEV          ! lake elevation
   real(dp)                             :: LAKAVGLEV          ! lake average level (for initialization)
@@ -396,10 +392,10 @@ implicit none
   real(dp)                             :: DSCHSPL            ! discharge at spillway height
   real(dp)                             :: RATECVA            ! discharge rating curve parameter
   real(dp)                             :: RATECVB            ! discharge rating curve parameter
- END TYPE LAKPRP
+ end type LAKPRP
 
  ! Lake topology
- TYPE, public :: LAKTOPO
+ type, public :: LAKTOPO
   integer(i4b)                         :: LAKE_IX           ! Lake index (1,2,...,nlak)
   integer(i4b)                         :: LAKE_ID           ! Lake ID (REC code)
   real(dp)                             :: LAKLAT1           ! Centroid latitude
@@ -410,16 +406,16 @@ implicit none
   integer(i4b)                         :: DREACHK           ! Downstream reach ID
   integer(i4b)                         :: DLAKE_I           ! Downstream lake index
   integer(i4b)                         :: DLAKE_K           ! Downstream lake ID
- END TYPE LAKTOPO
+ end type LAKTOPO
 
  ! Lake fluxes
- TYPE, public :: LKFLX
+ type, public :: LKFLX
   real(dp)                             :: LAKE_Qav          ! lake discharge (average over time step) (m3 s-1)
   real(dp)                             :: LAKE_Q            ! lake discharge (instantaneous) (m3 s-1)
   real(dp)                             :: LAKE_P            ! lake precipitation (m3)
   real(dp)                             :: LAKE_E            ! lake evaporation (m3)
   real(dp)                             :: LAKE_I            ! inflow to lake (m3 s-1)
- END TYPE LKFLX
+ end type LKFLX
 
 END MODULE dataTypes
 

--- a/route/build/src/main_route.f90
+++ b/route/build/src/main_route.f90
@@ -246,6 +246,12 @@ CONTAINS
 
    ! 3. subroutine: river reach routing
    do ix=1,size(routeMethods)
+     if (.not. allocated(rch_routes(ix)%rch_route)) then
+       ierr=20
+       write(cmessage,'(A,I0)') 'routing object is not allocated for routeMethods index ', ix
+       message=trim(message)//trim(cmessage)
+       return
+     end if
      call route_network(rch_routes(ix)%rch_route, &  ! input: instantiated routing object
                         routeMethods(ix),         &  ! input: routing method index
                         river_basin,              &  ! input: river basin data type
@@ -290,7 +296,7 @@ CONTAINS
 
     implicit none
     ! Argument variables
-    class(base_route_rch), intent(in),    allocatable :: rch_route
+    class(base_route_rch), intent(in)                 :: rch_route
     integer(i4b),          intent(in)                 :: idRoute              ! routing method id
     type(subbasin_omp),    intent(in),    allocatable :: river_basin(:)       ! river basin information (mainstem, tributary outlet etc.)
     real(dp),              intent(in)                 :: T0,T1                ! start and end of the time step (seconds)
@@ -359,6 +365,7 @@ CONTAINS
 !$OMP          shared(RPARAM_in)                        & ! data structure shared
 !$OMP          shared(RCHSTA_out)                       & ! data structure shared
 !$OMP          shared(RCHFLX_out)                       & ! data structure shared
+!$OMP          shared(rch_route)                        & ! routing object shared
 !$OMP          shared(ix,idxRoute)                      & ! indices shared
 !$OMP          firstprivate(nTrib)
       do iTrib = 1,nTrib

--- a/route/build/src/standalone/read_remap.f90
+++ b/route/build/src/standalone/read_remap.f90
@@ -101,13 +101,15 @@ CONTAINS
  ! local variables
  integer(i4b)                       :: ix,jx             ! index of variables
  integer(i4b), allocatable          :: idxZero(:)        ! indices where array variables are zero
+ integer(i4b), allocatable          :: temp_num_qhru(:)  ! local array that holds # of overlapping HRUs for each river network hru
  integer(i4b)                       :: nHRU_map          ! number of HRU in mapping files (this should match up with river network hru)
  integer(i4b)                       :: nData             ! number of data (weight, runoff hru id) in mapping files
  integer(i4b)                       :: total_intersects  ! sum of intersected hydrologic model hrus over the entire routing HRUs
  integer(i4b)                       :: nZero             ! number of array variables with zero
  logical(lgt), allocatable          :: logical_array(:)  !
  real(dp),     allocatable          :: real_array(:)     !
- integer(i8b), allocatable          :: int_array(:)      !
+ integer(i4b), allocatable          :: int4_array(:)      !
+ integer(i8b), allocatable          :: int8_array(:)      !
 
  ierr=0; message='check_remap_data/'
 
@@ -126,43 +128,42 @@ CONTAINS
    write(iulog,'(3a)') ' Correct ',trim(dname_data_remap), &
                      & ' dimension variables at routing HRUs without any interesected hydrologic model hrus'
 
-   nZero=count(remap_data_in%num_qhru==0)
+   ! If there is river network hrus without any overlapping hydrologic model hrus,
+   ! num_qhru=0 and also correcpoinding data-dimension varialbes=0 (that is why sum of num_qhru != data dimension size
+   ! Thefore, need to remove 0 data-dimension variables
+
+   nZero=count(remap_data_in%num_qhru==0) ! number of elements in num_qhru with 0 values
 
    allocate(logical_array(nData))
    logical_array = .true.
 
+   ! To locate index of data-dimension variable to be removed, just need to change 0 to 1 in num_qhru (using temp_num_qhru)
+   allocate(temp_num_qhru, source=remap_data_in%num_qhru)
+   where (temp_num_qhru==0) temp_num_qhru=1
+
    if (nZero>0) then
-     allocate(idxZero(nZero))
-     idxZero = pack(arth(1,1,nHRU_map), remap_data_in%num_qhru==0)
+     idxZero = pack(arth(1,1,nHRU_map), remap_data_in%num_qhru==0) ! indxex in num_qhru with 0
+     ! turn false (no keeping this element) at index of data-dimension for corresponding river network hru with 0 num_qhru
      do ix = 1,nZero
-       jx = sum(remap_data_in%num_qhru(1:idxZero(ix)))+1
+       jx = sum(temp_num_qhru(1:idxZero(ix)))
        logical_array(jx) = .false.
      end do
 
-     allocate(real_array(total_intersects), int_array(total_intersects))
-     if (allocated(remap_data_in%qhru_id)) then
+     if (allocated(remap_data_in%weight)) then
        real_array = pack(remap_data_in%weight, logical_array)
-       deallocate(remap_data_in%weight)
-       allocate(remap_data_in%weight(total_intersects))
-       remap_data_in%weight = real_array
+       call move_alloc(real_array, remap_data_in%weight)
      end if
      if (allocated(remap_data_in%qhru_id)) then
-       int_array = pack(remap_data_in%qhru_id, logical_array)
-       deallocate(remap_data_in%qhru_id)
-       allocate(remap_data_in%qhru_id(total_intersects))
-       remap_data_in%qhru_id = int_array
+       int8_array = pack(remap_data_in%qhru_id, logical_array)
+       call move_alloc(int8_array, remap_data_in%qhru_id)
      end if
      if (allocated(remap_data_in%i_index)) then
-       int_array = pack(remap_data_in%i_index, logical_array)
-       deallocate(remap_data_in%i_index)
-       allocate(remap_data_in%i_index(total_intersects))
-       remap_data_in%i_index = int_array
+       int4_array = pack(remap_data_in%i_index, logical_array)
+       call move_alloc(int4_array, remap_data_in%i_index)
      end if
      if (allocated(remap_data_in%j_index)) then
-       int_array = pack(remap_data_in%j_index, logical_array)
-       deallocate(remap_data_in%j_index)
-       allocate(remap_data_in%j_index(total_intersects))
-       remap_data_in%j_index = int_array
+       int4_array = pack(remap_data_in%j_index, logical_array)
+       call move_alloc(int4_array, remap_data_in%j_index)
      end if
    end if
  end if


### PR DESCRIPTION
**Clean ups, bugfix on mapping correction, nvidia compiler**

Fixing standalone mapping netCDF: 

**Background** If the dimension size of `data` (dimension of 1D ragged array such as weight, source hru) is different than sum of `num_qhru` (a array holding number of overlapping source hru for each river network hru),  there are river network hru(s) that does not have any overlapping source hrus. This is indicated by 0 of `num_qhru`. See [user-guide](https://mizuroute.readthedocs.io/en/main/users_guide/Input_files.html#runoff-remapping-file-required-for-runoff-input-option-2-and-3) for more information.

**Problem&fix** However, corresponding element in 1D ragged arrays to the river network hru without any source hru is also 0, though the ragged arrays should not include this (that is why sum of `num_qhru` is not equal to data dimension size). There was a logical error to detect such indices in the ragged array.  This PR fixes this.  **_If a use uses such a mapping file, remapped runoff should be incorrect and get wrong answers for the rest of simulation without this fix._**. Fix are in `read_remap.f90`

Enable nvidia compiler on NCAR HPC. 

This includes the other cleanups