### PR TITLE
small clean up in diffusive/kinematic wave solver

### DIFF
--- a/route/build/src/advection_diffusion.f90
+++ b/route/build/src/advection_diffusion.f90
@@ -24,7 +24,7 @@ CONTAINS
                        dk,            & ! input: diffusivity [m2/s]
                        FluxLat,       & ! input: lateral flux into chaneel [unit of quantity]
                        FluxPrev,      & ! input: Flux at previous time step [unit of quantity]
-                       FluxLocal,     & ! inout: Flux soloved at current time step [unit of quantity]
+                       FluxSolved,    & ! inout: Flux soloved at current time step [unit of quantity]
                        verbose,       & ! input: reach index to be examined
                        advec_scheme,  & ! optional input: advection term descretization: 1->central difference, 2->upwind method
                        downstreamBC,  & ! optional input: downstream end B.C. 1->Neumann, 2->absorbing
@@ -70,7 +70,7 @@ CONTAINS
   real(dp),     intent(in)      :: dk                        ! diffusivity [m2/s]
   real(dp),     intent(in)      :: FluxLat                   ! lateral flux into chaneel [m3/s]
   real(dp),     intent(in)      :: FluxPrev(nMolecule)       ! sub-reach quantity at previous time step [m3/s]
-  real(dp),     intent(out)     :: FluxLocal(nMolecule,0:1)  ! sub-reach & sub-time step quantity at previous and current time step [m3/s]
+  real(dp),     intent(out)     :: FluxSolved(nMolecule)     ! sub-reach & sub-time step quantity at current time step [m3/s]
   logical(lgt), intent(in)      :: verbose                   ! reach index to be examined
   integer(i4b), optional, intent(in) :: advec_scheme         ! advection term descretization: 1->central diff.(default), 2->upwind method
   integer(i4b), optional, intent(in) :: downstreamBC         ! downstream end B.C. 1->Neumann (default), 2->absorbing
@@ -83,7 +83,6 @@ CONTAINS
   real(dp)                      :: Sbc                       ! neumann BC slope
   real(dp)                      :: diagonal(nMolecule,3)     ! diagonal part of matrix - diagonal(:,1)=upper, diagonal(:,2)=middle, diagonal(:,3)=lower
   real(dp)                      :: b(nMolecule)              ! right-hand side of the matrix equation
-  real(dp)                      :: FluxSolved(nMolecule)     ! solved flux at sub-reach at current time step [unit depending on type of flux]
   real(dp)                      :: wck                       ! weight for advection
   real(dp)                      :: wdk                       ! weight for diffusion
   integer(i4b)                  :: ix                        ! loop index
@@ -124,9 +123,8 @@ CONTAINS
     write(iulog,'(A,1X,G12.5)') ' time-step [sec]=',dt_local
   end if
 
-  FluxLocal(1:nMolecule, 0) = FluxPrev    ! previous time step
-  FluxLocal(1:nMolecule, 1) = realMissing ! initialize current time step part
-  FluxLocal(1,1)  = FluxUpstream          ! quantity from upstream at current time step
+  FluxSolved(1:nMolecule) = realMissing ! initialize current time step part
+  FluxSolved(1)= FluxUpstream           ! quantity from upstream at current time step
 
   ! Fourier number and Courant number
   Cd = dk*dt_local/(dx*dx)
@@ -170,29 +168,27 @@ CONTAINS
 
   ! populate right-hand side
   ! upstream boundary condition
-  b(1)             = FluxLocal(1,1)
+  b(1)             = FluxSolved(1)
   ! downstream boundary condition
   if (downBC == absorbingBC) then
-    b(nMolecule) = (1._dp-(1._dp-wck)*Ca)*FluxLocal(nMolecule,0) + (1-wck)*Ca*FluxLocal(nMolecule-1,0)
+    b(nMolecule) = (1._dp-(1._dp-wck)*Ca)*FluxPrev(nMolecule) + (1-wck)*Ca*FluxPrev(nMolecule-1)
   else if (downBC == neumannBC) then
-    Sbc = (FluxLocal(nMolecule,0)-FluxLocal(nMolecule-1,0))
+    Sbc = (FluxPrev(nMolecule)-FluxPrev(nMolecule-1))
     b(nMolecule)     = Sbc
   end if
   ! internal node points
   if (advec_discretization==upwind) then
