### PR TITLE
unit conversion for direct transfer to outlet

### DIFF
--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -380,6 +380,7 @@ CONTAINS
     real(r8)                     :: irrig_depth            ! depth of irrigation demand during time step [mm]
     real(r8)                     :: river_depth            ! depth of river water during time step [mm]
     real(r8), allocatable        :: qSend(:)               ! array holding negative lateral flow to be sent to outlet
+    real(r8), allocatable        :: mm_to_m3(:)            ! conversion factor based on local area [m2] from kg/m2(=mm) to m3
     logical                      :: finished               ! dummy arguments (not really used)
     character(len=CL)            :: cmessage               ! error message from subroutines
     integer                      :: ierr                   ! error code
@@ -438,7 +439,9 @@ CONTAINS
     call t_startf('mizuRoute_bypass_route')
 
     allocate(qSend(ctl%lnumr))
+    allocate(mm_to_m3(ctl%lnumr))
     qSend = 0._r8
+    mm_to_m3 = 1.e-3_r8*ctl%area(begr:endr)
 
     select case(trim(bypass_routing_option))
       case('direct_in_place')
@@ -481,6 +484,9 @@ CONTAINS
           ctl%qsur(begr:endr, nt_liq) = 0._r8
         end where
 
+        ! --- convert direct unit (kg/m3/s==mm/s to m3/s)
+        ctl%direct(begr:endr, nt_liq) = ctl%direct(begr:endr, nt_liq)*mm_to_m3(begr:endr)
+
       case('direct_to_outlet')
         ! ----  qgwl [mm/s]
         select case(trim(qgwl_runoff_option))
@@ -502,7 +508,6 @@ CONTAINS
 
         ! Distribute "direct runoff to ocean" to targe reach (i.e., outlet of river network)
         call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct(:,nt_liq), fillvalue=0._r8)
-        call shr_mpi_barrier(mpicom_rof) ! AI says no need to call mpi barrier
 
       case default; call shr_sys_abort(trim(subname)//'unexpected bypass_routing_option')
     end select
@@ -511,12 +516,12 @@ CONTAINS
 
     call t_startf('mizuRoute_direct_to_outlet_land_ice')
 
-    qSend(:) = 0._r8
-    qSend(begr:endr) = qSend(begr:endr) + ctl%qsur(begr:endr, nt_ice) + ctl%qsub(begr:endr, nt_ice) + ctl%qgwl(begr:endr, nt_ice)
+    qSend(begr:endr) = 0._r8
+    qSend(begr:endr) = ctl%qsur(begr:endr, nt_ice) + ctl%qsub(begr:endr, nt_ice) + ctl%qgwl(begr:endr, nt_ice)
+    qSend(begr:endr) = qSend(begr:endr)*mm_to_m3(begr:endr)
 
     ! Distribute "direct runoff to ocean" to targe reach (i.e., outlet of river network)
     call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct(:,nt_ice), fillvalue=0._r8)
-    call shr_mpi_barrier(mpicom_rof) ! AI says no need to call mpi barrier
 
     ! Set ctl%qsur, ctl%qsub and ctl%qgwl to zero for nt_ice
     ctl%qsur(:,nt_ice) = 0._r8
@@ -527,9 +532,14 @@ CONTAINS
 
     call t_startf('mizuRoute_direct_to_outlet_glc_runoff')
     if (ctl%rof_from_glc) then
+      qSend(begr:endr) = 0._r8
+      qSend(begr:endr) = ctl%qglc_liq(begr:endr)*mm_to_m3(begr:endr)
       ! Distribute "direct runoff to ocean" to targe reach (i.e., outlet of river network)
-      call shr_mpi_sparse_distribute(ctl%qglc_liq(:), commRch(:)%destTask, commRch(:)%destIndex, ctl%direct_glc(:,nt_liq), fillvalue=0._r8)
-      call shr_mpi_sparse_distribute(ctl%qglc_ice(:), commRch(:)%destTask, commRch(:)%destIndex, ctl%direct_glc(:,nt_ice), fillvalue=0._r8)
+      call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct_glc(:,nt_liq), fillvalue=0._r8)
+
+      qSend(begr:endr) = 0._r8
+      qSend(begr:endr) = ctl%qglc_ice(begr:endr)*mm_to_m3(begr:endr)
+      call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct_glc(:,nt_ice), fillvalue=0._r8)
     else
       ctl%direct_glc(:,:) = 0._r8
     end if