-    b(2:nMolecule-1) = ((1._dp-wck)*Ca +(1._dp-wdk)*Cd)*FluxLocal(1:nMolecule-2,0)  &
-                     + (1._dp-(1._dp-wck)*Ca-2._dp*(1._dp-wdk)*Cd)*FluxLocal(2:nMolecule-1,0) &
-                     + (1._dp-wdk)*Cd*FluxLocal(3:nMolecule,0)
+    b(2:nMolecule-1) = ((1._dp-wck)*Ca +(1._dp-wdk)*Cd)*FluxPrev(1:nMolecule-2)  &
+                     + (1._dp-(1._dp-wck)*Ca-2._dp*(1._dp-wdk)*Cd)*FluxPrev(2:nMolecule-1) &
+                     + (1._dp-wdk)*Cd*FluxPrev(3:nMolecule)
   else if (advec_discretization==central) then
-    b(2:nMolecule-1) = ((1._dp-wck)*Ca +2._dp*(1._dp-wdk)*Cd)*FluxLocal(1:nMolecule-2,0)  &
-                      + (2._dp-4._dp*(1._dp-wdk)*Cd)*FluxLocal(2:nMolecule-1,0)           &
-                      - ((1._dp-wck)*Ca -2._dp*(1._dp-wdk)*Cd)*FluxLocal(3:nMolecule,0)
+    b(2:nMolecule-1) = ((1._dp-wck)*Ca +2._dp*(1._dp-wdk)*Cd)*FluxPrev(1:nMolecule-2)  &
+                      + (2._dp-4._dp*(1._dp-wdk)*Cd)*FluxPrev(2:nMolecule-1)           &
+                      - ((1._dp-wck)*Ca -2._dp*(1._dp-wdk)*Cd)*FluxPrev(3:nMolecule)
   end if
 
-  ! solve matrix equation - get updated FluxLocal
+  ! solve matrix equation - get updated FluxSolved
   call TDMA(nMolecule, diagonal, b, FluxSolved)
-
-  FluxLocal(:,1) = FluxSolved
 
   if (verbose) then
     write(fmt1,'(A,I5,A)') '(A,1X',nMolecule,'(1X,G15.4))'

--- a/route/build/src/dfw_route.f90
+++ b/route/build/src/dfw_route.f90
@@ -241,7 +241,6 @@ CONTAINS
  real(dp)                        :: depth          ! flow depth [m]
  real(dp)                        :: ck             ! kinematic wave celerity [m/s]
  real(dp)                        :: dk             ! diffusivity [m2/s]
- real(dp), allocatable           :: Qlocal(:,:)    ! sub-reach & sub-time step discharge at previous and current time step [m3/s]
  real(dp), allocatable           :: Qprev(:)       ! sub-reach discharge at previous time step [m3/s]
  real(dp)                        :: dTsub          ! time inteval for sub time-step [sec]
  real(dp)                        :: qoutTmp        ! temporary scalar for discharge from reach
@@ -263,16 +262,16 @@ CONTAINS
            zc        => rch_param%SIDE_SLOPE, & ! channel side slope
            zf        => rch_param%FLDP_SLOPE, & ! floodplain slope
            bankVol   => rch_param%R_STORAGE,  & ! bankful volume
-           L         => rch_param%RLENGTH)      ! channel length
+           L         => rch_param%RLENGTH,    & ! channel length
+           Qnode     => rstate%molecule%Q)
 
  if (.not. isHW .or. hw_drain_point==top_reach) then
 
    if (L > min_length_route) then
 
+   ! initialize previous time step flow
    allocate(Qprev(nMolecule), stat=ierr, errmsg=cmessage)
    if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
-   ! initialize previous time step flow
    Qprev(1:nMolecule) = rstate%molecule%Q     ! flow state at previous time step
 
    if (verbose) then
@@ -289,9 +288,6 @@ CONTAINS
      write(iulog,'(A,1X,I3,A,1X,G12.5)') ' No. sub timestep=',nTsub,' sub time-step [sec]=',dTsub
    end if
 