@@ -539,6 +549,7 @@ CONTAINS
     call t_startf('mizuRoute_mapping_runoff')
 
     ! Transfer actual irrigation rate [mm/s] to river segment
+    ! unit conversion mm/s to m3/s is done in mizuRoute code
     if (masterproc) then
       if (nRch_mainstem > 0) then ! mainstem
         call basin2reach(ctl%qirrig_actual(1:nHRU_mainstem), NETOPO_main, RPARAM_main, flux_wm_main, &
@@ -658,7 +669,8 @@ CONTAINS
                                    offset)
 
     ! Descriptions: get exporting variables
-    !  - discharge [kg/m2/s]=[mm/s]
+    !  - discharge [kg/m2/s = mm/s]
+    !  - direct runoff transfer [mm/s]
     !  - water volume per HUC area [m]
     !  - flood [mm/s]
     !  NOTE 1) offset (optional input): in main processor, index for ctl variable is based on 1 through nHRU_mainstem+nHRU_trib
@@ -709,7 +721,7 @@ CONTAINS
         end if
         if (update_q) then
           if (NETOPO_in(iRch)%DREACHI==-1 .and. NETOPO_in(iRch)%DREACHK<=0) then ! if reach is the outlet
-            ctl%discharge(ix,ctl%nt_liq) = RCHFLX_in(iRch)%ROUTE(iRoute)%REACH_Q* NETOPO_in(iRch)%HRUWGT(iHru)/ctl%area(ix)/0.001_r8
+            ctl%discharge(ix,ctl%nt_liq) = RCHFLX_in(iRch)%ROUTE(iRoute)%REACH_Q* NETOPO_in(iRch)%HRUWGT(iHru)/(ctl%area(ix)*0.001_r8)
           end if
         end if
         if (update_fld) then
@@ -717,6 +729,12 @@ CONTAINS
         end if
       end do
     end do
+
+    ctl%direct(:,ctl%nt_liq) =ctl%direct(:,ctl%nt_liq) / (ctl%area(:)*0.001_r8)
+    ctl%direct(:,ctl%nt_ice) =ctl%direct(:,ctl%nt_ice) / (ctl%area(:)*0.001_r8)
+    ctl%direct_glc(:,ctl%nt_liq) =ctl%direct_glc(:,ctl%nt_liq) / (ctl%area(:)*0.001_r8)
+    ctl%direct_glc(:,ctl%nt_ice) =ctl%direct_glc(:,ctl%nt_ice) / (ctl%area(:)*0.001_r8)
+
   END SUBROUTINE
 
   SUBROUTINE RtmRestGetfile()

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -231,7 +231,7 @@ CONTAINS
     end if
 
     allocate(depth_to_vol(ctl%lnumr))