-   allocate(Qlocal(1:nMolecule, 0:1), stat=ierr, errmsg=cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
    do it = 1, nTsub
      Qbar = (Qupstream+Qprev(1)+Qprev(nMolecule-1))/3.0 ! 3 point average discharge [m3/s]
      depth = flow_depth(abs(Qbar), bt, zc, S, n, zf=zf, bankDepth=bankDepth) ! compute flow depth as normal depth (a function of flow)
@@ -306,21 +302,22 @@ CONTAINS
                     dk,                 & ! input: diffusivity [m2/s]
                     Qlat,               & ! input: lateral quantity into chaneel [unit of quantity]
                     Qprev,              & ! input: quantity at previous time step [unit of quantity]
-                    Qlocal,             & ! inout: quantity soloved at current time step [unit of quantity]
+                    Qnode,              & ! inout: quantity soloved at current time step [unit of quantity]
                     verbose,            & ! input: reach index to be examined
                     advec_scheme=advec_scheme, & ! optional input: advection scheme (1->central difference, 2->upwind)
                     downstreamBC=downBC)         ! optional input: downstream boundary condition (1->Neumann, 2->open boundary condition)
+     if (it<nTsub) Qprev = Qnode
    end do
 
    ! For very low flow condition, outflow - inflow may exceed current storage, so limit outflow and adjust flow profile
-   if (abs(Qlocal(nMolecule-1,1))>0._dp) then
+   if (abs(Qnode(nMolecule-1))>0._dp) then
      volTmp = max(0._dp, rflux%ROUTE(idxDW)%REACH_VOL(1))
-     qoutTmp = Qlocal(nMolecule-1,1)*dt
+     qoutTmp = Qnode(nMolecule-1)*dt
      pcntReduc = min((volTmp + dt*Qupstream)*0.999_dp/qoutTmp, 1._dp)
-     Qlocal(2:nMolecule,1) = Qlocal(2:nMolecule,1)*pcntReduc
+     Qnode(2:nMolecule) = Qnode(2:nMolecule)*pcntReduc
    end if
 
-   rflux%ROUTE(idxDW)%REACH_VOL(1) = rflux%ROUTE(idxDW)%REACH_VOL(1) + (Qupstream - Qlocal(nMolecule-1,1))*dt
+   rflux%ROUTE(idxDW)%REACH_VOL(1) = rflux%ROUTE(idxDW)%REACH_VOL(1) + (Qupstream - Qnode(nMolecule-1))*dt
 
    ! if reach volume exceeds flood threshold volume, excess water is flooded volume.
    if (rflux%ROUTE(idxDW)%REACH_VOL(1) > bankVol) then
@@ -332,15 +329,12 @@ CONTAINS
    rflux%ROUTE(idxDW)%REACH_ELE = water_height(rflux%ROUTE(idxDW)%REACH_VOL(1)/L, bt, zc, zf=zf, bankDepth=bankDepth)
 
    ! store final outflow in data structure
-   rflux%ROUTE(idxDW)%REACH_Q = Qlocal(nMolecule-1,1) + Qlat
-
-   ! update state
-   rstate%molecule%Q = Qlocal(:,1)
+   rflux%ROUTE(idxDW)%REACH_Q = Qnode(nMolecule-1) + Qlat
 
    else ! length < min_length_route: length is short enough to just pass upstream to downstream
      rflux%ROUTE(idxDW)%REACH_Q = Qupstream + Qlat
-     rstate%molecule%Q(1:nMolecule) = 0._dp
-     rstate%molecule%Q(nMolecule)   = rflux%ROUTE(idxDW)%REACH_Q
+     Qnode(1:nMolecule) = 0._dp
+     Qnode(nMolecule)   = rflux%ROUTE(idxDW)%REACH_Q
 
      rflux%ROUTE(idxDW)%REACH_VOL(0) = 0._dp
      rflux%ROUTE(idxDW)%REACH_VOL(1) = 0._dp
@@ -356,12 +350,8 @@ CONTAINS
    rflux%ROUTE(idxDW)%FLOOD_VOL(1) = 0._dp
    rflux%ROUTE(idxDW)%REACH_ELE    = 0._dp
 
-   rstate%molecule%Q(1:nMolecule) = 0._dp
-   rstate%molecule%Q(nMolecule)   = rflux%ROUTE(idxDW)%REACH_Q
-
-   if (verbose) then
-     write(iulog,'(A)')            ' This is headwater '
-   endif
+   Qnode(1:nMolecule) = 0._dp
+   Qnode(nMolecule)   = rflux%ROUTE(idxDW)%REACH_Q
 
  endif
 