-    depth_to_vol = 1.e-3_r8*ctl%area(begr:endr)
+    depth_to_vol = 1.e-3_r8*ctl%area(ctl%begr:ctl%endr)
 
     if ( any(ctl%gindex(ctl%begr:ctl%endr) < 1) )then
       call shr_sys_abort(trim(subname)//"bad gindex < 1")

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -650,6 +650,11 @@ CONTAINS
       call get_river_export_data(NETOPO_trib, RCHFLX_trib)
     end if
 
+    ctl%direct(:,ctl%nt_liq) =ctl%direct(:,ctl%nt_liq) / (ctl%area(:)*0.001_r8)
+    ctl%direct(:,ctl%nt_ice) =ctl%direct(:,ctl%nt_ice) / (ctl%area(:)*0.001_r8)
+    ctl%direct_glc(:,ctl%nt_liq) =ctl%direct_glc(:,ctl%nt_liq) / (ctl%area(:)*0.001_r8)
+    ctl%direct_glc(:,ctl%nt_ice) =ctl%direct_glc(:,ctl%nt_ice) / (ctl%area(:)*0.001_r8)
+
     call t_stopf('mizuRoute_prep_export')
 
     end associate
@@ -729,11 +734,6 @@ CONTAINS
         end if
       end do
     end do
-
-    ctl%direct(:,ctl%nt_liq) =ctl%direct(:,ctl%nt_liq) / (ctl%area(:)*0.001_r8)
-    ctl%direct(:,ctl%nt_ice) =ctl%direct(:,ctl%nt_ice) / (ctl%area(:)*0.001_r8)
-    ctl%direct_glc(:,ctl%nt_liq) =ctl%direct_glc(:,ctl%nt_liq) / (ctl%area(:)*0.001_r8)
-    ctl%direct_glc(:,ctl%nt_ice) =ctl%direct_glc(:,ctl%nt_ice) / (ctl%area(:)*0.001_r8)
 
   END SUBROUTINE
 

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -30,6 +30,7 @@ MODULE RtmMod
   implicit none
   logical, parameter :: verbose=.false.
   integer, parameter :: iRoute=1        ! index of routing method chosen. cesm-coupled run allows only one option (5 options available), this is always 1.
+  real(r8), allocatable :: depth_to_vol(:)  ! conversion factor based on local area [m2] from kg/m2(=mm) to m3
 
   private
   public route_ini          ! Initialize mizuRoute
@@ -229,6 +230,9 @@ CONTAINS
       call get_hru_area(NETOPO_trib, RPARAM_trib, verbose=verbose)
     end if
 
+    allocate(depth_to_vol(ctl%lnumr))
+    depth_to_vol = 1.e-3_r8*ctl%area(begr:endr)
+
     if ( any(ctl%gindex(ctl%begr:ctl%endr) < 1) )then
       call shr_sys_abort(trim(subname)//"bad gindex < 1")
     endif
@@ -380,7 +384,6 @@ CONTAINS
     real(r8)                     :: irrig_depth            ! depth of irrigation demand during time step [mm]
     real(r8)                     :: river_depth            ! depth of river water during time step [mm]
     real(r8), allocatable        :: qSend(:)               ! array holding negative lateral flow to be sent to outlet
-    real(r8), allocatable        :: mm_to_m3(:)            ! conversion factor based on local area [m2] from kg/m2(=mm) to m3
     logical                      :: finished               ! dummy arguments (not really used)
     character(len=CL)            :: cmessage               ! error message from subroutines
     integer                      :: ierr                   ! error code
@@ -439,9 +442,7 @@ CONTAINS
     call t_startf('mizuRoute_bypass_route')
 
     allocate(qSend(ctl%lnumr))
-    allocate(mm_to_m3(ctl%lnumr))
-    qSend = 0._r8
-    mm_to_m3 = 1.e-3_r8*ctl%area(begr:endr)
+    qSend = 0._r8  ! initialize with zero because changing part of qgwl, a part of qsub, and a part of qsur sequentially
 
     select case(trim(bypass_routing_option))
       case('direct_in_place')
@@ -485,7 +486,7 @@ CONTAINS
         end where
 
         ! --- convert direct unit (kg/m3/s==mm/s to m3/s)
-        ctl%direct(begr:endr, nt_liq) = ctl%direct(begr:endr, nt_liq)*mm_to_m3(begr:endr)
+        ctl%direct(begr:endr, nt_liq) = ctl%direct(begr:endr, nt_liq)*depth_to_vol(begr:endr)
 
       case('direct_to_outlet')
         ! ----  qgwl [mm/s]
@@ -507,6 +508,7 @@ CONTAINS
         end where
 
         ! Distribute "direct runoff to ocean" to targe reach (i.e., outlet of river network)
+        qSend(begr:endr) = qSend(begr:endr)*depth_to_vol(begr:endr)
         call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct(:,nt_liq), fillvalue=0._r8)
 
       case default; call shr_sys_abort(trim(subname)//'unexpected bypass_routing_option')
@@ -516,11 +518,8 @@ CONTAINS
 
     call t_startf('mizuRoute_direct_to_outlet_land_ice')
 
-    qSend(begr:endr) = 0._r8
-    qSend(begr:endr) = ctl%qsur(begr:endr, nt_ice) + ctl%qsub(begr:endr, nt_ice) + ctl%qgwl(begr:endr, nt_ice)
-    qSend(begr:endr) = qSend(begr:endr)*mm_to_m3(begr:endr)
-
     ! Distribute "direct runoff to ocean" to targe reach (i.e., outlet of river network)
+    qSend(begr:endr) = (ctl%qsur(begr:endr, nt_ice) + ctl%qsub(begr:endr, nt_ice) + ctl%qgwl(begr:endr, nt_ice))*depth_to_vol(begr:endr)
     call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct(:,nt_ice), fillvalue=0._r8)
 
     ! Set ctl%qsur, ctl%qsub and ctl%qgwl to zero for nt_ice
@@ -532,13 +531,11 @@ CONTAINS
 
     call t_startf('mizuRoute_direct_to_outlet_glc_runoff')
     if (ctl%rof_from_glc) then
-      qSend(begr:endr) = 0._r8
-      qSend(begr:endr) = ctl%qglc_liq(begr:endr)*mm_to_m3(begr:endr)
       ! Distribute "direct runoff to ocean" to targe reach (i.e., outlet of river network)
+      qSend(begr:endr) = ctl%qglc_liq(begr:endr)*depth_to_vol(begr:endr)
       call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct_glc(:,nt_liq), fillvalue=0._r8)
 