--- a/route/build/src/kwe_route.f90
+++ b/route/build/src/kwe_route.f90
@@ -51,6 +51,7 @@ CONTAINS
                    RCHSTA_out,     & ! inout: reach state data structure
                    RCHFLX_out,     & ! inout: reach flux data structure
                    ierr, message)    ! output: error control
+
  implicit none
  ! Argument variables
  class(kwe_route_rch)                      :: this              ! kwe_route_rch object to bound this procedure
@@ -237,7 +238,6 @@ CONTAINS
  real(dp)                        :: depth          ! flow depth [m]
  real(dp)                        :: ck             ! kinematic wave celerity [m/s]
  real(dp)                        :: dk             ! diffusivity [m2/s]
- real(dp), allocatable           :: Qlocal(:,:)    ! sub-reach & sub-time step discharge at previous and current time step [m3/s]
  real(dp), allocatable           :: Qprev(:)       ! sub-reach discharge at previous time step [m3/s]
  real(dp)                        :: dTsub          ! time inteval for sub time-step [sec]
  real(dp)                        :: qoutTmp        ! temporary scalar for discharge from reach
@@ -251,24 +251,25 @@ CONTAINS
 
  ntSub = 1  ! number of sub-time step
 
- associate(S         => rch_param%R_SLOPE,    & ! channel slope
+ associate(nMolecule => nMolecule%KW_ROUTE,   & ! number of computing points in a reach
+           S         => rch_param%R_SLOPE,    & ! channel slope
            n         => rch_param%R_MAN_N,    & ! manning n
            bt        => rch_param%R_WIDTH,    & ! channel bottom width
            bankDepth => rch_param%R_DEPTH,    & ! bankfull depth
            zc        => rch_param%SIDE_SLOPE, & ! channel side slope
            zf        => rch_param%FLDP_SLOPE, & ! floodplain slope
            bankVol   => rch_param%R_STORAGE,  & ! bankful volume
-           L         => rch_param%RLENGTH)      ! channel length
+           L         => rch_param%RLENGTH,    & ! channel length
+           Qnode     => rstate%molecule%Q)
 
  if (.not. isHW .or. hw_drain_point==top_reach) then
 
    if (L > min_length_route) then
 
-   allocate(Qprev(nMolecule%KW_ROUTE), stat=ierr, errmsg=cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
    ! initialize previous time step flow
-   Qprev(1:nMolecule%KW_ROUTE) = rstate%molecule%Q     ! flow state at previous time step
+   allocate(Qprev(nMolecule), stat=ierr, errmsg=cmessage)
+   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
+   Qprev(1:nMolecule) = rstate%molecule%Q     ! flow state at previous time step
 
    if (verbose) then
      write(iulog,'(A,1X,G12.5)') ' length [m]        =',L
@@ -284,36 +285,34 @@ CONTAINS
      write(iulog,'(A,1X,I3,A,1X,G12.5)') ' No. sub timestep=',nTsub,' sub time-step [sec]=',dTsub
    end if
 
-   allocate(Qlocal(1:nMolecule%KW_ROUTE, 0:1), stat=ierr, errmsg=cmessage)
-   if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
-
    do it = 1, nTsub
-     Qbar = (Qupstream+Qprev(1)+Qprev(nMolecule%KW_ROUTE-1))/3.0 ! 3 point average discharge [m3/s]
+     Qbar = (Qupstream+Qprev(1)+Qprev(nMolecule-1))/3.0 ! 3 point average discharge [m3/s]
      depth = flow_depth(abs(Qbar), bt, zc, S, n, zf=zf, bankDepth=bankDepth) ! compute flow depth as normal depth (a function of flow)
      ck    = celerity(abs(Qbar), depth, bt, zc, S, n, zf=zf, bankDepth=bankDepth)
      dk    = 0._dp
 
      call solve_ade(L,                  & ! input: river parameter data structure
-                    nMolecule%KW_ROUTE, & ! input: number of sub-segments
+                    nMolecule,          & ! input: number of sub-segments
                     dTsub,              & ! input: time_step [sec]
                     Qupstream,          & ! input: quantity from upstream [unit of quantity]
                     ck,                 & ! input: velocity [m/s]
                     dk,                 & ! input: diffusivity [m2/s]
                     Qlat,               & ! input: lateral quantity into chaneel [unit of quantity]
                     Qprev,              & ! input: quantity at previous time step [unit of quantity]
-                    Qlocal,             & ! inout: quantity soloved at current time step [unit of quantity]
+                    Qnode,              & ! inout: quantity soloved at current time step [unit of quantity]
                     verbose)              ! input: reach index to be examined
+     if (it<nTsub) Qprev = Qnode
    end do
 
    ! For very low flow condition, outflow - inflow may exceed current storage, so limit outflow and adjust flow profile
-   if (abs(Qlocal(nMolecule%KW_ROUTE-1,1))>0._dp) then
+   if (abs(Qnode(nMolecule-1))>0._dp) then
      volTmp = max(0._dp, rflux%ROUTE(idxKW)%REACH_VOL(1))
-     qoutTmp = Qlocal(nMolecule%KW_ROUTE-1,1)*dt
+     qoutTmp = Qnode(nMolecule-1)*dt
      pcntReduc = min((volTmp + dt*Qupstream)*0.999_dp/qoutTmp, 1._dp)
-     Qlocal(2:nMolecule%KW_ROUTE,1) = Qlocal(2:nMolecule%KW_ROUTE,1)*pcntReduc
+     Qnode(2:nMolecule) = Qnode(2:nMolecule)*pcntReduc
    end if
 
-   rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(1) + (Qupstream - Qlocal(nMolecule%KW_ROUTE-1,1))*dt
+   rflux%ROUTE(idxKW)%REACH_VOL(1) = rflux%ROUTE(idxKW)%REACH_VOL(1) + (Qupstream - Qnode(nMolecule-1))*dt
 
    ! if reach volume exceeds flood threshold volume, excess water is flooded volume.
    if (rflux%ROUTE(idxKW)%REACH_VOL(1) > bankVol) then
@@ -325,15 +324,12 @@ CONTAINS
    rflux%ROUTE(idxKW)%REACH_ELE = water_height(rflux%ROUTE(idxKW)%REACH_VOL(1)/L, bt, zc, zf=zf, bankDepth=bankDepth)
 
    ! store final outflow in data structure
-   rflux%ROUTE(idxKW)%REACH_Q = Qlocal(nMolecule%KW_ROUTE-1,1) + Qlat
-
-   ! update state
-   rstate%molecule%Q = Qlocal(:,1)
+   rflux%ROUTE(idxKW)%REACH_Q = Qnode(nMolecule-1) + Qlat
 
    else ! length < min_length_route: length is short enough to just pass upstream to downstream
      rflux%ROUTE(idxKW)%REACH_Q = Qupstream + Qlat
-     rstate%molecule%Q(1:nMolecule%KW_ROUTE) = 0._dp
-     rstate%molecule%Q(nMolecule%KW_ROUTE)   = rflux%ROUTE(idxKW)%REACH_Q
+     Qnode(1:nMolecule) = 0._dp
+     Qnode(nMolecule)   = rflux%ROUTE(idxKW)%REACH_Q
 
      rflux%ROUTE(idxKW)%REACH_VOL(0) = 0._dp
      rflux%ROUTE(idxKW)%REACH_VOL(1) = 0._dp
@@ -349,12 +345,8 @@ CONTAINS
    rflux%ROUTE(idxKW)%FLOOD_VOL(1) = 0._dp
    rflux%ROUTE(idxKW)%REACH_ELE    = 0._dp
 
-   rstate%molecule%Q(1:nMolecule%KW_ROUTE) = 0._dp
-   rstate%molecule%Q(nMolecule%KW_ROUTE)   = rflux%ROUTE(idxKW)%REACH_Q
-
-   if (verbose) then
-     write(iulog,'(A)')            ' This is headwater '
-   endif
+   Qnode(1:nMolecule) = 0._dp
+   Qnode(nMolecule)   = rflux%ROUTE(idxKW)%REACH_Q
 
  endif
 


### PR DESCRIPTION
Remove unnecessary arrays: 
`Qlocal`, and instead, work with state data type, `rstate%nMolecule%Q(:)` directly
`FluxSolved`, used this as output argument, instead of local array in solve_ade subroutine, and also no [FluxLocal](url) required. 