-      qSend(begr:endr) = 0._r8
-      qSend(begr:endr) = ctl%qglc_ice(begr:endr)*mm_to_m3(begr:endr)
+      qSend(begr:endr) = ctl%qglc_ice(begr:endr)*depth_to_vol(begr:endr)
       call shr_mpi_sparse_distribute(qSend, commRch(:)%destTask, commRch(:)%destIndex, ctl%direct_glc(:,nt_ice), fillvalue=0._r8)
     else
       ctl%direct_glc(:,:) = 0._r8
@@ -650,10 +647,10 @@ CONTAINS
       call get_river_export_data(NETOPO_trib, RCHFLX_trib)
     end if
 
-    ctl%direct(:,ctl%nt_liq) =ctl%direct(:,ctl%nt_liq) / (ctl%area(:)*0.001_r8)
-    ctl%direct(:,ctl%nt_ice) =ctl%direct(:,ctl%nt_ice) / (ctl%area(:)*0.001_r8)
-    ctl%direct_glc(:,ctl%nt_liq) =ctl%direct_glc(:,ctl%nt_liq) / (ctl%area(:)*0.001_r8)
-    ctl%direct_glc(:,ctl%nt_ice) =ctl%direct_glc(:,ctl%nt_ice) / (ctl%area(:)*0.001_r8)
+    ctl%direct(:,ctl%nt_liq) =ctl%direct(:,ctl%nt_liq) / depth_to_vol(:)
+    ctl%direct(:,ctl%nt_ice) =ctl%direct(:,ctl%nt_ice) / depth_to_vol(:)
+    ctl%direct_glc(:,ctl%nt_liq) =ctl%direct_glc(:,ctl%nt_liq) / depth_to_vol(:)
+    ctl%direct_glc(:,ctl%nt_ice) =ctl%direct_glc(:,ctl%nt_ice) / depth_to_vol(:)
 
     call t_stopf('mizuRoute_prep_export')
 

--- a/route/build/cpl/RtmMod.F90
+++ b/route/build/cpl/RtmMod.F90
@@ -723,7 +723,7 @@ CONTAINS
         end if
         if (update_q) then
           if (NETOPO_in(iRch)%DREACHI==-1 .and. NETOPO_in(iRch)%DREACHK<=0) then ! if reach is the outlet
-            ctl%discharge(ix,ctl%nt_liq) = RCHFLX_in(iRch)%ROUTE(iRoute)%REACH_Q* NETOPO_in(iRch)%HRUWGT(iHru)/(ctl%area(ix)*0.001_r8)
+            ctl%discharge(ix,ctl%nt_liq) = RCHFLX_in(iRch)%ROUTE(iRoute)%REACH_Q* NETOPO_in(iRch)%HRUWGT(iHru)/(depth_to_vol(ix))
           end if
         end if
         if (update_fld) then

--- a/route/build/cpl/nuopc/rof_import_export.F90
+++ b/route/build/cpl/nuopc/rof_import_export.F90
@@ -221,7 +221,7 @@ contains
       nullify(dataptr)
     end if
 
-    if (fldchk(importState, 'Fgrg_rofl') .and. fldchk(importState, 'Fgrg_rofl')) then
+    if (fldchk(importState, 'Fgrg_rofl') .and. fldchk(importState, 'Fgrg_rofi')) then
       ctl%rof_from_glc = .true.
     else
       ctl%rof_from_glc = .false.


### PR DESCRIPTION
Runoff imported from coupler (liquid and ice runoff from land-model and glacier runoff from glc model) is given in depth, or kg/m2/s (~=mm/s). Also, routed runoff that is exported to the coupler need to be in kg/m2/s. This quantity is thought as depth per area. So after runoff depth imported into ROF model, depth flux is converted to volume flux using local HRU area to get actual amount of water/ice, then route the volume through the network, or directly transfer to the outlet. Before exporting the routed runoff volume, the volume is converted to depth using the local area at the outlet. 

Currently direct to outlet operation does not do this depth-volume (and volume-depth) conversion and transferred depth directly immediately after the runoff is imported. This causes budget imbalance in ROF model, because the area at upstream HRU and area at outlet location are different. 

This PR fix the error.  